### PR TITLE
fix: chặn render crash trắng màn hình + lỗi async thoát tầm kiểm soát

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,15 +5,61 @@ import { initSettings } from "./settings/settings-store";
 import { initPresets } from "./presets/presets-store";
 import { initWorkspaces } from "./open-board/workspaces-store";
 import { App } from "./ui/app";
+import { ErrorBoundary } from "./ui/error-boundary";
+
+// Last-resort net: async errors that never touch a React/Preact render tree
+// (rejected promises outside any .catch chain, errors thrown from timers,
+// event handlers, etc.) are otherwise invisible in a packaged app with no
+// devtools open. Log them so they always show up somewhere instead of
+// silently vanishing.
+window.addEventListener("error", (event) => {
+  console.error("[window.onerror]", event.error ?? event.message);
+});
+window.addEventListener("unhandledrejection", (event) => {
+  console.error("[unhandledrejection]", event.reason);
+});
+
+function renderFatalStartupError(root: HTMLElement, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  root.innerHTML = "";
+  const wrap = document.createElement("div");
+  wrap.className = "crash-boundary";
+  wrap.innerHTML = `
+    <div class="crash-boundary__card">
+      <p class="crash-boundary__eyebrow">Stackgrid không khởi động được</p>
+      <h1>Lỗi khi tải dữ liệu ban đầu</h1>
+      <p class="crash-boundary__detail"></p>
+    </div>`;
+  wrap.querySelector(".crash-boundary__detail")!.textContent = message;
+  root.appendChild(wrap);
+}
 
 async function main(): Promise<void> {
-  await initSettings();
-  await Promise.all([initPresets(), initWorkspaces()]);
   const root = document.getElementById("root");
   if (!root) {
     throw new Error("#root element not found");
   }
-  render(<App />, root);
+  try {
+    await initSettings();
+    await Promise.all([initPresets(), initWorkspaces()]);
+  } catch (error) {
+    // initSettings/initPresets/initWorkspaces already degrade internally on
+    // known failure modes; this only fires for something truly unexpected.
+    // Fail visibly instead of leaving a blank window.
+    console.error("[startup] Unexpected init failure:", error);
+    renderFatalStartupError(root, error);
+    return;
+  }
+  render(
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>,
+    root,
+  );
 }
 
