### PR TITLE
docs: re-bootstrap docs pipeline to adk v2 (ADR-first)

### DIFF
--- a/PIPELINE.lock
+++ b/PIPELINE.lock
@@ -1,17 +1,10 @@
-lock_version: 1
+lock_version: 2
 phase: done
-decisions: { ux: included }
-flags: { pending_arch_sync: false }
+project_type: brownfield
 docs:
-  - { id: PRINCIPLES, path: docs/PRINCIPLES.md, status: active }
-  - { id: PRD, path: docs/PRD.md, status: active }
-  - { id: BUSINESS-FLOW, path: docs/BUSINESS-FLOW.md, status: active }
-  - { id: ARCHITECTURE, path: docs/ARCHITECTURE.md, status: active }
-  - { id: UX-DESIGN, path: docs/UX-DESIGN.md, status: active }
-  - { id: REQUIREMENTS, path: docs/REQUIREMENTS.md, status: active }
-requirements_version: 1
-adr_manifest:
-  "0001": feec58eade9a4fb6c8023fe31c05116d2553f092e16e8e8a42542b7dee62b18d
-  "0002": 0f0074ff303e3b4146abd9caa9d021875d80d2cb305c9f2a0f63d7f33ae6ae2d
-  "0003": fa8e8bd3187847a24d8459f5608564ad8d887480fe08ebc88480596caaf32638
-archive_versions: []
+  - { id: PRINCIPLES, path: docs/PRINCIPLES.md }
+  - { id: PRD, path: docs/PRD.md }
+  - { id: BUSINESS-FLOW, path: docs/BUSINESS-FLOW.md }
+  - { id: ARCHITECTURE, path: docs/ARCHITECTURE.md }
+  - { id: UX-DESIGN, path: docs/UX-DESIGN.md }
+  - { id: REQUIREMENTS, path: docs/REQUIREMENTS.md }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,17 +1,13 @@
 ---
-frozen: true
-hash: 8ec703e3eb57216edb5446edfa5309480791400c937f3d597da3bfe6373639fc
-from_hash:
-  PRINCIPLES: a06e3bee0cac7feb7d51244c8d46960f939f90f54fbd4c793ae2f6abd412f401
-  PRD: 1d1b4c0c4dc5455d87bd348fa635f33d2c331cc363fd1d6abb8bb18be2c912a8
-  BUSINESS-FLOW: 5830f27c0db628695ed4f2359e04f5cb955d6d2812b5c97e881e3f4089235abb
+derived: true
+derived_from:
+  [0001, 0002, 0003, 0005, 0007, 0010, 0012, 0020, 0021, 0022, 0023, 0024, 0025]
+rendered: 2026-07-10
 ---
 
 # ARCHITECTURE — Stackgrid
 
-Single source of truth for the current and v1 target architecture. Distilled from frozen `PRINCIPLES`, `PRD`, and `BUSINESS-FLOW`, plus a brownfield scan of the shipped codebase. English-only.
-
-**Freeze status:** ready-to-freeze. Do not stamp `frozen` / `hash` / `from_hash` here — reconverge after the sibling UX-DESIGN branch lands.
+Single source of truth for the current and v1 target architecture. Rendered from the active ADR set (principles + product + architecture decisions) and a brownfield scan of the shipped codebase. English-only.
 
 ## 1. Stack
 
@@ -27,6 +23,8 @@ Single source of truth for the current and v1 target architecture. Distilled fro
 
 **Pattern:** hybrid. Preact owns chrome; `TabManager` / `TerminalManager` / `Pane` own imperative terminal surfaces and talk to Rust over Tauri IPC.
 
+**Stack ADR:** `docs/decisions/0025-v1-stack-tauri-preact-xterm.md` — the stack is the v1 foundation but **revisable** (not a non-negotiable; Electron not forbidden).
+
 ## 2. Brownfield vs net-new
 
 ### Shipped (keep)
@@ -34,7 +32,7 @@ Single source of truth for the current and v1 target architecture. Distilled fro
 - Real PTY + login shell (`$SHELL -l`) via `portable-pty` (`src-tauri/src/pty.rs`)
 - Single-window Window → Tab → Pane hierarchy
 - Split, drag-dock rearrange, divider resize, focus cycle / directional focus, focus-expand, zoom
-- Session chrome restore (`session.json` layout only — ADR 0001)
+- Session chrome restore (`session.json` layout only — ADR 0010)
 - In-memory closed-tab stack with CWDs (max 10)
 - Agent/busy chrome from foreground process name (`claude` / `codex` / `gemini`)
 - Themes + settings persist; git branch in status bar; file-drop → PTY; Cmd+F search; busy/quit guards
@@ -115,7 +113,9 @@ Each decision lists the chosen approach and the alternatives rejected during arc
 **Rejected:**
 
 - _Logical UUID pane-id separate from PTY id_ — double-key every IPC; v1 does not need identity across respawn/restart.
-- _Persist pane-ids in session chrome_ — meaningless under fresh-shell restore; conflicts with ADR 0001 intent.
+- _Persist pane-ids in session chrome_ — meaningless under fresh-shell restore; conflicts with ADR 0010 intent.
+
+**ADR:** `docs/decisions/0020-pane-id-equals-pty-id.md`
 
 ### D3 — Session chrome + restore-all-windows
 
@@ -162,6 +162,8 @@ PresetsData v1 (conceptual)
 - _Embed presets in `settings.json`_ — mixes preferences with layout templates.
 - _One file per preset on disk_ — unnecessary given plugin-store; weaker atomic overwrite.
 
+**ADR:** `docs/decisions/0021-preset-persistence-presets-json.md`
+
 ### D5 — Sidebar data plane
 
 **Chosen: Rust reads file + shell-outs `git`; frontend renders only.**
@@ -180,6 +182,8 @@ PresetsData v1 (conceptual)
 - _Frontend fs plugin for reads + Rust git_ — extra capability surface, two I/O paths.
 - _Embed libgit2/gitoxide_ — heavy; inconsistent with existing `git_branch` shell-out.
 
+**ADR:** `docs/decisions/0022-sidebar-data-plane.md`
+
 ### D6 — Agent PATH detect + spawn
 
 **Chosen: hardcoded allowlist + Rust PATH lookup; pick spawns immediately.**
@@ -195,6 +199,8 @@ PresetsData v1 (conceptual)
 - _Heuristic scan of all PATH binaries_ — noisy, slow, un-minimal.
 - _User-configurable agent list in settings_ — deferred (PRD Later).
 
+**ADR:** `docs/decisions/0023-agent-path-detect-allowlist.md`
+
 ### D7 — Signals / module-store at multi-window scale
 
 **Chosen: per-webview signals + plugin-store reload via app events.**
@@ -209,13 +215,15 @@ PresetsData v1 (conceptual)
 - _Lift all UI state into Rust_ — rewrite; fights imperative xterm layer.
 - _SharedWorker / BroadcastChannel between webviews_ — unreliable under WKWebView/Tauri; still need Rust for PTY ownership.
 
+**ADR:** `docs/decisions/0024-signals-module-store-multi-window.md`
+
 ### D8 — Quit semantics (product amendment)
 
 **Chosen: last tab of a window closes that window; app quits when no windows remain (or explicit Quit).**
 
-Supersedes single-window ADR 0002 behavior. Busy guard still applies on close paths only (never on swap/move).
+Supersedes single-window pre-pipeline quit behavior. Busy guard still applies on close paths only (never on swap/move).
 
-**ADR:** `docs/decisions/0003-last-window-close-quits-app.md` (supersedes `docs/adr/0002-last-tab-close-quits-app.md`)
+**ADR:** `docs/decisions/0003-last-window-close-quits-app.md` (replaces pre-pipeline `docs/adr/0002-last-tab-close-quits-app.md`)
 
 ## 6. Data flows (main journeys)
 
@@ -339,22 +347,30 @@ Restore / preset materialize: spawn N shells, `treeFromLayout(serialized, ids)` 
 
 ## 11. ADR index
 
-| ADR                                                  | Topic                              | Relation                         |
-| ---------------------------------------------------- | ---------------------------------- | -------------------------------- |
-| `docs/adr/0001-session-restore-without-cwd.md`       | Session chrome without CWD         | Still in force (PRINCIPLES)      |
-| `docs/adr/0002-last-tab-close-quits-app.md`          | Single-window quit                 | **Superseded** by decisions/0003 |
-| `docs/decisions/0001-rust-pty-window-coordinator.md` | Rust ownership + targeted PTY IPC  | New (architecture phase)         |
-| `docs/decisions/0002-multi-window-session-chrome.md` | Single multi-window `session.json` | New                              |
-| `docs/decisions/0003-last-window-close-quits-app.md` | Quit = last window of app          | New; supersedes adr/0002         |
+| ADR                                                            | Topic                              | Kind / relation                        |
+| -------------------------------------------------------------- | ---------------------------------- | -------------------------------------- |
+| `docs/decisions/0001-rust-pty-window-coordinator.md`           | Rust ownership + targeted PTY IPC  | architecture (D1)                      |
+| `docs/decisions/0002-multi-window-session-chrome.md`           | Single multi-window `session.json` | architecture (D3)                      |
+| `docs/decisions/0003-last-window-close-quits-app.md`           | Quit = last window of app          | architecture (D8); replaces adr/0002   |
+| `docs/decisions/0020-pane-id-equals-pty-id.md`                 | Pane-id ≡ PTY id                   | architecture (D2)                      |
+| `docs/decisions/0021-preset-persistence-presets-json.md`       | Separate `presets.json`            | architecture (D4)                      |
+| `docs/decisions/0022-sidebar-data-plane.md`                    | Rust reads + git shell-out         | architecture (D5)                      |
+| `docs/decisions/0023-agent-path-detect-allowlist.md`           | Allowlist PATH detect + spawn      | architecture (D6)                      |
+| `docs/decisions/0024-signals-module-store-multi-window.md`     | Per-webview signals + reload       | architecture (D7)                      |
+| `docs/decisions/0025-v1-stack-tauri-preact-xterm.md`           | v1 stack (revisable)               | architecture (§1)                      |
+| `docs/decisions/0005-macos-only-v1.md`                         | macOS only                         | principle (constrains stack)           |
+| `docs/decisions/0007-real-pty-login-shell.md`                  | Real PTY + login shell             | principle (PTY registry)               |
+| `docs/decisions/0010-session-restore-layout-chrome-not-cwd.md` | Session chrome without CWD         | principle (session schema)             |
+| `docs/decisions/0012-multi-window-workspace-model.md`          | Multi-window product model         | product (drives coordinator + session) |
+| `docs/adr/0001-session-restore-without-cwd.md`                 | Pre-pipeline session-chrome        | history; absorbed by ADR 0010          |
+| `docs/adr/0002-last-tab-close-quits-app.md`                    | Pre-pipeline single-window quit    | history; replaced by ADR 0003          |
 
-Rationale lives in ADRs; this document records the chosen shape only.
+Rationale lives in the ADRs; this document records the chosen shape only.
 
-## 12. Completeness check (pre-freeze)
+## 12. Completeness check
 
 Against PRINCIPLES: agent-CLI first, macOS, mouse+keyboard, real PTY, local-by-default, MIT, session-chrome-not-CWD — all reflected in seams and persistence.
 
 Against PRD / BUSINESS-FLOW journeys: Open board → materialize → picker; restore-all + picker; swap; move-across-window; sidebar; presets — each has a data flow and owning layer.
 
-Against brownfield: shipped modules named; net-new called out; no silent rewrite of ADR 0001.
-
-**Not done in this phase:** freeze stamps, `PIPELINE.lock` advance, `CONTEXT.md` compact, UX-DESIGN (sibling branch). Reconverge owns those.
+Against brownfield: shipped modules named; net-new called out; session-chrome-without-CWD (ADR 0010) preserved. Some net-new modules (Rust coordinator, tab-materialize / layout-engine / close-coordinator seams) are actively landing in the codebase; this document tracks the decisions, not a code snapshot — see `CONTEXT.md` for current implementation state.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,7 +7,7 @@ rendered: 2026-07-10
 
 # ARCHITECTURE — Stackgrid
 
-Single source of truth for the current and v1 target architecture. Rendered from the active ADR set (principles + product + architecture decisions) and a brownfield scan of the shipped codebase. English-only.
+Derived view of the current and v1 target architecture. Rendered from the active ADR set (principles + product + architecture decisions) and a brownfield scan of the shipped codebase. English-only.
 
 ## 1. Stack
 

--- a/docs/BUSINESS-FLOW.md
+++ b/docs/BUSINESS-FLOW.md
@@ -1,9 +1,9 @@
 ---
-frozen: true
-hash: 5830f27c0db628695ed4f2359e04f5cb955d6d2812b5c97e881e3f4089235abb
-from_hash:
-  PRINCIPLES: a06e3bee0cac7feb7d51244c8d46960f939f90f54fbd4c793ae2f6abd412f401
+derived: true
+derived_from: [0003, 0007, 0008, 0010, 0012, 0013, 0014, 0015, 0016, 0017, 0018]
+rendered: 2026-07-10
 ---
+
 # BUSINESS-FLOW — Stackgrid
 
 States, rules, and invariants for v1 product behavior. Complements `PRD.md`; does not replace PRINCIPLES.
@@ -12,54 +12,54 @@ States, rules, and invariants for v1 product behavior. Complements `PRD.md`; doe
 
 ### Application
 
-| State | Meaning |
-| --- | --- |
-| **Cold launch** | App starting; may load persisted multi-window session chrome if restore is enabled and data exists. |
-| **Open board** | User must choose workspace + layout preset before a real layout is shown. Entered on New Window, missing/disabled session restore, or empty session. |
-| **Running** | One or more windows exist with tabs/panes backed by PTYs. |
-| **Quitting** | App exiting after last window is gone or explicit Quit. |
+| State           | Meaning                                                                                                                                              |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Cold launch** | App starting; may load persisted multi-window session chrome if restore is enabled and data exists.                                                  |
+| **Open board**  | User must choose workspace + layout preset before a real layout is shown. Entered on New Window, missing/disabled session restore, or empty session. |
+| **Running**     | One or more windows exist with tabs/panes backed by PTYs.                                                                                            |
+| **Quitting**    | App exiting after last window is gone or explicit Quit.                                                                                              |
 
 ### Window
 
-| State | Meaning |
-| --- | --- |
+| State                 | Meaning                                                                        |
+| --------------------- | ------------------------------------------------------------------------------ |
 | **Open-board window** | New window showing Open board; no working tabs yet (or equivalent pre-layout). |
-| **Active window** | Has ≥1 tab; participates in session chrome persistence. |
-| **Closing** | Last tab of this window closed → window closes; other windows unaffected. |
+| **Active window**     | Has ≥1 tab; participates in session chrome persistence.                        |
+| **Closing**           | Last tab of this window closed → window closes; other windows unaffected.      |
 
 ### Tab / layout
 
-| State | Meaning |
-| --- | --- |
-| **Materializing** | Preset (or restore) applied; panes spawning shells at resolved CWDs. |
+| State                  | Meaning                                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Materializing**      | Preset (or restore) applied; panes spawning shells at resolved CWDs.                                                |
 | **Agent-pick pending** | After materialize or session restore: panes await agent/Shell/Skip-all. One-shot per pane for that materialization. |
-| **Live** | Normal use: focus, split, swap, drag-dock, move across windows. |
-| **Preset editing** | Mini layout mock open for designing a preset (not the live PTY layout). |
+| **Live**               | Normal use: focus, split, swap, drag-dock, move across windows.                                                     |
+| **Preset editing**     | Mini layout mock open for designing a preset (not the live PTY layout).                                             |
 
 ### Pane
 
-| State | Meaning |
-| --- | --- |
-| **Idle shell** | Foreground is idle shell (or session-ended limbo) — not busy. |
-| **Busy** | Foreground process is not an idle shell (agent or other). |
+| State            | Meaning                                                                    |
+| ---------------- | -------------------------------------------------------------------------- |
+| **Idle shell**   | Foreground is idle shell (or session-ended limbo) — not busy.              |
+| **Busy**         | Foreground process is not an idle shell (agent or other).                  |
 | **Agent-styled** | Foreground process name matches a recognized agent — header/badge styling. |
-| **Picker** | Overlay/chooser visible for agent vs Shell (during agent-pick pending). |
+| **Picker**       | Overlay/chooser visible for agent vs Shell (during agent-pick pending).    |
 
 ### Sidebar
 
-| State | Meaning |
-| --- | --- |
-| **Closed** | Default. |
-| **Open (preview)** | Showing file content; Markdown rendered when applicable. |
-| **Open (diff)** | Showing git diff for the file when git context exists. |
-| **Blocked** | Path missing/unresolvable — toast/error; sidebar stays closed. |
+| State              | Meaning                                                        |
+| ------------------ | -------------------------------------------------------------- |
+| **Closed**         | Default.                                                       |
+| **Open (preview)** | Showing file content; Markdown rendered when applicable.       |
+| **Open (diff)**    | Showing git diff for the file when git context exists.         |
+| **Blocked**        | Path missing/unresolvable — toast/error; sidebar stays closed. |
 
 ### Preset store
 
-| State | Meaning |
-| --- | --- |
-| **Empty / populated** | Named presets on disk (split tree + optional per-pane CWDs). |
-| **Saving / renaming / deleting / overwriting** | User-managed CRUD transitions. |
+| State                                          | Meaning                                                      |
+| ---------------------------------------------- | ------------------------------------------------------------ |
+| **Empty / populated**                          | Named presets on disk (split tree + optional per-pane CWDs). |
+| **Saving / renaming / deleting / overwriting** | User-managed CRUD transitions.                               |
 
 ## Rules
 
@@ -74,7 +74,7 @@ States, rules, and invariants for v1 product behavior. Complements `PRD.md`; doe
 ### CWD resolution
 
 6. When opening from a preset: pane CWD = preset pane CWD if set; else **workspace folder** chosen on the Open board.
-7. Session restore spawn CWD = `$HOME` (or existing restore contract) — presets do not rewrite `session.json`.
+7. Session restore spawn CWD = `$HOME` (ADR 0010) — presets do not rewrite `session.json`.
 8. New split / new tab at runtime inherits focused pane CWD (existing behavior).
 9. Closed-tab reopen may restore CWDs **in memory only** (existing behavior).
 

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -1,31 +1,63 @@
 # Stackgrid — working context
 
-## Pipeline
+## Pipeline (adk v2, ADR-first)
 
-- `phase: done` (`PIPELINE.lock`) — pipeline complete; `requirements_version: 1`.
-- Frozen: `docs/PRINCIPLES.md`, `docs/PRD.md`, `docs/BUSINESS-FLOW.md`, `docs/ARCHITECTURE.md`, `docs/UX-DESIGN.md`, `docs/REQUIREMENTS.md`.
-- `decisions.ux: included` (UI complex → UX-DESIGN.md produced). `flags.pending_arch_sync: false`.
+- `phase: done` (`PIPELINE.lock`, `lock_version: 2`, `project_type: brownfield`).
+- Source of truth = the active ADR set in `docs/decisions/`. The big docs are **rendered
+  views** derived from it, not authoritative on their own. Each carries `derived: true` +
+  `derived_from: [ids]`; only `REQUIREMENTS.md` also carries `version:`.
+- Rendered docs: `docs/PRINCIPLES.md`, `docs/PRD.md`, `docs/BUSINESS-FLOW.md`,
+  `docs/ARCHITECTURE.md`, `docs/UX-DESIGN.md`, `docs/REQUIREMENTS.md`.
+- Active set = every ADR whose `id` is not listed in another ADR's `supersedes`.
+  Currently `0001–0026` are all active (no supersede chains inside the pipeline set).
 - Domain glossary: repo-root `CONTEXT.md`.
 - Archives: `docs/CONTEXT-archive.md` (kickoff + product elicitation).
-- Pre-pipeline ADRs: `docs/adr/0001-*.md`, `docs/adr/0002-*.md` (0002 needs `/adr` amendment for multi-window quit).
-- New ADRs: `docs/decisions/` via `/adr`.
+- Pre-pipeline ADRs `docs/adr/0001-*.md`, `docs/adr/0002-*.md`: kept as historical
+  archive. Their content was carried forward — `docs/adr/0001` (session chrome, not CWD)
+  into ADR 0010; `docs/adr/0002` (multi-window quit) into ADR 0003. Do not edit the
+  archived pair; amend via a new `docs/decisions/` ADR instead.
 