-void main();
+main().catch((error: unknown) => {
+  console.error("[startup] Unhandled main() failure:", error);
+  const root = document.getElementById("root");
+  if (root) renderFatalStartupError(root, error);
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -1746,3 +1746,38 @@ body,
 .persist-error-bar button:hover {
   border-color: var(--accent);
 }
+.crash-boundary {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+  color: var(--text-primary);
+  font-family: var(--ui-font);
+}
+.crash-boundary__card {
+  max-width: 360px;
+  padding: 24px;
+  border: 1px solid var(--hair-strong);
+  border-radius: var(--radius);
+  background: var(--chrome-1);
+  text-align: center;
+}
+.crash-boundary__eyebrow {
+  margin: 0 0 6px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.crash-boundary__card h1 {
+  margin: 0 0 8px;
+  font-size: 15px;
+  font-weight: 600;
+}
+.crash-boundary__detail {
+  margin: 0 0 16px;
+  font-size: 12px;
+  color: var(--text-muted);
+  word-break: break-word;
+}

--- a/src/terminal/session-persistence.ts
+++ b/src/terminal/session-persistence.ts
@@ -1,6 +1,7 @@
 import { Store } from "@tauri-apps/plugin-store";
 import { validateSession, type SessionData } from "../lib/session-schema";
 import { flushSettingsSave } from "../settings/settings-store";
+import { reportPersistError } from "../chrome/events";
 
 const SESSION_FILE = "session.json";
 const SESSION_KEY = "session";
@@ -51,7 +52,11 @@ async function writeSession(build: () => SessionData | null): Promise<void> {
     await store.set(SESSION_KEY, data);
     await store.save();
   } catch (err: unknown) {
+    // Layout/tab state may silently fail to land on disk otherwise — mirror
+    // settings/presets/workspaces so the user learns before they quit and
+    // lose the last ≤500ms of changes for good.
     console.warn("Failed to save session:", err);
+    reportPersistError("Layout wasn't saved to disk");
   }
 }
 

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -88,14 +88,22 @@ export function App() {
 
   useEffect(() => {
     const unsubs: UnlistenFn[] = [];
-    void listen("menu:save-preset", () => {
+    listen("menu:save-preset", () => {
       if (!boardOpen.value) {
         saveDialogOpen.value = true;
       }
-    }).then((fn) => unsubs.push(fn));
-    void listen("menu:new-preset", () => {
+    })
+      .then((fn) => unsubs.push(fn))
+      .catch((err: unknown) => {
+        console.error("Failed to listen for menu:save-preset:", err);
+      });
+    listen("menu:new-preset", () => {
       editorRequest.value = { source: "live" };
-    }).then((fn) => unsubs.push(fn));
+    })
+      .then((fn) => unsubs.push(fn))
+      .catch((err: unknown) => {
+        console.error("Failed to listen for menu:new-preset:", err);
+      });
     return () => unsubs.forEach((fn) => fn());
   }, []);
 

--- a/src/ui/error-boundary.tsx
+++ b/src/ui/error-boundary.tsx
@@ -1,0 +1,46 @@
+import { Component, type ComponentChildren } from "preact";
+
+type Props = { children: ComponentChildren };
+type State = { error: Error | null };
+
+/**
+ * Root-level render-error boundary. Without this, any uncaught error thrown
+ * during render/effects anywhere in the tree white-screens the whole app
+ * with zero recovery UI and — in a packaged Tauri build with no devtools
+ * open — zero visible diagnostics either. This is the last line of defense;
+ * it does not replace local error handling (PersistErrorBar, in-pane error
+ * lines, etc.), it only guarantees render crashes never escape unseen.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: unknown): State {
+    return { error: error instanceof Error ? error : new Error(String(error)) };
+  }
+
+  componentDidCatch(error: unknown): void {
+    console.error("[error-boundary] Uncaught render error:", error);
+  }
+
+  render() {
+    const { error } = this.state;
+    if (!error) {
+      return this.props.children;
+    }
+    return (
+      <div class="crash-boundary">
+        <div class="crash-boundary__card">
+          <p class="crash-boundary__eyebrow">Stackgrid gặp lỗi</p>
+          <h1>Đã có lỗi không mong muốn xảy ra</h1>
+          <p class="crash-boundary__detail">{error.message}</p>
+          <button
+            class="btn-reset"
+            onClick={() => this.setState({ error: null })}
+          >
+            Thử tải lại giao diện
+          </button>
+        </div>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Rà soát error-handling coverage của app (React/Preact boundary, IPC, global handlers, data persistence) và vá các điểm lỗi có thể thoát khỏi tầm kiểm soát:

- **Không có error boundary nào bọc `<App/>`** — một lỗi render bất kỳ ở đâu trong cây component làm trắng toàn bộ UI, không log, không có đường hồi phục (đặc biệt nghiêm trọng trong build đóng gói không mở devtools).
  - Thêm `src/ui/error-boundary.tsx` (Preact `componentDidCatch`), bọc `<App/>` trong `main.tsx`.
- **Không có global handler** cho lỗi async thoát khỏi mọi catch chain (`window.onerror`, `unhandledrejection`) → biến mất âm thầm trong production. Thêm 2 listener log ra console trong `main.tsx`.
- **`main()` khởi động không có `.catch()`** — nếu `initSettings/initPresets/initWorkspaces` lỗi bất ngờ, màn hình trắng vô thời hạn không rõ nguyên nhân. Bọc init flow bằng try/catch + render UI báo lỗi khởi động thay vì màn hình trắng.
- **2 `listen("menu:save-preset"/"menu:new-preset")`** trong `app.tsx` thiếu `.catch()` → unhandled rejection nếu subscribe thất bại. Đã thêm `.catch()` + log, đồng bộ pattern với các `listen()` khác trong file.
- **`session-persistence.ts`**: lỗi lưu session (layout/tab state) trước đây chỉ `console.warn`, không báo cho user — khác với settings/presets/workspaces đã có `reportPersistError`. Giờ wire vào cùng cơ chế `PersistErrorBar` để user biết trước khi quit và mất thay đổi.

Không đổi hành vi nghiệp vụ nào. Các phần đã kiểm soát tốt từ trước (Rust Tauri commands trả `Result` sạch qua IPC, không có `unwrap()/panic!` ở đường dẫn production, `flushSettingsSave` đã được `quit-guard.ts` bọc try/catch ở call site) được giữ nguyên.

## Test plan

- [x] `tsc --noEmit` pass
- [x] `vitest run` — 212/212 test pass, không regress
- [x] `npm run build` (`tsc && vite build`) thành công

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recovery screens for startup and runtime application errors.
  * Added a retry option after render failures.
  * Improved visibility of unexpected errors through console logging.

* **Bug Fixes**
  * Persistence failures now provide visible error reporting when layouts cannot be saved.
  * Menu action listener setup failures are now logged instead of failing silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->