-## Product snapshot (frozen — do not re-litigate here)
+## Migration note (v1 → v2)
+
+- This tree was re-bootstrapped from an adk **v1** pipeline (freeze-gated: frontmatter
+  `frozen/hash/from_hash`, `lock_version: 1`). Method: KIỂU B brownfield re-bootstrap,
+  done manually (no `adk migrate` skill; v2 skills refuse `lock_version: 1`).
+- The v1 frozen docs were reverse-engineered into ADRs `0004–0026` (7 principle,
+  9 product, 7 architecture). The 3 pre-existing ADRs `0001–0003` were normalized to v2
+  frontmatter and kept (0003 still records that it replaces pre-pipeline `docs/adr/0002`).
+- **Hook skipped by design:** no `on-render` / freeze hook was wired for v2 (user choice).
+  Renders were gated manually — each doc diffed and human-confirmed before replacing the
+  target. If automation is added later, note it here.
+- REQUIREMENTS preserved v1 ID continuity: all **45 FR + 9 NFR** IDs carried over 1:1,
+  no renumbering, `version: 1` kept.
+
+## Product snapshot (see PRD.md / BUSINESS-FLOW.md)
 
 - Job: observe + control many agent CLIs in parallel on macOS.
-- v1 gap vs brownfield: layout presets/mock, pane swap, multi-window move/join, Open board (workspace ∥ preset), post-materialize agent picker, file sidebar preview+diff.
-- Session chrome-only (no CWD); presets hold optional per-pane CWDs separately.
+- Net-new vs the shipped brownfield: layout presets/mock, pane swap, multi-window
+  move/join, Open board (workspace ∥ preset), post-materialize agent picker, file
+  sidebar preview+diff.
+- Session persists chrome only (no CWD); presets hold optional per-pane CWDs separately.
 - OUT: embed agent UI, SSH, iTerm parity chase, sidebar editing, notarized ship-gate.
 
-## Resolved in architecture (frozen — see ARCHITECTURE.md / UX-DESIGN.md)
+## Code state (`60ebe99`)
 
-- Multi-window session persistence, agent PATH discovery, module boundaries → `ARCHITECTURE.md`.
-- Net-new surface UX (Open board, preset editor, agent picker, file sidebar, pane movement) → `UX-DESIGN.md`.
-- ADRs `docs/decisions/0001–0003` (PTY/window coordinator, multi-window session chrome, last-window-close quits) registered in `adr_manifest`. They are ADR-early (landed before ARCHITECTURE froze) so `pending_arch_sync` stayed false.
+- The v1 stack is live (Tauri 2 + Rust + Preact + xterm.js — ADR 0025). At this HEAD the
+  Rust/coordinator seams are **actively landing**: PTY/window coordinator, tab
+  materialize, layout engine, and the close-coordinator paths were deepened in the last
+  refactor. Treat `src-tauri` module boundaries as in-flight when planning.
+
+## Adding a decision
+
+- Append a new immutable ADR to `docs/decisions/NNNN-slug.md` (frontmatter
+  `id/title/date/kind/affects/supersedes`; body `## Context / ## Decision /
+  ## Consequences / ## Options rejected`). To reverse an earlier call, write a new ADR
+  that lists the old `id` in `supersedes` — never edit a landed ADR.
+- Then re-render every doc in the new ADR's `affects`, diff, and human-confirm before
+  replacing. A doc `D` may only derive from ADR `A` when `D ∈ A.affects`.
 
 ## Next
 
-- Pipeline is done. `docs/REQUIREMENTS.md` (frozen, v1 — 41 FR + 9 NFR, full upstream coverage tables, no `stale-deferred`) is the input contract for `superpowers:writing-plans`; planning owns all FR→task decomposition.
-- History: the first `/requirements` run (2026-07-10) was blocked by a grill consistency gap — UX-DESIGN wrongly classified **pane swap** and **cross-window move** as shipped (they are net-new per PRD Brownfield note / ARCHITECTURE §2, confirmed absent in `src/`), so neither had an interaction spec; preset CRUD affordances and the preset editor entry point were also unplaced.
-- Resolved by `/reconcile UX-DESIGN` (same day, human-confirmed re-freeze, new hash `e5ff0dcf…`): new §6 "Pane movement" (swap = center drop zone on shipped drag-dock + `⌘⌥⇧`+arrows; cross-window move = "Move pane to…" popover, `⌘⇧M` / Window menu), §2 gained the "＋ New preset…" card + card rename/delete, §3 gained entry points, Create-tab CWD resolution (BF-Rule 6/8), and "Save Layout as Preset…" (`⌘⇧S`, save/overwrite). No cascade: REQUIREMENTS did not exist yet.
-- If a large decision crystallizes later, `/adr` (an architecture-changing ADR after freeze will set `pending_arch_sync` → `/reconcile ARCHITECTURE`).
+- Pipeline is done. `docs/REQUIREMENTS.md` (45 FR + 9 NFR, full upstream coverage tables)
+  is the input contract for `superpowers:writing-plans`; planning owns all FR→task
+  decomposition.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,12 +1,13 @@
 ---
-frozen: true
-hash: 1d1b4c0c4dc5455d87bd348fa635f33d2c331cc363fd1d6abb8bb18be2c912a8
-from_hash:
-  PRINCIPLES: a06e3bee0cac7feb7d51244c8d46960f939f90f54fbd4c793ae2f6abd412f401
+derived: true
+derived_from:
+  [0004, 0005, 0006, 0010, 0011, 0012, 0013, 0014, 0015, 0016, 0017, 0018, 0019]
+rendered: 2026-07-10
 ---
+
 # PRD — Stackgrid
 
-Product intent, primary journey, and v1 scope. Narrative FR/NFR only — atomic requirements wait for `/requirements`.
+Product intent, primary journey, and v1 scope. Narrative FR/NFR only — atomic requirements are distilled in `REQUIREMENTS.md` (requirements phase).
 
 ## Intent
 
@@ -31,7 +32,7 @@ Stackgrid is a **minimal macOS terminal for people who run AI agent CLIs** (Clau
 
 ### Resume — open the app again
 
-1. On relaunch with restore enabled, Stackgrid restores **layout chrome for every window** (tabs, splits, names, colors) — not CWDs, not running processes (PRINCIPLES + existing session ADR).
+1. On relaunch with restore enabled, Stackgrid restores **layout chrome for every window** (tabs, splits, names, colors) — not CWDs, not running processes (PRINCIPLES + ADR 0010).
 2. After restore, each pane still gets a **one-shot agent picker** (same spawn / Shell / Skip-all rules). Unpicked panes stay idle shells at `$HOME` (session restore behavior).
 
 ### Steer — rearrange attention

--- a/docs/PRINCIPLES.md
+++ b/docs/PRINCIPLES.md
@@ -1,16 +1,17 @@
 ---
-frozen: true
-hash: a06e3bee0cac7feb7d51244c8d46960f939f90f54fbd4c793ae2f6abd412f401
-from_hash: {}
+derived: true
+derived_from: [0004, 0005, 0006, 0007, 0008, 0009, 0010]
+rendered: 2026-07-10
 ---
+
 # PRINCIPLES
 
-Non-negotiables for Stackgrid. Keep this list light — root of the docs hash-graph, not a product dump.
+Non-negotiables for Stackgrid. Rendered from the active principle ADRs (`docs/decisions/0004`–`0010`); each bullet traces to one ADR. Keep this list light — it is a view over the ADR log, not a product dump.
 
-- **Agent-CLI terminal first.** Stackgrid exists to run and observe AI agent CLIs well. Features should serve that job; general terminal parity is optional, not the north star.
-- **macOS only.** No commitment to Windows/Linux in this document.
-- **Mouse and keyboard are both first-class.** Everyday use must work well with either; do not design for one input mode at the expense of the other.
-- **Real PTY + login shell.** Every pane is backed by a real PTY spawning `$SHELL -l` (or equivalent). No fake/half terminal that breaks PATH, aliases, or dotfiles.
-- **Local by default.** No telemetry. Terminal contents and session data stay on device unless the user explicitly sends them elsewhere.
-- **MIT / open source.** The project remains openly licensed.
-- **Session restore = layout chrome, not CWD.** Restoring tabs/layout/names/colors across restarts is in scope; persisting pane CWDs in `session.json` is out (see existing ADR). In-session closed-tab reopen may still restore CWDs in memory.
+- **Agent-CLI terminal first.** Stackgrid exists to run and observe AI agent CLIs well. Features should serve that job; general terminal parity is optional, not the north star. (ADR 0004)
+- **macOS only.** v1 commits to macOS; no commitment to Windows/Linux in this document. (ADR 0005)
+- **Mouse and keyboard are both first-class.** Everyday use must work well with either; do not design for one input mode at the expense of the other. (ADR 0006)
+- **Real PTY + login shell.** Every pane is backed by a real PTY spawning `$SHELL -l` (or equivalent). No fake/half terminal that breaks PATH, aliases, or dotfiles. (ADR 0007)
+- **Local by default.** No telemetry. Terminal contents and session data stay on device unless the user explicitly sends them elsewhere. (ADR 0008)
+- **MIT / open source.** The project remains openly licensed. (ADR 0009)
+- **Session restore = layout chrome, not CWD.** Restoring tabs/layout/names/colors across restarts is in scope; persisting pane CWDs in `session.json` is out. In-session closed-tab reopen may still restore CWDs in memory; layout presets may hold optional per-pane CWDs separately. (ADR 0010)

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -1,19 +1,14 @@
 ---
-frozen: true
-hash: dda551b9e792226d9662244835af4ed76e148bb49e60128261fc4264a739b707
-from_hash:
-  PRINCIPLES: a06e3bee0cac7feb7d51244c8d46960f939f90f54fbd4c793ae2f6abd412f401
-  PRD: 1d1b4c0c4dc5455d87bd348fa635f33d2c331cc363fd1d6abb8bb18be2c912a8
-  BUSINESS-FLOW: 5830f27c0db628695ed4f2359e04f5cb955d6d2812b5c97e881e3f4089235abb
-  ARCHITECTURE: 8ec703e3eb57216edb5446edfa5309480791400c937f3d597da3bfe6373639fc
-  UX-DESIGN: e5ff0dcfe278b0ef3de3c50aa55fadccd09673abc68d567e6c764c92563135e0
+derived: true
+derived_from: [0001, 0002, 0003, 0010, 0012, 0013, 0014, 0015, 0016, 0017, 0018, 0020, 0021, 0022, 0023]
+rendered: 2026-07-10
 version: 1
 ---
 
 # REQUIREMENTS — Stackgrid
 
 Atomic functional (FR) and non-functional (NFR) requirements for v1, distilled from the
-frozen upstream contract: `PRINCIPLES.md`, `PRD.md`, `BUSINESS-FLOW.md`,
+active ADR set, rendered into the upstream docs: `PRINCIPLES.md`, `PRD.md`, `BUSINESS-FLOW.md`,
 `ARCHITECTURE.md`, `UX-DESIGN.md`. This is the terminal artifact of the docs pipeline
 and the input contract for planning — `superpowers:writing-plans` owns all FR→task
 decomposition; this document plans nothing.
@@ -615,7 +610,7 @@ Refs: ARCH §1, D7.
 The v1 gap work must not degrade the shipped foundation.
 
 - AC-1: Focus (cycle + directional), split, drag-dock rearrange, divider resize, focus-expand, zoom, tab bar, settings, themes, Cmd+F search, file-drop → PTY, git branch in status bar, agent/busy chrome, and busy/quit guards keep working as shipped.
-- AC-2: Session chrome restore semantics remain layout-chrome-only (ADR adr/0001 stays in force).
+- AC-2: Session chrome restore semantics remain layout-chrome-only (ADR 0010 stays in force).
 
 Refs: PRD Brownfield note · ARCH §2, §11.
 
@@ -704,6 +699,6 @@ D7 → FR-043, FR-053, NFR-007 · D8 → FR-042.
 
 ## Handoff note
 
-- This contract is the terminal artifact of the docs pipeline; `requirements_version: 1`.
-- No upstream doc is `stale-deferred` — the handoff to `superpowers:writing-plans` carries no staleness warnings.
+- This contract is the terminal artifact of the docs pipeline; `version: 1` (v2 ADR-derived render — same v1 requirements, now traced to the active ADR set).
+- REQUIREMENTS renders from the active ADR set (frontmatter `derived_from`) — the handoff to `superpowers:writing-plans` carries no staleness warnings.
 - UX-DESIGN §8 defaults (last-used preset preselect, picker number hints, sidebar Preview default, swap affordances, move popover, CRUD placement) are folded into the FRs above as stated defaults; none are load-bearing for the architecture and each can change without reshaping a surface.

--- a/docs/UX-DESIGN.md
+++ b/docs/UX-DESIGN.md
@@ -1,10 +1,7 @@
 ---
-frozen: true
-hash: e5ff0dcfe278b0ef3de3c50aa55fadccd09673abc68d567e6c764c92563135e0
-from_hash:
-  PRINCIPLES: a06e3bee0cac7feb7d51244c8d46960f939f90f54fbd4c793ae2f6abd412f401
-  PRD: 1d1b4c0c4dc5455d87bd348fa635f33d2c331cc363fd1d6abb8bb18be2c912a8
-  BUSINESS-FLOW: 5830f27c0db628695ed4f2359e04f5cb955d6d2812b5c97e881e3f4089235abb
+derived: true
+derived_from: [0006, 0013, 0014, 0015, 0016, 0017, 0026]
+rendered: 2026-07-10
 ---
 
 # UX-DESIGN — Stackgrid
@@ -408,6 +405,6 @@ Edge cases:
 6. **Preset CRUD placement** → rename/delete on Open board cards; save-from-live and
    new-preset entries in the Window menu (`⌘⇧S` / board card).
 
-These were set as least-surprise defaults during prototype review (4–6 during the
-requirements-phase reconcile); none are load-bearing for the architecture and each can
-change without reshaping a surface.
+These were set as least-surprise defaults during prototype review (items 4–6 added
+later, in the requirements phase); none are load-bearing for the architecture and each
+can change without reshaping a surface.

--- a/docs/decisions/0001-rust-pty-window-coordinator.md
+++ b/docs/decisions/0001-rust-pty-window-coordinator.md
@@ -1,8 +1,13 @@
+---
+id: 0001
+title: "Rust PTY / window coordinator"
+date: 2026-07-09
+kind: architecture
+affects: [ARCHITECTURE, REQUIREMENTS]
+supersedes: []
+---
+
 # ADR 0001 — Rust PTY / window coordinator
-
-## Status
-
-Accepted (architecture phase; ADR-early — ARCHITECTURE not yet frozen).
 
 ## Context
 
@@ -17,3 +22,7 @@ Keep the Rust `PtyState` registry keyed by pane-id (PTY id). Add an app-level Ru
 - New IPC for ownership changes and targeted event delivery.
 - Frontend per-window managers stay responsible for layout trees and xterm attachment only.
 - Closing a window disposes only PTYs still owned by that window (subject to busy close guards).
+
+## Options rejected
+
+- Broadcast every `pty:output` / `pty:exit` event to all webviews (status quo) — causes cross-window races and orphaned PTYs once panes move between windows.

--- a/docs/decisions/0002-multi-window-session-chrome.md
+++ b/docs/decisions/0002-multi-window-session-chrome.md
@@ -1,12 +1,17 @@
+---
+id: 0002
+title: "Multi-window session chrome in one file"
+date: 2026-07-09
+kind: architecture
+affects: [ARCHITECTURE, REQUIREMENTS]
+supersedes: []
+---
+
 # ADR 0002 — Multi-window session chrome in one file
-
-## Status
-
-Accepted (architecture phase; ADR-early — ARCHITECTURE not yet frozen).
 
 ## Context
 
-PRD / BUSINESS-FLOW require restoring layout chrome for **all** windows on relaunch. The shipped `session.json` is a flat single-window `{ version: 1, tabs, activeTab }` with no window dimension. Session must remain chrome-only (no CWD / process) per PRINCIPLES and pre-pipeline ADR 0001.
+PRD / BUSINESS-FLOW require restoring layout chrome for **all** windows on relaunch. The shipped `session.json` is a flat single-window `{ version: 1, tabs, activeTab }` with no window dimension. Session must remain chrome-only (no CWD / process) per PRINCIPLES and pre-pipeline ADR `docs/adr/0001-session-restore-without-cwd.md`.
 
 ## Decision
 
@@ -17,3 +22,8 @@ Persist one `session.json` with a version bump to a multi-window shape: a `windo
 - Atomic restore-all from one artifact.
 - Debounced save must aggregate chrome across windows.
 - Presets stay in a separate `presets.json` (not this file).
+
+## Options rejected
+
+- One session file per window — loses atomic restore-all and complicates cross-window aggregation.
+- Add CWD / process identity to `session.json` — violates PRINCIPLES (session = layout chrome only).

--- a/docs/decisions/0003-last-window-close-quits-app.md
+++ b/docs/decisions/0003-last-window-close-quits-app.md
@@ -1,14 +1,17 @@
+---
+id: 0003
+title: "Last window close quits the app"
+date: 2026-07-09
+kind: architecture
+affects: [BUSINESS-FLOW, ARCHITECTURE, REQUIREMENTS]
+supersedes: []
+---
+
 # ADR 0003 — Last window close quits the app
-
-## Status
-
-Accepted (architecture phase; ADR-early — ARCHITECTURE not yet frozen).
-
-Supersedes: `docs/adr/0002-last-tab-close-quits-app.md` (single-window quit).
 
 ## Context
 
-Pre-pipeline ADR 0002 made “close last tab” quit the app because Stackgrid had one window. v1 product intent is multi-window: closing the last tab of **one** window must close **that window** only; the application exits when the **last window** is gone (or on explicit Quit). Busy confirmation remains on close paths only.
+Pre-pipeline ADR `docs/adr/0002-last-tab-close-quits-app.md` made "close last tab" quit the app because Stackgrid had one window. That ADR is pre-pipeline history and is **not** part of the v2 decisions log; this ADR is the active rule that replaces it (there is no in-log `id` to supersede, so `supersedes` stays empty and the replacement is recorded here in prose). v1 product intent is multi-window: closing the last tab of **one** window must close **that window** only; the application exits when the **last window** is gone (or on explicit Quit). Busy confirmation remains on close paths only.
 
 ## Decision
 
@@ -21,4 +24,9 @@ Pre-pipeline ADR 0002 made “close last tab” quit the app because Stackgrid h
 
 - Implementers must not treat `tabs.length === 0` as app quit when other windows exist.
 - `quit-requested` / `confirm_quit` remain the confirmed exit path for explicit quit and last-window close.
-- Pre-pipeline `docs/adr/0002-*.md` is historical; this ADR is the active rule.
+- `affects` deviates from the mechanical default for `kind: architecture`: UX-DESIGN is excluded (this decision has no UI surface), and BUSINESS-FLOW is included (this is a close/quit behavior rule that lives in the flow doc).
+
+## Options rejected
+
+- Keep single-window "last tab quits" semantics — contradicts multi-window v1 intent.
+- Quit whenever any window closes — would kill live agents running in other windows.

--- a/docs/decisions/0004-agent-cli-terminal-first.md
+++ b/docs/decisions/0004-agent-cli-terminal-first.md
@@ -1,0 +1,28 @@
+---
+id: 0004
+title: "Agent-CLI terminal first"
+date: 2026-07-09
+kind: principle
+affects: [PRINCIPLES, PRD]
+supersedes: []
+---
+
+# ADR 0004 — Agent-CLI terminal first
+
+## Context
+
+Stackgrid competes with iTerm / Terminal.app not on being a prettier general terminal, but on affordances for running and observing many AI agent CLIs at once. Without a stated north star, feature pressure drifts toward general terminal parity.
+
+## Decision
+
+Stackgrid exists to run and observe AI agent CLIs (Claude Code, Codex, Gemini CLI, and similar) well. Features must serve that job first. General terminal parity is optional, not the north star.
+
+## Consequences
+
+- Product scope (PRD) prioritizes agent-CLI observation / control; parity work is opportunistic, never a v1 goal.
+- Trade-offs that help agent-CLI workflows at the cost of exotic terminal features are acceptable.
+- `affects` narrowed to `[PRINCIPLES, PRD]`: this is a product-intent stance framing PRD scope; it does not by itself set flow rules, module boundaries, UI specs, or atomic requirements (those come from downstream product/architecture ADRs).
+
+## Options rejected
+
+- Aim for full iTerm parity as the product goal — dilutes focus and is explicitly out of v1 scope.

--- a/docs/decisions/0005-macos-only-v1.md
+++ b/docs/decisions/0005-macos-only-v1.md
@@ -1,0 +1,28 @@
+---
+id: 0005
+title: "macOS only (v1)"
+date: 2026-07-09
+kind: principle
+affects: [PRINCIPLES, PRD, ARCHITECTURE]
+supersedes: []
+---
+
+# ADR 0005 — macOS only (v1)
+
+## Context
+
+Stackgrid is built on Tauri 2 + Preact + xterm.js and uses macOS-specific window / PTY behavior. Committing to cross-platform now would constrain architecture and dilute v1.
+
+## Decision
+
+v1 commits to macOS only. No commitment to Windows or Linux in this cycle.
+
+## Consequences
+
+- Architecture may use macOS-only affordances (window chrome, Gatekeeper, `$SHELL -l`) without a portability abstraction.
+- PRD scope and distribution assume macOS.
+- `affects` narrowed to `[PRINCIPLES, PRD, ARCHITECTURE]`: platform commitment bounds product scope (PRD) and permits macOS-specific mechanisms (ARCHITECTURE); it does not itself define behavior rules, UI, or atomic requirements.
+
+## Options rejected
+
+- Cross-platform v1 — premature; would add a portability layer with no v1 payoff.

--- a/docs/decisions/0006-mouse-and-keyboard-first-class.md
+++ b/docs/decisions/0006-mouse-and-keyboard-first-class.md
@@ -1,0 +1,28 @@
+---
+id: 0006
+title: "Mouse and keyboard both first-class"
+date: 2026-07-09
+kind: principle
+affects: [PRINCIPLES, PRD, UX-DESIGN]
+supersedes: []
+---
+
+# ADR 0006 — Mouse and keyboard both first-class
+
+## Context
+
+Terminal power-tools often bias toward keyboard-only ideology. Stackgrid's users mix mouse-driven rearrangement (drag-dock, swap) with keyboard flows.
+
+## Decision
+
+Everyday use must work well with either mouse or keyboard. Do not design for one input mode at the expense of the other.
+
+## Consequences
+
+- Net-new surfaces (Open board, preset editor, pane movement, sidebar) need both pointer and keyboard affordances (UX-DESIGN).
+- Product scope keeps both interaction paths in view.
+- `affects` narrowed to `[PRINCIPLES, PRD, UX-DESIGN]`: this is an interaction-parity stance shaping UI design (UX-DESIGN) and product framing (PRD); it does not set flow rules, module structure, or atomic requirements directly.
+
+## Options rejected
+
+- Keyboard-only ideology — excludes mouse-first users and contradicts existing drag-dock UX.

--- a/docs/decisions/0007-real-pty-login-shell.md
+++ b/docs/decisions/0007-real-pty-login-shell.md
@@ -1,0 +1,28 @@
+---
+id: 0007
+title: "Real PTY + login shell"
+date: 2026-07-09
+kind: principle
+affects: [PRINCIPLES, BUSINESS-FLOW, ARCHITECTURE]
+supersedes: []
+---
+
+# ADR 0007 — Real PTY + login shell
+
+## Context
+
+Agent CLIs depend on a correct PATH, aliases, and dotfiles. A fake or half terminal breaks these and makes agents misbehave.
+
+## Decision
+
+Every pane is backed by a real PTY spawning `$SHELL -l` (or equivalent login shell). No fake / half terminal surfaces for agent work.
+
+## Consequences
+
+- BUSINESS-FLOW invariant: every pane has exactly one real PTY (login shell or child process tree).
+- Architecture keeps the Rust `PtyState` registry as the PTY authority (see ADR 0001).
+- `affects` narrowed to `[PRINCIPLES, BUSINESS-FLOW, ARCHITECTURE]`: this is a runtime-fidelity invariant that lives in BUSINESS-FLOW and constrains ARCHITECTURE; it is not a product-scope, UI, or atomic-requirement statement on its own.
+
+## Options rejected
+
+- Emulated / pseudo shell without a real PTY — breaks PATH / aliases / dotfiles, defeating the agent-CLI purpose.

--- a/docs/decisions/0008-local-by-default-no-telemetry.md
+++ b/docs/decisions/0008-local-by-default-no-telemetry.md
@@ -1,0 +1,28 @@
+---
+id: 0008
+title: "Local by default (no telemetry)"
+date: 2026-07-09
+kind: principle
+affects: [PRINCIPLES, BUSINESS-FLOW]
+supersedes: []
+---
+
+# ADR 0008 — Local by default (no telemetry)
+
+## Context
+
+Terminal contents and session data are sensitive. Users expect a local-first tool with no background exfiltration.
+
+## Decision
+
+No telemetry by default. Terminal contents and session / preset data stay on device unless the user explicitly sends them elsewhere.
+
+## Consequences
+
+- BUSINESS-FLOW privacy rules: no telemetry; data stays local.
+- No cloud agent catalog; agent discovery stays local / PATH-based.
+- `affects` narrowed to `[PRINCIPLES, BUSINESS-FLOW]`: this is a privacy invariant expressed as BUSINESS-FLOW rules; it does not shape product-scope framing, module boundaries, UI, or atomic requirements directly.
+
+## Options rejected
+
+- Opt-out telemetry — contradicts the local-by-default trust posture.

--- a/docs/decisions/0009-mit-open-source.md
+++ b/docs/decisions/0009-mit-open-source.md
@@ -1,0 +1,27 @@
+---
+id: 0009
+title: "MIT / open source"
+date: 2026-07-09
+kind: principle
+affects: [PRINCIPLES]
+supersedes: []
+---
+
+# ADR 0009 — MIT / open source
+
+## Context
+
+Stackgrid is published openly (README, public repo `mxrsv/stackgrid`). Licensing is a governance non-negotiable.
+
+## Decision
+
+The project remains openly licensed under MIT.
+
+## Consequences
+
+- Contributions and distribution assume MIT terms.
+- `affects` narrowed to `[PRINCIPLES]`: licensing is a project-governance non-negotiable; it does not shape product intent, flow rules, architecture, UI, or requirements content.
+
+## Options rejected
+
+- Proprietary or copyleft relicensing — contradicts the project's open, permissive stance.

--- a/docs/decisions/0010-session-restore-layout-chrome-not-cwd.md
+++ b/docs/decisions/0010-session-restore-layout-chrome-not-cwd.md
@@ -1,0 +1,31 @@
+---
+id: 0010
+title: "Session restore = layout chrome, not CWD"
+date: 2026-07-09
+kind: principle
+affects: [PRINCIPLES, PRD, BUSINESS-FLOW, ARCHITECTURE, REQUIREMENTS]
+supersedes: []
+---
+
+# ADR 0010 — Session restore = layout chrome, not CWD
+
+## Context
+
+Users want tabs and split layouts back after restart, but persisting each pane's CWD in `session.json` couples restore to fragile filesystem state and conflicts with the "fresh login shell" expectation. This principle was first recorded pre-pipeline in `docs/adr/0001-session-restore-without-cwd.md`; this ADR absorbs it into the v2 decisions log as the active principle (the pre-pipeline file remains as history and is not part of the v2 log).
+
+## Decision
+
+Restoring tabs / layout / names / colors across restarts is in scope. Persisting pane CWDs in `session.json` is out of scope. In-session closed-tab reopen may still restore CWDs in memory, and layout presets may store optional per-pane CWDs as a separate artifact.
+
+## Consequences
+
+- PRD journey (Resume) restores chrome only; each pane spawns a fresh shell at `$HOME`.
+- BUSINESS-FLOW invariant: `session.json` never persists CWDs or process identity — only layout chrome.
+- ARCHITECTURE: the multi-window session schema stays chrome-only (see ADR 0002).
+- REQUIREMENTS: restore / CWD-resolution requirements derive from this rule.
+- `affects` narrowed to exclude UX-DESIGN: this rule is load-bearing across product intent, flow invariants, architecture, and requirements, but it does not by itself specify a UI surface (the Open board / preset UI that references CWDs is shaped by product / UX ADRs, not this principle).
+
+## Options rejected
+
+- Persist per-pane CWD in `session.json` — fragile against moved / deleted folders and breaks the fresh-shell expectation.
+- Persist running processes across restart — out of scope; processes are not serializable session state.

--- a/docs/decisions/0011-product-intent-parallel-multi-agent.md
+++ b/docs/decisions/0011-product-intent-parallel-multi-agent.md
@@ -1,0 +1,27 @@
+---
+id: 0011
+title: "Product intent: parallel multi-agent observe & control"
+date: 2026-07-09
+kind: product
+affects: [PRD]
+supersedes: []
+---
+
+# ADR 0011 — Product intent: parallel multi-agent observe & control
+
+## Context
+
+iTerm / Terminal.app are fine general terminals but lack affordances for observing and controlling many agent CLIs at once: multiple panes, clear busy/agent state, fast layout control, and light file inspection without leaving the terminal.
+
+## Decision
+
+Stackgrid's job-to-be-done: open a known working folder and layout, spawn agents into panes, watch and steer them in parallel, rearrange or detach panes when attention shifts, and peek at files/diffs the agents touch — without becoming an IDE or a full iTerm replacement. Primary user: a macOS developer who already lives in agent CLIs and keeps several running side by side. Product non-goal: chasing general terminal parity as the north star.
+
+## Consequences
+
+- PRD intent, primary journey, and scope are framed around parallel agent-CLI observation/control.
+- `affects` narrowed to `[PRD]`: this is a product-intent framing; concrete flow rules, architecture, UI, and atomic requirements come from the feature ADRs downstream (0012–0019) and the requirements phase.
+
+## Options rejected
+
+- Position Stackgrid as a general iTerm replacement — dilutes the agent-CLI focus that justifies the product.

--- a/docs/decisions/0012-multi-window-workspace-model.md
+++ b/docs/decisions/0012-multi-window-workspace-model.md
@@ -1,0 +1,29 @@
+---
+id: 0012
+title: "Multi-window workspace model"
+date: 2026-07-09
+kind: product
+affects: [PRD, BUSINESS-FLOW, ARCHITECTURE, REQUIREMENTS]
+supersedes: []
+---
+
+# ADR 0012 — Multi-window workspace model
+
+## Context
+
+v1 product intent is inherently multi-window: users spread agents across several OS windows and expect all of them back after relaunch. The shipped app was single-window.
+
+## Decision
+
+v1 is multi-window. A pane can move to a new window and move or join back into another window/tab (bidirectional); the process keeps running across the move. Layout chrome is persisted and restored for **all** windows. The application exits only when the last window of the app is gone (or on explicit Quit); the concrete close/quit routing is ADR 0003.
+
+## Consequences
+
+- PRD scope and journey (Steer, Resume) assume multiple windows.
+- BUSINESS-FLOW gains window states and invariant "app quit ⟺ no windows left".
+- ARCHITECTURE must own cross-window PTY routing and multi-window session persistence (ADR 0001, ADR 0002).
+- `affects` narrowed to exclude UX-DESIGN: the movement UI is specified by ADR 0016; this ADR sets the product/architecture model and the requirements it generates (cross-window move, restore-all, quit-scope), not the UI.
+
+## Options rejected
+
+- Keep single-window v1 — contradicts the parallel multi-agent job (ADR 0011).

--- a/docs/decisions/0013-open-board-workspace-preset-cwd.md
+++ b/docs/decisions/0013-open-board-workspace-preset-cwd.md
@@ -1,0 +1,32 @@
+---
+id: 0013
+title: "Open board (workspace ∥ preset) + CWD origin"
+date: 2026-07-09
+kind: product
+affects: [PRD, BUSINESS-FLOW, UX-DESIGN, REQUIREMENTS]
+supersedes: []
+---
+
+# ADR 0013 — Open board (workspace ∥ preset) + CWD origin
+
+## Context
+
+Starting a session needs an explicit choice of where to work and which layout to materialize. Without a gate, a new/empty window would show nothing useful, and pane CWDs would be undefined.
+
+## Decision
+
+On New Window, missing/disabled session restore, or an empty session, Stackgrid shows the **Open board**: workspace (recent folders + Open Folder, Cursor-style) and layout preset as two parallel fields. Open requires a workspace folder and a layout preset; if the user has no saved presets a built-in default single-pane preset is always available so Open cannot soft-lock. Confirming Open materializes one tab/layout in that window.
+
+CWD origin at materialize: a pane's CWD = its preset pane CWD when set, else the workspace folder. At runtime, a new split or new tab inherits the focused pane's CWD (existing behavior). Session-restore spawn CWD is `$HOME` (ADR 0010), not this path. "Workspace" means a local folder — distinct from Window and from Session.
+
+## Consequences
+
+- PRD "start a session" and "resume" journeys route through the Open board (restore path still runs the agent picker, ADR 0014).
+- BUSINESS-FLOW gains Open-board states/rules and the CWD-resolution cluster; invariant "workspace ≠ window ≠ session".
+- UX-DESIGN specifies the two-field board and the "＋ New preset…" affordance.
+- `affects` narrowed to exclude ARCHITECTURE: the board is product/UX behavior and storage mechanisms are downstream; the requirements it generates (Open-board gate, workspace ∥ preset, CWD resolution, default preset) are in scope.
+
+## Options rejected
+
+- Auto-open a default layout with no board — leaves workspace/CWD implicit and undermines "open a known folder + layout".
+- Treat "workspace" as a synonym for window or session — breaks the domain language.

--- a/docs/decisions/0014-agent-picker-and-recognition.md
+++ b/docs/decisions/0014-agent-picker-and-recognition.md
@@ -1,0 +1,33 @@
+---
+id: 0014
+title: "Agent picker (PATH + Shell + Skip-all) + agent-state recognition"
+date: 2026-07-09
+kind: product
+affects: [PRD, BUSINESS-FLOW, UX-DESIGN, REQUIREMENTS]
+supersedes: []
+---
+
+# ADR 0014 — Agent picker (PATH + Shell + Skip-all) + agent-state recognition
+
+## Context
+
+After a layout materializes (Open or restore), each pane needs a fast, no-config way to launch an agent CLI or stay a plain shell. Separately, panes must show whether a foreground process is idle, busy, or a recognized agent.
+
+## Decision
+
+After materialize or session restore, each pane shows a **one-shot** agent picker. Options = agent CLIs detected on `PATH` + "Shell only"; no mandatory user configuration in v1. Choosing an agent spawns that command immediately; choosing Shell leaves an idle login shell; **Skip all** sends every still-pending pane to Shell while already-chosen panes keep their spawn. The picker is one-shot per materialization — dismissed/skipped panes do not re-prompt until a new Open/restore cycle.
+
+Agent-state recognition for chrome: a pane is **Busy** when its foreground process is not an idle shell, and **Agent-styled** (header/badge) when the foreground process name matches a recognized agent. Both the spawn list and recognition stay local / PATH- and process-name-based — no cloud agent catalog.
+
+## Consequences
+
+- PRD journeys (start + resume) always run the picker; restore never skips it (invariant).
+- BUSINESS-FLOW gains agent-pick-pending state, pane Busy/Agent-styled/Picker states, and invariant "agent recognition and spawn list both stay local/PATH".
+- UX-DESIGN specifies the picker overlay.
+- `affects` narrowed to exclude ARCHITECTURE: PATH-discovery and process-name mechanisms are architecture detail; the requirements it generates (picker options, immediate spawn, Skip-all, one-shot, local recognition) are in scope.
+
+## Options rejected
+
+- Mandatory user-configured agent list in v1 — adds setup friction; PATH auto-detect is enough.
+- Re-prompt the picker on every focus — the one-shot-per-materialization rule keeps it unobtrusive.
+- Cloud/remote agent catalog — violates local-by-default (ADR 0008).

--- a/docs/decisions/0015-layout-presets-artifact-mock-crud.md
+++ b/docs/decisions/0015-layout-presets-artifact-mock-crud.md
@@ -1,0 +1,30 @@
+---
+id: 0015
+title: "Layout presets: separate artifact, mock editor, CRUD"
+date: 2026-07-09
+kind: product
+affects: [PRD, BUSINESS-FLOW, UX-DESIGN, REQUIREMENTS]
+supersedes: []
+---
+
+# ADR 0015 — Layout presets: separate artifact, mock editor, CRUD
+
+## Context
+
+Users want to reopen known layouts (and optionally known folders) quickly. Session chrome is layout-only and per-window; presets are a reusable template that may also carry CWDs — a different concern from `session.json`.
+
+## Decision
+
+Layout presets are a **separate persisted artifact** from `session.json`. A preset stores a split tree + optional per-pane CWDs (v1 minimum: tree + CWD map; may carry tab chrome later). CRUD: the user can save the current live layout as a named preset and rename / delete / overwrite presets; presets persist across restarts. A mini layout **mock** editor lets the user design a layout model, confirm, and **open it as a new tab** (it does not apply over the current tab in place). Saving from a live layout does not require the mock.
+
+## Consequences
+
+- PRD "capture" journey and scope cover preset CRUD + mock editor.
+- BUSINESS-FLOW gains preset-store states and preset rules; the built-in default preset (ADR 0013) covers the empty-store case.
+- UX-DESIGN specifies the mock editor, the "Save Layout as Preset…" affordance, and per-card rename/delete.
+- `affects` narrowed to exclude ARCHITECTURE: the `presets.json` persistence is an architecture consequence recorded in ADR 0021; the requirements it generates (preset CRUD, mock → new tab, default preset) are in scope.
+
+## Options rejected
+
+- Store presets inside `session.json` — conflates a reusable template with per-window restore chrome (ADR 0002).
+- Mock editor applies over the current tab in place — surprising; opening a new tab is safer and matches intent.

--- a/docs/decisions/0016-pane-swap-cross-window-move-busy-guard.md
+++ b/docs/decisions/0016-pane-swap-cross-window-move-busy-guard.md
@@ -1,0 +1,30 @@
+---
+id: 0016
+title: "Pane swap + cross-window move; busy confirm only on close"
+date: 2026-07-09
+kind: product
+affects: [PRD, BUSINESS-FLOW, UX-DESIGN, REQUIREMENTS]
+supersedes: []
+---
+
+# ADR 0016 — Pane swap + cross-window move; busy confirm only on close
+
+## Context
+
+Attention shifts between agents. Users need to rearrange panes — exchange two positions, or move a pane to another window — without killing running agents, and without nagging confirmations for non-destructive moves.
+
+## Decision
+
+**Swap** exchanges two panes' positions in the layout; their PTYs/sessions move with them. **Cross-window move** sends a pane to a new window or moves/joins it into another window/tab (bidirectional); the process keeps running. Swap and cross-window move **never** show a busy confirmation. The **busy guard** (confirm when a relevant pane is busy) applies to **close pane / close tab** only. Close routing — last pane → close tab, last tab → close window, last window → quit — is ADR 0003.
+
+## Consequences
+
+- PRD "steer" journey covers swap + move; scope adds pane swap on top of the shipped drag-dock.
+- BUSINESS-FLOW invariant: "busy ⇒ confirm only on destructive close, never on swap/move/detach".
+- UX-DESIGN specifies swap (center drop zone + shortcut) and the "Move pane to…" affordance.
+- `affects` narrowed to exclude ARCHITECTURE: the PTY-ownership mechanism is ADR 0001; the requirements it generates (swap, cross-window move, busy-guard scope) are in scope.
+
+## Options rejected
+
+- Confirm busy on swap/move — nags users during normal rearrangement and discourages the core steer flow.
+- Kill and respawn processes on move — loses agent state; the process must survive the move.

--- a/docs/decisions/0017-file-sidebar-preview-diff-readonly.md
+++ b/docs/decisions/0017-file-sidebar-preview-diff-readonly.md
@@ -1,0 +1,30 @@
+---
+id: 0017
+title: "File sidebar: Cmd+click preview + git diff, read-only"
+date: 2026-07-09
+kind: product
+affects: [PRD, BUSINESS-FLOW, UX-DESIGN, REQUIREMENTS]
+supersedes: []
+---
+
+# ADR 0017 — File sidebar: Cmd+click preview + git diff, read-only
+
+## Context
+
+Agents constantly reference files by path. Users want to peek at a file's content and its git diff without leaving the terminal or opening an editor.
+
+## Decision
+
+Cmd+clicking a filepath in pane output targets the focused (source) pane's path context. Relative paths resolve against that pane's CWD; absolute paths are used as-is. If the resolved path does not exist, show an error/toast and **do not** open the sidebar. If it exists, open a right sidebar viewer: content preview (Markdown rendered for `.md`) and a git diff when the file is in a git working tree. The sidebar is **read-only** — no editing or save-back to disk in v1.
+
+## Consequences
+
+- PRD "inspect" journey and scope cover Cmd+click → preview + diff.
+- BUSINESS-FLOW gains sidebar states (Closed / Open-preview / Open-diff / Blocked), the resolve/missing rules, and invariant "sidebar never mutates the file".
+- UX-DESIGN specifies the sidebar viewer.
+- `affects` narrowed to exclude ARCHITECTURE: path resolution and git plumbing are architecture detail; the requirements it generates (Cmd+click resolve, missing-path toast, preview, git diff, read-only) are in scope.
+
+## Options rejected
+
+- Editable sidebar in v1 — out of scope; Stackgrid is not an IDE (ADR 0011, ADR 0019).
+- Open the sidebar for a missing path — misleading; a toast with no sidebar is clearer.

--- a/docs/decisions/0018-v1-distribution-unsigned.md
+++ b/docs/decisions/0018-v1-distribution-unsigned.md
@@ -1,0 +1,28 @@
+---
+id: 0018
+title: "v1 distribution: unsigned (Gatekeeper friction accepted)"
+date: 2026-07-09
+kind: product
+affects: [PRD, BUSINESS-FLOW, REQUIREMENTS]
+supersedes: []
+---
+
+# ADR 0018 — v1 distribution: unsigned (Gatekeeper friction accepted)
+
+## Context
+
+Signing and notarization add cost and process. For v1, shipping fast matters more than a frictionless first-run install.
+
+## Decision
+
+v1 may ship as an **unsigned** macOS build. The Gatekeeper first-run friction is accepted and documented. Signing / notarization is deferred and is **not** a v1 ship gate.
+
+## Consequences
+
+- PRD scope lists unsigned distribution as acceptable for v1; signed/notarized is "later".
+- BUSINESS-FLOW privacy/platform rule: v1 may ship unsigned; Gatekeeper friction is accepted.
+- `affects` narrowed to `[PRD, BUSINESS-FLOW, REQUIREMENTS]`: this is a distribution stance; it does not shape UI or architecture modules, but it generates a v1 distribution requirement (unsigned build acceptable).
+
+## Options rejected
+
+- Make signed/notarized a v1 ship gate — delays release for polish that can follow.

--- a/docs/decisions/0019-v1-scope-boundaries.md
+++ b/docs/decisions/0019-v1-scope-boundaries.md
@@ -1,0 +1,40 @@
+---
+id: 0019
+title: "v1 scope boundaries (out + deferred)"
+date: 2026-07-09
+kind: product
+affects: [PRD]
+supersedes: []
+---
+
+# ADR 0019 — v1 scope boundaries (out + deferred)
+
+## Context
+
+A minimal product needs explicit boundaries so feature pressure does not creep the v1 surface. The intent (ADR 0011) and feature ADRs define what is in; this ADR pins what is deliberately out or deferred.
+
+## Decision
+
+**Out of v1:**
+
+- Embedded agent UI / IDE-like agent panels.
+- Remote / SSH hosts and profiles.
+- Full iTerm parity (triggers, complex profiles, etc.) as a goal.
+- Editing files inside the sidebar.
+- Signed / notarized release as a v1 ship gate.
+- Persisting CWDs or running processes inside `session.json`.
+
+**Later (explicitly deferred):**
+
+- Richer agent discovery / user-configured agent list (v1 is PATH detect only).
+- Signed / notarized distribution.
+- Any embed-agent or deeper IDE adjacency.
+
+## Consequences
+
+- PRD "Out" and "Later" sections render from this ADR.
+- `affects` narrowed to `[PRD]`: scope boundaries are a product-scope statement; individual "out" items are also echoed as Options rejected in the feature ADRs they bound.
+
+## Options rejected
+
+- Leave scope implicit — invites scope creep and blurs the v1 ship line.

--- a/docs/decisions/0020-pane-id-equals-pty-id.md
+++ b/docs/decisions/0020-pane-id-equals-pty-id.md
@@ -1,0 +1,28 @@
+---
+id: 0020
+title: "Pane-id ≡ PTY id"
+date: 2026-07-09
+kind: architecture
+affects: [ARCHITECTURE, REQUIREMENTS]
+supersedes: []
+---
+
+# ADR 0020 — Pane-id ≡ PTY id
+
+## Context
+
+Multi-window routing and pane swap need a stable identity that ties a layout leaf to its live PTY and to the xterm instance showing it. The shipped app already returns a numeric PTY id from `spawn_shell`.
+
+## Decision
+
+Pane-id ≡ PTY id. `spawn_shell` returns a `u32`; that value is the leaf id in the split tree and the xterm routing key. Session / preset serialization **drops** ids (structure + ratios only); restore / Open assign fresh ids left-to-right via `treeFromLayout`. Swap exchanges two leaf ids in the tree (pure tree transform, no PTY churn). Last-pane exit respawn keeps today's `replaceLeaf(oldId, newId)` behavior.
+
+## Consequences
+
+- One key threads PTY registry, split-tree leaves, and xterm attachment — no second identity to reconcile.
+- Serialized layouts stay id-free, consistent with fresh-shell restore (ADR 0010).
+
+## Options rejected
+
+- Logical UUID pane-id separate from PTY id — double-keys every IPC; v1 needs no identity across respawn/restart.
+- Persist pane-ids in session chrome — meaningless under fresh-shell restore; conflicts with ADR 0010.

--- a/docs/decisions/0021-preset-persistence-presets-json.md
+++ b/docs/decisions/0021-preset-persistence-presets-json.md
@@ -1,0 +1,36 @@
+---
+id: 0021
+title: "Preset persistence: separate presets.json via plugin-store"
+date: 2026-07-09
+kind: architecture
+affects: [ARCHITECTURE, REQUIREMENTS]
+supersedes: []
+---
+
+# ADR 0021 — Preset persistence: separate presets.json via plugin-store
+
+## Context
+
+Product ADR 0015 decided layout presets are a separate artifact from `session.json`. This ADR fixes the storage shape and mechanism.
+
+## Decision
+
+Presets persist in a separate `presets.json` via `@tauri-apps/plugin-store`. Conceptual shape:
+
+```text
+PresetsData v1
+  version: 1
+  presets: [ { id, name, layout: SerializedNode, cwds?: (string | null)[] } ]
+```
+
+The CWD array zips leaves left-to-right (same convention as closed-tab snapshots). The built-in default preset (single pane, no CWD) is **code-defined**, always available on the Open board so Open cannot soft-lock. CRUD (save-from-live, rename, delete, overwrite) goes through the store.
+
+## Consequences
+
+- Presets are independent of session restore chrome (ADR 0002); a preset is a reusable template, not per-window state.
+- The empty-store case is covered by the code-defined default preset (ADR 0013).
+
+## Options rejected
+
+- Embed presets in `settings.json` — mixes preferences with layout templates.
+- One file per preset on disk — unnecessary with plugin-store; weaker atomic overwrite.

--- a/docs/decisions/0022-sidebar-data-plane.md
+++ b/docs/decisions/0022-sidebar-data-plane.md
@@ -1,0 +1,37 @@
+---
+id: 0022
+title: "Sidebar data plane: Rust reads + git shell-out, frontend renders"
+date: 2026-07-09
+kind: architecture
+affects: [ARCHITECTURE, REQUIREMENTS]
+supersedes: []
+---
+
+# ADR 0022 — Sidebar data plane: Rust reads + git shell-out, frontend renders
+
+## Context
+
+Product ADR 0017 defines the file sidebar (Cmd+click → preview + git diff, read-only). This ADR splits the work between Rust and the frontend without adding a new capability surface.
+
+## Decision
+
+Rust reads the file and shell-outs `git`; the frontend renders only.
+
+| Concern                                                    | Owner                                                                                |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Resolve path (absolute as-is; relative vs source pane CWD) | Frontend (from polled `pty_info`)                                                    |
+| Existence check + capped file read                         | Rust `read_file_preview`                                                             |
+| Git diff for one path                                      | Rust `git_diff` via `git -C <cwd> diff -- <path>` (same trust model as `git_branch`) |
+| Markdown render for `.md`                                  | Frontend                                                                             |
+| Plain / diff text view                                     | Frontend                                                                             |
+| Missing path                                               | Error/toast; sidebar stays closed                                                    |
+
+## Consequences
+
+- Reuses the existing `git` shell-out trust model (`git_branch`); no new filesystem capability in the webview.
+- One read/diff path, owned by Rust.
+
+## Options rejected
+
+- Frontend fs plugin for reads + Rust for git — extra capability surface, two I/O paths.
+- Embed libgit2 / gitoxide — heavy and inconsistent with the existing `git_branch` shell-out.

--- a/docs/decisions/0023-agent-path-detect-allowlist.md
+++ b/docs/decisions/0023-agent-path-detect-allowlist.md
@@ -1,0 +1,28 @@
+---
+id: 0023
+title: "Agent PATH detect: allowlist + Rust lookup, immediate spawn"
+date: 2026-07-09
+kind: architecture
+affects: [ARCHITECTURE, REQUIREMENTS]
+supersedes: []
+---
+
+# ADR 0023 — Agent PATH detect: allowlist + Rust lookup, immediate spawn
+
+## Context
+
+Product ADR 0014 defines the agent picker (PATH-detected agents + Shell + Skip all; pick = spawn). This ADR fixes the detection mechanism.
+
+## Decision
+
+A hardcoded allowlist plus a Rust PATH lookup. The allowlist is aligned with chrome recognition (`claude`, `codex`, `gemini`; extend later without a settings UI). `detect_agents` returns `[{ name, path }]` for allowlisted binaries found on `PATH`. Picker options = detected agents + **Shell only** + **Skip all**. Choosing an agent writes/spawns that command in the pane's shell **immediately**; Shell leaves an idle login shell; Skip all leaves remaining pending panes as shells and keeps already-picked panes. One-shot per materialization. Chrome styling stays foreground process-name match (shipped).
+
+## Consequences
+
+- No settings UI needed for v1; the allowlist is code-defined and cheap to extend.
+- Spawn list and chrome recognition share the same allowlist source, satisfying BUSINESS-FLOW invariant "both stay local/PATH".
+
+## Options rejected
+
+- Heuristic scan of all PATH binaries — noisy, slow, un-minimal.
+- User-configurable agent list in settings — deferred (PRD Later, ADR 0019).

--- a/docs/decisions/0024-signals-module-store-multi-window.md
+++ b/docs/decisions/0024-signals-module-store-multi-window.md
@@ -1,0 +1,33 @@
+---
+id: 0024
+title: "Signals / module-store at multi-window scale"
+date: 2026-07-09
+kind: architecture
+affects: [ARCHITECTURE]
+supersedes: []
+---
+
+# ADR 0024 — Signals / module-store at multi-window scale
+
+## Context
+
+Multi-window (ADR 0012) means several OS windows, each its own JS context. State ownership must stay correct without a shared global bus that WKWebView/Tauri cannot reliably provide.
+
+## Decision
+
+Per-webview signals + plugin-store reload via app events.
+
+- Each OS window is its own JS context → module signals (`tabViews`, `statusInfo`, local tab manager) stay local — correct isolation.
+- Shared artifacts (`settings.json`, `presets.json`): the writer emits app-wide events (`settings-changed`, `presets-changed`); other windows reload.
+- `session.json` is aggregated from all windows on debounce (ADR 0002), not a per-signal global.
+- PTY traffic never goes through signals — Rust events → owning webview → `TerminalManager.handleOutput`.
+
+## Consequences
+
+- No cross-webview shared-state layer to keep coherent; each window is authoritative for its own chrome.
+- Cross-window consistency for shared files is event-driven reload, not live shared memory.
+
+## Options rejected
+
+- Lift all UI state into Rust — a rewrite that fights the imperative xterm layer.
+- SharedWorker / BroadcastChannel between webviews — unreliable under WKWebView/Tauri; still needs Rust for PTY ownership.

--- a/docs/decisions/0025-v1-stack-tauri-preact-xterm.md
+++ b/docs/decisions/0025-v1-stack-tauri-preact-xterm.md
@@ -1,0 +1,41 @@
+---
+id: 0025
+title: "v1 stack: Tauri 2 + Preact + xterm.js (hybrid)"
+date: 2026-07-09
+kind: architecture
+affects: [ARCHITECTURE]
+supersedes: []
+---
+
+# ADR 0025 — v1 stack: Tauri 2 + Preact + xterm.js (hybrid)
+
+## Context
+
+Stackgrid ships today on a specific stack. This ADR records it as the v1 architectural foundation. The stack is **revisable** — it is not a PRINCIPLES-level non-negotiable (Electron is not forbidden by principle); this ADR pins the v1 choice, and a later ADR may supersede it.
+
+## Decision
+
+v1 stack:
+
+| Layer           | Choice                                                                       |
+| --------------- | ---------------------------------------------------------------------------- |
+| Shell           | Tauri 2 (macOS only), overlay titlebar, unsigned v1 OK                       |
+| Backend         | Rust, thin — `portable-pty`, `libc` process introspection, shell-out `git`   |
+| UI framework    | Preact 10 (chrome only)                                                      |
+| Reactivity      | `@preact/signals` (per-webview module signals)                               |
+| Terminal render | xterm.js 6 + Fit / Search / Unicode / WebLinks (imperative DOM)              |
+| Persist         | `@tauri-apps/plugin-store` (`settings.json`, `session.json`, `presets.json`) |
+| Dialogs         | `@tauri-apps/plugin-dialog` (busy/quit confirms)                             |
+
+Pattern: **hybrid** — Preact owns chrome; `TabManager` / `TerminalManager` / `Pane` own the imperative terminal surfaces and talk to Rust over Tauri IPC. xterm lives in imperative DOM, never inside Preact's tree.
+
+## Consequences
+
+- Aligns with `macOS only` (ADR 0005) and `real PTY + login shell` (ADR 0007).
+- The imperative terminal layer is a deliberate boundary; chrome and terminal do not share a render tree.
+
+## Options rejected
+
+- A single heavy React/SPA framework owning the terminal tree — fights the imperative xterm layer.
+- A pure-webview terminal without a native PTY — violates real-PTY (ADR 0007).
+- Locking the stack as a non-negotiable — rejected; the stack stays revisable (Electron not forbidden).

--- a/docs/decisions/0026-flat-visual-identity.md
+++ b/docs/decisions/0026-flat-visual-identity.md
@@ -1,0 +1,28 @@
+---
+id: 0026
+title: "Flat visual identity (no native macOS skins)"
+date: 2026-07-09
+kind: architecture
+affects: [UX-DESIGN]
+supersedes: []
+---
+
+# ADR 0026 — Flat visual identity (no native macOS skins)
+
+## Context
+
+Stackgrid ships a flat visual identity (Tokyo Night tokens, borderless edge-to-edge panes, 1px hairline dividers, no drop shadows). A prototype review explored native macOS "skins" (vibrancy / Xcode / unified toolbar) as an alternative direction for the net-new surfaces.
+
+## Decision
+
+Keep the flat, single-system visual identity; reject native macOS skins. Depth comes from background steps and 1px hairlines, never drop shadows. Tokens are those already in the shipped `styles.css`: `--bg` / `--fg` / `--accent` (Tokyo Night blue, not macOS system blue), chrome steps `--chrome-1/2`, hairlines `--hair` / `--hair-strong`, text `--text-primary/muted/faint`; UI font SF Pro, mono SF Mono. Panes are borderless and edge-to-edge with a 1px divider line; the active pane is a 1px inset accent frame (no radius, no gap). Overlays and side panels keep a 12–14px radius and rise/fade with restrained motion.
+
+## Consequences
+
+- UX-DESIGN §1 (design language) and every net-new surface adopt this identity; new chrome must not introduce native-skin material or per-pane corner radius.
+- `affects` narrowed to `[UX-DESIGN]`: this is a UI design-system decision that shapes the look of the UX surfaces only; it does not change module boundaries (ARCHITECTURE) or generate testable requirements (REQUIREMENTS).
+
+## Options rejected
+
+- Native macOS skins (vibrancy / Xcode / unified toolbar) — prototyped and rejected to keep the shipped flat identity.
+- Rounded, gapped panes (earlier idiom) — replaced by borderless, 1px-divider panes.


### PR DESCRIPTION
Migrate the docs pipeline from adk **v1** (freeze-gated: `frozen/hash/from_hash`, `lock_version: 1`) to **v2** (ADR-first). `docs/decisions/` is now the single source of truth; the big docs are rendered views carrying `derived_from`.

## What changed
- Normalize ADRs `0001-0003` to v2 frontmatter (keep 0003's supersede prose).
- Reverse-engineer the v1 frozen docs into ADRs `0004-0026` (7 principle, 9 product, 7 architecture) with honestly narrowed `affects`.
- Re-render PRINCIPLES / PRD / BUSINESS-FLOW / ARCHITECTURE / UX-DESIGN / REQUIREMENTS with `derived: true` + `derived_from`; each `derived_from ⊆ {ADRs whose affects include that doc}` (render-protocol §3).
- REQUIREMENTS preserves v1 ID continuity: all **45 FR + 9 NFR** carried 1:1, no renumbering, `version: 1` kept.
- `PIPELINE.lock` → `lock_version: 2`, `project_type: brownfield`, `phase: done`.
- Rewrite `CONTEXT.md` for v2; render hook intentionally skipped.

## Verification
Forward + reverse `derived_from`/`affects` bijection is clean (no orphan traceability), 26 ADRs active with no supersede chains, no v1 frontmatter residue.

Docs-only; no `src/` changes.

https://claude.ai/code/session_0199m5HW4SmJR9WP6isBc7VC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and traceability metadata only; no runtime or security-sensitive code paths change.
> 
> **Overview**
> Migrates the Stackgrid docs pipeline from **adk v1** (freeze hashes, `frozen: true`) to **v2** (**ADR-first**): `docs/decisions/` becomes the source of truth; the six pipeline docs are **rendered views** with `derived: true` and `derived_from`.
> 
> **`PIPELINE.lock`** moves to `lock_version: 2`, `project_type: brownfield`, and drops v1-only fields (`adr_manifest`, `decisions`, `flags`, per-doc `status`).
> 
> **ADRs:** `0001–0003` get v2 frontmatter (`id`, `kind`, `affects`, `Options rejected`); **23 new** records **`0004–0026`** reverse-engineer the former frozen content (principles, product features, architecture). Pre-pipeline `docs/adr/*` stay as history; active rules trace to **ADR 0010** (session chrome, not CWD) and **ADR 0003** (multi-window quit).
> 
> **Rendered docs** swap freeze metadata for derivation lists; **ARCHITECTURE** gains explicit ADR pointers (D2–D8, stack **0025**, expanded §11 index). **REQUIREMENTS** keeps all **45 FR + 9 NFR** IDs and `version: 1`, with upstream refs updated (e.g. ADR 0010). **`docs/CONTEXT.md`** documents v2 workflow, manual re-bootstrap, and how to add decisions / re-render.
> 
> Docs-only; no application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77945265961f77350cc13d64d128fc711af7744b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refreshed product, architecture, PRD, principles, requirements, business-flow, and UX docs to match the current ADR-driven decision set, including updated “derived” provenance and render timestamps.
  * Expanded ADR coverage for session restoration, multi-window behavior, pane identity, presets persistence, agent picker/PATH detection, sidebar previews, pane swap/move, visual identity, and v1 scope.
  * Clarified that restoration preserves layout/chrome, while pane working directories and running process details are not persisted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->