### PR TITLE
feat(terminal): xterm quick wins (OSC 8, search, scrollback, PTY batch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Four built-in presets — **Tokyo Night** (default), **Dracula**, **One Dark**, 
 Hold ⌘ and click in any pane's output:
 
 - a **file path** (with optional `:line:col`) opens in your editor — VS Code, Cursor, Zed, or a custom command — resolving relative paths against that pane's working directory;
-- a **URL** opens in your default browser.
+- a **URL** (including OSC 8 hyperlinks written by CLI tools) opens in your default browser.
 
 Plain clicks still belong to the terminal, so mouse-driven TUIs (Claude Code, Codex) keep working.
 
 ### 🔍 Search & scrollback
 
-Incremental, case-insensitive **find** in the focused pane (⌘F) with match counts, and **clear buffer** (⌘K) to drop scrollback while keeping the current prompt.
+Incremental, case-insensitive **find** in the focused pane (⌘F) with match counts and tick marks on the overview ruler, and **clear buffer** (⌘K) to drop scrollback while keeping the current prompt. How many lines each pane keeps is configurable under Settings › Scrollback.
 
 ### 🪶 Lightweight & local-first
 
@@ -133,6 +133,8 @@ A pane is **busy** when its foreground process is something other than an idle s
 | ⌘+ / ⌘- / ⌘0 | Font zoom in / out / reset |
 | ⌘Q           | Quit                       |
 
+Shift+Enter is not distinguishable from Enter in xterm today (a known limit). In Claude Code, use **Option+Enter** or type `\` then Enter to insert a newline without submitting.
+
 ## Settings
 
 Open **Settings** from the toolbar to configure:
@@ -141,6 +143,7 @@ Open **Settings** from the toolbar to configure:
 - **Theme** and per-color overrides.
 - **Editor** for ⌘+click — VS Code, Cursor, Zed, or a custom command.
 - **Tab bar position** — left sidebar or top bar.
+- **Scrollback** — lines kept per pane (1k … 100k).
 - **Focus Expand** and **pane bar** toggles.
 
 Settings, layout presets, workspace recents, and logos are stored as JSON via the Tauri store; the panel has a **Restore defaults** button.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stackgrid",
-  "version": "0.4.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stackgrid",
-      "version": "0.4.0",
+      "version": "0.6.1",
       "dependencies": {
         "@preact/signals": "^2.9.2",
         "@tauri-apps/api": "^2",
@@ -1291,9 +1291,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1308,9 +1305,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1325,9 +1319,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1342,9 +1333,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1359,9 +1347,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1376,9 +1361,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1393,9 +1375,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1410,9 +1389,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1427,9 +1403,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1444,9 +1417,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1461,9 +1431,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1478,9 +1445,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1495,9 +1459,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1687,9 +1648,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1707,9 +1665,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1727,9 +1682,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1747,9 +1699,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1767,9 +1716,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,11 @@
 {
   "name": "stackgrid",
-  "version": "0.6.1",
-  "lockfileVersion": 3,
+  "version": "0.6.2",  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stackgrid",
-      "version": "0.6.1",
-      "dependencies": {
+      "version": "0.6.2",      "dependencies": {
         "@preact/signals": "^2.9.2",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,13 @@
 {
   "name": "stackgrid",
-  "version": "0.6.2",  "lockfileVersion": 3,
+  "version": "0.6.2",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stackgrid",
-      "version": "0.6.2",      "dependencies": {
+      "version": "0.6.2",
+      "dependencies": {
         "@preact/signals": "^2.9.2",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.1",
@@ -1289,6 +1291,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1303,6 +1308,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1317,6 +1325,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1331,6 +1342,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1345,6 +1359,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1359,6 +1376,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1373,6 +1393,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1387,6 +1410,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1401,6 +1427,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1415,6 +1444,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1429,6 +1461,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1443,6 +1478,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1457,6 +1495,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1646,6 +1687,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1663,6 +1707,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1680,6 +1727,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1697,6 +1747,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1714,6 +1767,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stackgrid",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3221,7 +3221,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stackgrid"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "base64 0.22.1",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackgrid"
-version = "0.6.1"
+version = "0.6.2"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -5,6 +5,7 @@ use std::{
     io::{Read, Write},
     sync::{
         atomic::{AtomicU32, Ordering},
+        mpsc,
         Mutex,
     },
     thread,
@@ -82,6 +83,40 @@ fn take_valid_utf8(pending: &mut Vec<u8>) -> String {
     }
 }
 
+/// Cap for a single emitted batch — large enough to absorb a bursty `cat`,
+/// small enough that one IPC message stays cheap.
+const BATCH_MAX_BYTES: usize = 64 * 1024;
+
+/// Drain already-queued chunks into `first` until `cap` or the channel is empty.
+/// Order is preserved. A chunk that would push the batch past `cap` is parked
+/// in `held` for the next call (std mpsc cannot peek / un-recv).
+fn collect_batch(
+    first: Vec<u8>,
+    rx: &mpsc::Receiver<Vec<u8>>,
+    cap: usize,
+    held: &mut Option<Vec<u8>>,
+) -> Vec<u8> {
+    let mut batch = first;
+    loop {
+        if batch.len() >= cap {
+            break;
+        }
+        let chunk = match held.take() {
+            Some(chunk) => chunk,
+            None => match rx.try_recv() {
+                Ok(chunk) => chunk,
+                Err(mpsc::TryRecvError::Empty | mpsc::TryRecvError::Disconnected) => break,
+            },
+        };
+        if !batch.is_empty() && batch.len() + chunk.len() > cap {
+            *held = Some(chunk);
+            break;
+        }
+        batch.extend_from_slice(&chunk);
+    }
+    batch
+}
+
 fn remove_session(app: &AppHandle, id: u32) {
     let state = app.state::<PtyState>();
     if let Ok(mut sessions) = state.sessions.lock() {
@@ -124,6 +159,10 @@ pub fn spawn_shell(
     }
     cmd.env("TERM", "xterm-256color");
     cmd.env("COLORTERM", "truecolor");
+    // Own identity — tools can detect Stackgrid without ConEmu spoofing.
+    // Keep ConEmuANSI below until OSC 9;4 emitters recognize TERM_PROGRAM.
+    cmd.env("TERM_PROGRAM", "Stackgrid");
+    cmd.env("TERM_PROGRAM_VERSION", env!("CARGO_PKG_VERSION"));
     if !cfg!(windows) {
         // Stackgrid consumes OSC 9;4 progress reports (the sidebar spinner),
         // but Claude Code only emits them when it recognizes the terminal:
@@ -132,6 +171,8 @@ pub fn spawn_shell(
         // such capability flag — ConEmu is Windows-only, so no macOS tool
         // changes behavior on it (and on a real Windows build we must NOT
         // fake it: tools pick ConEmu-specific paths on a plain ConPTY).
+        // Own TERM_PROGRAM is set above so we can drop this spoof once
+        // Claude Code (and peers) recognize Stackgrid by name.
         // Verified empirically (PTY harness): without this claude emits zero
         // OSC 9;4; with it, state 0 at startup, 3 while working, 0 when done.
         cmd.env("ConEmuANSI", "ON");
@@ -163,35 +204,59 @@ pub fn spawn_shell(
     // Ownership seam: pane stays tied to the spawning window until Move to window.
     coordinator.register(id, window.label().to_string());
 
-    let output_app = app.clone();
+    // Reader forwards raw bytes; emitter batches + decodes. No timer — when
+    // emit keeps up, each chunk goes straight through; when the webview is
+    // slower, try_recv drains the backlog into larger IPC messages.
+    let (tx, rx) = mpsc::channel::<Vec<u8>>();
     thread::spawn(move || {
         let mut buf = [0u8; 8192];
-        // Multi-byte UTF-8 sequences can straddle read boundaries; lossy-decoding
-        // each chunk independently turns the split halves into U+FFFD, which
-        // corrupts TUI output (extra columns → wrapped dividers → ghost lines).
-        // Hold back an incomplete trailing sequence until the next read instead.
-        let mut pending: Vec<u8> = Vec::new();
         loop {
             match reader.read(&mut buf) {
                 Ok(0) | Err(_) => break,
                 Ok(n) => {
-                    pending.extend_from_slice(&buf[..n]);
-                    let data = take_valid_utf8(&mut pending);
-                    if data.is_empty() {
-                        continue;
+                    if tx.send(buf[..n].to_vec()).is_err() {
+                        break;
                     }
-                    let coordinator = output_app.state::<WindowCoordinator>();
-                    emit_to_owner(
-                        &output_app,
-                        &coordinator,
-                        id,
-                        EVENT_OUTPUT,
-                        OutputPayload { id, data },
-                    );
                 }
             }
         }
-        // Stream ended mid-sequence — flush whatever is left, lossily.
+        // Drop tx so the emitter sees Disconnected and runs the exit path.
+    });
+
+    let output_app = app.clone();
+    thread::spawn(move || {
+        // Multi-byte UTF-8 sequences can straddle chunk boundaries; lossy-
+        // decoding each batch independently turns the split halves into
+        // U+FFFD. Hold back an incomplete trailing sequence instead.
+        let mut pending: Vec<u8> = Vec::new();
+        let mut held: Option<Vec<u8>> = None;
+        loop {
+            let first = match held.take() {
+                Some(chunk) => chunk,
+                None => match rx.recv() {
+                    Ok(chunk) => chunk,
+                    Err(mpsc::RecvError) => break,
+                },
+            };
+            let batch = collect_batch(first, &rx, BATCH_MAX_BYTES, &mut held);
+            pending.extend_from_slice(&batch);
+            let data = take_valid_utf8(&mut pending);
+            if data.is_empty() {
+                continue;
+            }
+            let coordinator = output_app.state::<WindowCoordinator>();
+            emit_to_owner(
+                &output_app,
+                &coordinator,
+                id,
+                EVENT_OUTPUT,
+                OutputPayload { id, data },
+            );
+        }
+        // Channel closed — flush whatever is left, lossily, then exit.
+        if let Some(chunk) = held.take() {
+            pending.extend_from_slice(&chunk);
+        }
         if !pending.is_empty() {
             let data = String::from_utf8_lossy(&pending).to_string();
             let coordinator = output_app.state::<WindowCoordinator>();
@@ -311,7 +376,45 @@ pub fn kill_pty(
 
 #[cfg(test)]
 mod tests {
-    use super::take_valid_utf8;
+    use super::{collect_batch, take_valid_utf8};
+    use std::sync::mpsc;
+
+    #[test]
+    fn collect_batch_concatenates_queued_chunks_in_order() {
+        let (tx, rx) = mpsc::channel();
+        tx.send(b"bb".to_vec()).unwrap();
+        tx.send(b"cc".to_vec()).unwrap();
+        let mut held = None;
+        let batch = collect_batch(b"aa".to_vec(), &rx, 64 * 1024, &mut held);
+        assert_eq!(batch, b"aabbcc");
+        assert!(held.is_none());
+    }
+
+    #[test]
+    fn collect_batch_stops_at_cap_and_holds_the_overflow_chunk() {
+        let (tx, rx) = mpsc::channel();
+        let chunk = vec![b'x'; 30 * 1024];
+        tx.send(chunk.clone()).unwrap();
+        tx.send(chunk.clone()).unwrap();
+        tx.send(chunk.clone()).unwrap();
+        let mut held = None;
+        let first = rx.recv().unwrap();
+        let batch = collect_batch(first, &rx, 64 * 1024, &mut held);
+        assert_eq!(batch.len(), 60 * 1024);
+        assert_eq!(held.as_ref().map(|c| c.len()), Some(30 * 1024));
+        // Nothing left in rx — the overflow sits in `held` for the next call
+        // (std mpsc cannot put a chunk back after try_recv).
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn collect_batch_returns_first_when_queue_is_empty() {
+        let (_tx, rx) = mpsc::channel();
+        let mut held = None;
+        let batch = collect_batch(b"solo".to_vec(), &rx, 64 * 1024, &mut held);
+        assert_eq!(batch, b"solo");
+        assert!(held.is_none());
+    }
 
     #[test]
     fn passes_through_complete_utf8() {

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -83,22 +83,33 @@ fn take_valid_utf8(pending: &mut Vec<u8>) -> String {
     }
 }
 
+/// Bound on the reader→emitter queue. `sync_channel` blocks the reader once
+/// the queue is full, so a fast producer (`cat` a huge file, `yes`) backs up
+/// into the PTY pipe and gets throttled by the kernel — an unbounded channel
+/// would let the queue grow to the size of the output instead.
+const QUEUE_CHUNKS: usize = 64;
+
 /// Cap for a single emitted batch — large enough to absorb a bursty `cat`,
 /// small enough that one IPC message stays cheap.
 const BATCH_MAX_BYTES: usize = 64 * 1024;
 
-/// Drain already-queued chunks into `first` until `cap` or the channel is empty.
+/// Append `first` plus any already-queued chunks to `out`, up to `cap` bytes.
 /// Order is preserved. A chunk that would push the batch past `cap` is parked
 /// in `held` for the next call (std mpsc cannot peek / un-recv).
+///
+/// Appending straight into the caller's buffer keeps this to one copy per
+/// chunk; building an intermediate batch would copy every byte twice.
 fn collect_batch(
     first: Vec<u8>,
     rx: &mpsc::Receiver<Vec<u8>>,
     cap: usize,
     held: &mut Option<Vec<u8>>,
-) -> Vec<u8> {
-    let mut batch = first;
+    out: &mut Vec<u8>,
+) {
+    let mut len = first.len();
+    out.extend_from_slice(&first);
     loop {
-        if batch.len() >= cap {
+        if len >= cap {
             break;
         }
         let chunk = match held.take() {
@@ -108,13 +119,13 @@ fn collect_batch(
                 Err(mpsc::TryRecvError::Empty | mpsc::TryRecvError::Disconnected) => break,
             },
         };
-        if !batch.is_empty() && batch.len() + chunk.len() > cap {
+        if len != 0 && len + chunk.len() > cap {
             *held = Some(chunk);
             break;
         }
-        batch.extend_from_slice(&chunk);
+        out.extend_from_slice(&chunk);
+        len += chunk.len();
     }
-    batch
 }
 
 fn remove_session(app: &AppHandle, id: u32) {
@@ -206,8 +217,9 @@ pub fn spawn_shell(
 
     // Reader forwards raw bytes; emitter batches + decodes. No timer — when
     // emit keeps up, each chunk goes straight through; when the webview is
-    // slower, try_recv drains the backlog into larger IPC messages.
-    let (tx, rx) = mpsc::channel::<Vec<u8>>();
+    // slower, try_recv drains the backlog into larger IPC messages. The
+    // channel is bounded so that backlog cannot outgrow QUEUE_CHUNKS.
+    let (tx, rx) = mpsc::sync_channel::<Vec<u8>>(QUEUE_CHUNKS);
     thread::spawn(move || {
         let mut buf = [0u8; 8192];
         loop {
@@ -238,8 +250,7 @@ pub fn spawn_shell(
                     Err(mpsc::RecvError) => break,
                 },
             };
-            let batch = collect_batch(first, &rx, BATCH_MAX_BYTES, &mut held);
-            pending.extend_from_slice(&batch);
+            collect_batch(first, &rx, BATCH_MAX_BYTES, &mut held, &mut pending);
             let data = take_valid_utf8(&mut pending);
             if data.is_empty() {
                 continue;
@@ -253,10 +264,9 @@ pub fn spawn_shell(
                 OutputPayload { id, data },
             );
         }
-        // Channel closed — flush whatever is left, lossily, then exit.
-        if let Some(chunk) = held.take() {
-            pending.extend_from_slice(&chunk);
-        }
+        // Channel closed — flush whatever is left, lossily, then exit. `held`
+        // is necessarily None here: the loop only reaches `recv` (and so only
+        // breaks) on an iteration that found nothing parked.
         if !pending.is_empty() {
             let data = String::from_utf8_lossy(&pending).to_string();
             let coordinator = output_app.state::<WindowCoordinator>();
@@ -376,31 +386,44 @@ pub fn kill_pty(
 
 #[cfg(test)]
 mod tests {
-    use super::{collect_batch, take_valid_utf8};
+    use super::{collect_batch, take_valid_utf8, QUEUE_CHUNKS};
     use std::sync::mpsc;
 
     #[test]
     fn collect_batch_concatenates_queued_chunks_in_order() {
-        let (tx, rx) = mpsc::channel();
+        let (tx, rx) = mpsc::sync_channel(QUEUE_CHUNKS);
         tx.send(b"bb".to_vec()).unwrap();
         tx.send(b"cc".to_vec()).unwrap();
         let mut held = None;
-        let batch = collect_batch(b"aa".to_vec(), &rx, 64 * 1024, &mut held);
-        assert_eq!(batch, b"aabbcc");
+        let mut out = Vec::new();
+        collect_batch(b"aa".to_vec(), &rx, 64 * 1024, &mut held, &mut out);
+        assert_eq!(out, b"aabbcc");
         assert!(held.is_none());
     }
 
     #[test]
+    fn collect_batch_appends_after_an_incomplete_tail() {
+        // `out` is the emitter's `pending`, which may already hold the first
+        // bytes of a UTF-8 sequence split across reads — those must survive.
+        let (_tx, rx) = mpsc::sync_channel::<Vec<u8>>(QUEUE_CHUNKS);
+        let mut held = None;
+        let mut out = vec![0xE1, 0xBB]; // leading two bytes of "ố"
+        collect_batch(vec![0x91], &rx, 64 * 1024, &mut held, &mut out);
+        assert_eq!(String::from_utf8(out).unwrap(), "ố");
+    }
+
+    #[test]
     fn collect_batch_stops_at_cap_and_holds_the_overflow_chunk() {
-        let (tx, rx) = mpsc::channel();
+        let (tx, rx) = mpsc::sync_channel(QUEUE_CHUNKS);
         let chunk = vec![b'x'; 30 * 1024];
         tx.send(chunk.clone()).unwrap();
         tx.send(chunk.clone()).unwrap();
         tx.send(chunk.clone()).unwrap();
         let mut held = None;
+        let mut out = Vec::new();
         let first = rx.recv().unwrap();
-        let batch = collect_batch(first, &rx, 64 * 1024, &mut held);
-        assert_eq!(batch.len(), 60 * 1024);
+        collect_batch(first, &rx, 64 * 1024, &mut held, &mut out);
+        assert_eq!(out.len(), 60 * 1024);
         assert_eq!(held.as_ref().map(|c| c.len()), Some(30 * 1024));
         // Nothing left in rx — the overflow sits in `held` for the next call
         // (std mpsc cannot put a chunk back after try_recv).
@@ -409,10 +432,11 @@ mod tests {
 
     #[test]
     fn collect_batch_returns_first_when_queue_is_empty() {
-        let (_tx, rx) = mpsc::channel();
+        let (_tx, rx) = mpsc::sync_channel::<Vec<u8>>(QUEUE_CHUNKS);
         let mut held = None;
-        let batch = collect_batch(b"solo".to_vec(), &rx, 64 * 1024, &mut held);
-        assert_eq!(batch, b"solo");
+        let mut out = Vec::new();
+        collect_batch(b"solo".to_vec(), &rx, 64 * 1024, &mut held, &mut out);
+        assert_eq!(out, b"solo");
         assert!(held.is_none());
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Stackgrid",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "com.kyantran.stackgrid",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/terminal-links.ts
+++ b/src/lib/terminal-links.ts
@@ -34,6 +34,23 @@ export const MAX_CANDIDATES_PER_LINE = 24;
 const URL_RE =
   /(https?|HTTPS?):[/]{2}[^\s"'!*(){}|\\^<>`]*[^\s"':,.!?{}|\\^~[\]`()<>]/g;
 
+/**
+ * Whether a URI may be handed to the default browser.
+ *
+ * Detected links already come from `URL_RE`, but an OSC 8 hyperlink carries a
+ * URI the *output* chose — anything printed to the terminal (a downloaded log,
+ * a curl response) can ask for `file:///…` or an app-registered scheme like
+ * `vscode://`. Only http/https ever reach the opener.
+ */
+export function isBrowsableUrl(uri: string): boolean {
+  try {
+    const { protocol } = new URL(uri);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false; // not a URI at all
+  }
+}
+
 // Characters a path segment is made of. Spaces are not included: an unquoted
 // path with a space is ambiguous in terminal output, so it is left alone
 // (VS Code does the same).

--- a/src/settings/settings-schema.test.ts
+++ b/src/settings/settings-schema.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_SETTINGS, validateSettings } from "./settings-schema";
+import {
+  DEFAULT_SETTINGS,
+  validateSettings,
+} from "./settings-schema";
 
 describe("validateSettings", () => {
   it("silently drops the legacy restoreTabs field", () => {
@@ -61,5 +64,28 @@ describe("focusExpand", () => {
     expect(
       validateSettings({ ...DEFAULT_SETTINGS, focusExpand: "yes" }).focusExpand,
     ).toBe(false);
+  });
+});
+
+describe("scrollback", () => {
+  it("defaults to 10000 when missing", () => {
+    expect(DEFAULT_SETTINGS.scrollback).toBe(10_000);
+    expect(validateSettings({}).scrollback).toBe(10_000);
+  });
+
+  it("falls back to 10000 on a non-number", () => {
+    expect(validateSettings({ scrollback: "abc" }).scrollback).toBe(10_000);
+  });
+
+  it("clamps below the minimum to 1000", () => {
+    expect(validateSettings({ scrollback: 250 }).scrollback).toBe(1000);
+  });
+
+  it("clamps above the maximum to 100000", () => {
+    expect(validateSettings({ scrollback: 999_999 }).scrollback).toBe(100_000);
+  });
+
+  it("keeps an in-range value", () => {
+    expect(validateSettings({ scrollback: 5000 }).scrollback).toBe(5000);
   });
 });

--- a/src/settings/settings-schema.ts
+++ b/src/settings/settings-schema.ts
@@ -22,10 +22,18 @@ export interface Settings {
   editorId: EditorId;
   /** Command template used when `editorId` is `custom` (empty until set). */
   editorCommand: string;
+  /** Lines of scrollback kept per pane. */
+  scrollback: number;
 }
 
 export const FONT_SIZE_MIN = 10;
 export const FONT_SIZE_MAX = 24;
+
+export const SCROLLBACK_MIN = 1000;
+export const SCROLLBACK_MAX = 100_000;
+export const SCROLLBACK_CHOICES = [
+  1000, 5000, 10_000, 50_000, 100_000,
+] as const;
 
 export const FONT_FALLBACK = "Menlo, Monaco, monospace";
 
@@ -46,6 +54,7 @@ export const DEFAULT_SETTINGS: Settings = {
   tabBarPosition: "left",
   editorId: "vscode",
   editorCommand: "",
+  scrollback: 10_000,
 };
 
 const HEX_COLOR = /^#[0-9a-fA-F]{6}$/;
@@ -62,6 +71,13 @@ export function isHexColor(value: unknown): value is string {
 
 export function clampFontSize(size: number): number {
   return Math.min(FONT_SIZE_MAX, Math.max(FONT_SIZE_MIN, Math.round(size)));
+}
+
+export function clampScrollback(n: number): number {
+  return Math.min(
+    SCROLLBACK_MAX,
+    Math.max(SCROLLBACK_MIN, Math.round(n)),
+  );
 }
 
 function validateColorOverrides(raw: unknown): Partial<TerminalColors> {
@@ -117,5 +133,9 @@ export function validateSettings(raw: unknown): Settings {
       typeof source.editorCommand === "string"
         ? source.editorCommand
         : DEFAULT_SETTINGS.editorCommand,
+    scrollback:
+      typeof source.scrollback === "number" && Number.isFinite(source.scrollback)
+        ? clampScrollback(source.scrollback)
+        : DEFAULT_SETTINGS.scrollback,
   };
 }

--- a/src/terminal/osc-link-handler.test.ts
+++ b/src/terminal/osc-link-handler.test.ts
@@ -32,6 +32,21 @@ describe("createOscLinkHandler", () => {
     expect(client.openedUrls).toEqual(["https://example.com"]);
   });
 
+  it.each([
+    "file:///Users/me/.ssh/id_rsa",
+    "vscode://file/etc/passwd",
+    "javascript:alert(1)",
+    "not a uri at all",
+  ])("refuses to open %s", (uri) => {
+    const client = createMemoryLinkClient();
+    const handler = createOscLinkHandler(client);
+    handler.activate(mouseEvent(true), uri, {
+      start: { x: 1, y: 1 },
+      end: { x: 1, y: 1 },
+    });
+    expect(client.openedUrls).toEqual([]);
+  });
+
   it("openUrl rejection does not throw an unhandled rejection", async () => {
     const client = createMemoryLinkClient();
     client.openUrl = () => Promise.reject(new Error("blocked"));

--- a/src/terminal/osc-link-handler.test.ts
+++ b/src/terminal/osc-link-handler.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, expect, it, vi } from "vitest";
 import { createMemoryLinkClient } from "./link-client";
 import { createOscLinkHandler } from "./osc-link-handler";

--- a/src/terminal/osc-link-handler.test.ts
+++ b/src/terminal/osc-link-handler.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMemoryLinkClient } from "./link-client";
+import { createOscLinkHandler } from "./osc-link-handler";
+
+vi.mock("../chrome/events", () => ({
+  reportPersistError: vi.fn(),
+}));
+
+function mouseEvent(metaKey: boolean): MouseEvent {
+  return new MouseEvent("click", { metaKey });
+}
+
+describe("createOscLinkHandler", () => {
+  it("plain click does not call openUrl", () => {
+    const client = createMemoryLinkClient();
+    const handler = createOscLinkHandler(client);
+    handler.activate(mouseEvent(false), "https://example.com", {
+      start: { x: 1, y: 1 },
+      end: { x: 1, y: 1 },
+    });
+    expect(client.openedUrls).toEqual([]);
+  });
+
+  it("⌘+click opens the URI via the link client", () => {
+    const client = createMemoryLinkClient();
+    const handler = createOscLinkHandler(client);
+    handler.activate(mouseEvent(true), "https://example.com", {
+      start: { x: 1, y: 1 },
+      end: { x: 1, y: 1 },
+    });
+    expect(client.openedUrls).toEqual(["https://example.com"]);
+  });
+
+  it("openUrl rejection does not throw an unhandled rejection", async () => {
+    const client = createMemoryLinkClient();
+    client.openUrl = () => Promise.reject(new Error("blocked"));
+    const handler = createOscLinkHandler(client);
+    handler.activate(mouseEvent(true), "https://example.com", {
+      start: { x: 1, y: 1 },
+      end: { x: 1, y: 1 },
+    });
+    // Flush the microtask queue so a leaked rejection would surface.
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+});

--- a/src/terminal/osc-link-handler.ts
+++ b/src/terminal/osc-link-handler.ts
@@ -1,5 +1,6 @@
 import type { ILinkHandler } from "@xterm/xterm";
 import { reportPersistError } from "../chrome/events";
+import { isBrowsableUrl } from "../lib/terminal-links";
 import { defaultLinkClient, type LinkClient } from "./link-client";
 
 /**
@@ -8,12 +9,19 @@ import { defaultLinkClient, type LinkClient } from "./link-client";
  *
  * Same convention as the custom link provider: only Cmd+click activates;
  * a plain click belongs to the terminal (selection, TUI mouse).
+ *
+ * Unlike a detected link, the URI here is whatever the output wrote, so it
+ * goes through the same http/https gate the detector applies.
  */
 export function createOscLinkHandler(client?: LinkClient): ILinkHandler {
   const linkClient = client ?? defaultLinkClient;
   return {
     activate(event, text) {
       if (!event.metaKey) {
+        return;
+      }
+      if (!isBrowsableUrl(text)) {
+        reportPersistError(`Only http/https links can be opened: ${text}`);
         return;
       }
       linkClient.openUrl(text).catch((err: unknown) => {

--- a/src/terminal/osc-link-handler.ts
+++ b/src/terminal/osc-link-handler.ts
@@ -1,0 +1,24 @@
+import type { ILinkHandler } from "@xterm/xterm";
+import { reportPersistError } from "../chrome/events";
+import { defaultLinkClient, type LinkClient } from "./link-client";
+
+/**
+ * OSC 8 hyperlink handler — routes through Tauri instead of the xterm
+ * fallback (`window.confirm` + `window.open`), which WKWebView blocks.
+ *
+ * Same convention as the custom link provider: only Cmd+click activates;
+ * a plain click belongs to the terminal (selection, TUI mouse).
+ */
+export function createOscLinkHandler(client?: LinkClient): ILinkHandler {
+  const linkClient = client ?? defaultLinkClient;
+  return {
+    activate(event, text) {
+      if (!event.metaKey) {
+        return;
+      }
+      linkClient.openUrl(text).catch((err: unknown) => {
+        reportPersistError(`Couldn't open the link: ${String(err)}`);
+      });
+    },
+  };
+}

--- a/src/terminal/pane.ts
+++ b/src/terminal/pane.ts
@@ -100,8 +100,11 @@ export function createPane(
     overviewRuler: { width: 14 },
     // Smooth wheel scroll (~125ms) feels less jumpy than the default snap.
     smoothScrollDuration: 125,
-    // Lift dark-on-dark ANSI colors so faint text stays readable.
-    minimumContrastRatio: 4.5,
+    // No minimumContrastRatio on purpose: it rewrites *every* color, so an
+    // agent TUI's deliberately dim grays get pulled up to near-white and the
+    // information hierarchy flattens (SGR 2 `dim` stops reading as dim), on
+    // top of a per-cell contrast computation in the render path. A theme
+    // whose ANSI colors are too dark is fixed in `resolveTheme`, not here.
   });
 
   const fitAddon = new FitAddon();

--- a/src/terminal/pane.ts
+++ b/src/terminal/pane.ts
@@ -8,6 +8,7 @@ import { installImeTrace } from "./ime-trace";
 import { resolveTheme } from "../settings/themes";
 import type { PaneHeaderInfo } from "../lib/process-info";
 import { createLinkProvider } from "./link-provider";
+import { createOscLinkHandler } from "./osc-link-handler";
 import { paneCwd } from "./pane-cwd";
 
 export interface PaneEvents {
@@ -87,11 +88,20 @@ export function createPane(
     fontSize: initial.fontSize,
     fontFamily: toFontStack(initial.fontFamily),
     lineHeight: 1.25,
-    scrollback: 10_000,
+    scrollback: initial.scrollback,
     // Option must stay a character key on macOS so IMEs (Vietnamese Telex,
     // dead-key accents) can compose — `true` swallows it as Meta.
     macOptionIsMeta: false,
     theme: resolveTheme(initial),
+    // OSC 8 hyperlinks otherwise fall back to window.confirm/open, which
+    // WKWebView blocks — route through Tauri like the custom link provider.
+    linkHandler: createOscLinkHandler(),
+    // Search decorations paint match ticks here; width 0 skips the ruler.
+    overviewRuler: { width: 14 },
+    // Smooth wheel scroll (~125ms) feels less jumpy than the default snap.
+    smoothScrollDuration: 125,
+    // Lift dark-on-dark ANSI colors so faint text stays readable.
+    minimumContrastRatio: 4.5,
   });
 
   const fitAddon = new FitAddon();
@@ -182,6 +192,7 @@ export function createPane(
     term.options.fontFamily = toFontStack(next.fontFamily);
     term.options.fontSize = next.fontSize;
     term.options.theme = resolveTheme(next);
+    term.options.scrollback = next.scrollback;
     fit();
   }
 

--- a/src/terminal/search-bar.test.ts
+++ b/src/terminal/search-bar.test.ts
@@ -1,5 +1,23 @@
-import { describe, expect, it } from "vitest";
-import { formatMatchCount } from "./search-bar";
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { formatMatchCount, openSearchBar, closeSearchBar } from "./search-bar";
+import type { Pane } from "./pane";
+
+vi.mock("../settings/settings-store", () => ({
+  settings: {
+    value: {
+      themeId: "tokyo-night",
+      colorOverrides: {},
+    },
+  },
+}));
+
+vi.mock("../settings/themes", () => ({
+  resolveTheme: () => ({
+    selectionBackground: "#33467c",
+    yellow: "#e0af68",
+  }),
+}));
 
 describe("formatMatchCount", () => {
   it("formats 1-based index over count", () => {
@@ -13,5 +31,41 @@ describe("formatMatchCount", () => {
 
   it("shows only the total when the active match is untracked", () => {
     expect(formatMatchCount(-1, 17)).toBe("17");
+  });
+});
+
+describe("search term NFC", () => {
+  afterEach(() => {
+    closeSearchBar();
+  });
+
+  it("normalizes an NFD input to NFC before calling findNext", () => {
+    const findNext = vi.fn();
+    const findPrevious = vi.fn();
+    const clearDecorations = vi.fn();
+    const onDidChangeResults = vi.fn(() => ({ dispose: vi.fn() }));
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+
+    const pane = {
+      id: 1,
+      element: host,
+      search: { findNext, findPrevious, clearDecorations, onDidChangeResults },
+      focus: vi.fn(),
+    } as unknown as Pane;
+
+    openSearchBar(pane);
+    const input = host.querySelector("input") as HTMLInputElement;
+    // NFD "thôn" = t h o + ◌̂ + n
+    const nfd = "tho\u0302n";
+    expect(nfd.normalize("NFC")).toBe("thôn");
+
+    input.value = nfd;
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+
+    expect(findNext).toHaveBeenCalledWith(
+      "thôn",
+      expect.objectContaining({ incremental: true }),
+    );
   });
 });

--- a/src/terminal/search-bar.test.ts
+++ b/src/terminal/search-bar.test.ts
@@ -34,38 +34,65 @@ describe("formatMatchCount", () => {
   });
 });
 
-describe("search term NFC", () => {
+describe("search term normalization", () => {
   afterEach(() => {
     closeSearchBar();
   });
 
-  it("normalizes an NFD input to NFC before calling findNext", () => {
-    const findNext = vi.fn();
-    const findPrevious = vi.fn();
-    const clearDecorations = vi.fn();
-    const onDidChangeResults = vi.fn(() => ({ dispose: vi.fn() }));
+  // Normalize explicitly so the forms cannot drift with the file's encoding:
+  // NFC keeps the o-circumflex as one code point, NFD splits it in two.
+  const NFC = "thôn".normalize("NFC");
+  const NFD = NFC.normalize("NFD");
+
+  function mountBar(findNext: (term: string) => boolean) {
     const host = document.createElement("div");
     document.body.appendChild(host);
-
     const pane = {
       id: 1,
       element: host,
-      search: { findNext, findPrevious, clearDecorations, onDidChangeResults },
+      search: {
+        findNext: vi.fn(findNext),
+        findPrevious: vi.fn(() => false),
+        clearDecorations: vi.fn(),
+        onDidChangeResults: vi.fn(() => ({ dispose: vi.fn() })),
+      },
       focus: vi.fn(),
     } as unknown as Pane;
-
     openSearchBar(pane);
-    const input = host.querySelector("input") as HTMLInputElement;
-    // NFD "thôn" = t h o + ◌̂ + n
-    const nfd = "tho\u0302n";
-    expect(nfd.normalize("NFC")).toBe("thôn");
+    return {
+      input: host.querySelector("input") as HTMLInputElement,
+      findNext: pane.search.findNext as unknown as ReturnType<typeof vi.fn>,
+    };
+  }
 
-    input.value = nfd;
+  function type(input: HTMLInputElement, value: string): void {
+    input.value = value;
     input.dispatchEvent(new Event("input", { bubbles: true }));
+  }
 
-    expect(findNext).toHaveBeenCalledWith(
-      "thôn",
+  it("tries NFC first for an NFD input", () => {
+    const bar = mountBar(() => true);
+    type(bar.input, NFD);
+
+    expect(bar.findNext).toHaveBeenCalledTimes(1);
+    expect(bar.findNext).toHaveBeenCalledWith(
+      NFC,
       expect.objectContaining({ incremental: true }),
     );
+  });
+
+  it("falls back to NFD when NFC finds nothing (macOS paths are NFD)", () => {
+    const bar = mountBar((term) => term === NFD);
+    type(bar.input, NFC);
+
+    expect(bar.findNext).toHaveBeenNthCalledWith(1, NFC, expect.anything());
+    expect(bar.findNext).toHaveBeenNthCalledWith(2, NFD, expect.anything());
+  });
+
+  it("does not search twice when the term is normalization-invariant", () => {
+    const bar = mountBar(() => false);
+    type(bar.input, "plain");
+
+    expect(bar.findNext).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/terminal/search-bar.ts
+++ b/src/terminal/search-bar.ts
@@ -37,12 +37,16 @@ function searchOptions(incremental: boolean): ISearchOptions {
     decorations: {
       matchBackground: match,
       activeMatchBackground: activeMatch,
-      // Required by ISearchDecorationOptions even though there is no
-      // overview ruler — theme-derived placeholder colors.
+      // Painted on the overview ruler (pane sets overviewRuler.width).
       matchOverviewRuler: match,
       activeMatchColorOverviewRuler: activeMatch,
     },
   };
+}
+
+/** NFC so an IME-typed NFD term still matches composed buffer text. */
+function searchTerm(value: string): string {
+  return value.normalize("NFC");
 }
 
 function barButton(
@@ -82,12 +86,12 @@ export function openSearchBar(pane: Pane): void {
 
   const findNext = (): void => {
     if (input.value !== "") {
-      pane.search.findNext(input.value, searchOptions(false));
+      pane.search.findNext(searchTerm(input.value), searchOptions(false));
     }
   };
   const findPrevious = (): void => {
     if (input.value !== "") {
-      pane.search.findPrevious(input.value, searchOptions(false));
+      pane.search.findPrevious(searchTerm(input.value), searchOptions(false));
     }
   };
 
@@ -112,7 +116,7 @@ export function openSearchBar(pane: Pane): void {
       return;
     }
     // Incremental: the current selection expands instead of jumping ahead
-    pane.search.findNext(input.value, searchOptions(true));
+    pane.search.findNext(searchTerm(input.value), searchOptions(true));
   });
 
   // The global shortcut handler skips inputs outside .pane__term, so the

--- a/src/terminal/search-bar.ts
+++ b/src/terminal/search-bar.ts
@@ -44,9 +44,25 @@ function searchOptions(incremental: boolean): ISearchOptions {
   };
 }
 
-/** NFC so an IME-typed NFD term still matches composed buffer text. */
-function searchTerm(value: string): string {
-  return value.normalize("NFC");
+/**
+ * Run `find` against both Unicode normalizations of the term.
+ *
+ * Neither side can be normalized on its own: an IME types Vietnamese as NFD
+ * while most program output is NFC, but macOS hands back filenames in NFD —
+ * and the addon searches the raw buffer, which we cannot normalize. So try
+ * NFC first, then NFD when the two differ and NFC found nothing.
+ */
+function findNormalized(
+  find: (term: string, options: ISearchOptions) => boolean,
+  value: string,
+  options: ISearchOptions,
+): boolean {
+  const nfc = value.normalize("NFC");
+  if (find(nfc, options)) {
+    return true;
+  }
+  const nfd = value.normalize("NFD");
+  return nfd === nfc ? false : find(nfd, options);
 }
 
 function barButton(
@@ -84,14 +100,19 @@ export function openSearchBar(pane: Pane): void {
   const counter = document.createElement("span");
   counter.className = "search-bar__count";
 
+  const next = (term: string, options: ISearchOptions): boolean =>
+    pane.search.findNext(term, options);
+  const previous = (term: string, options: ISearchOptions): boolean =>
+    pane.search.findPrevious(term, options);
+
   const findNext = (): void => {
     if (input.value !== "") {
-      pane.search.findNext(searchTerm(input.value), searchOptions(false));
+      findNormalized(next, input.value, searchOptions(false));
     }
   };
   const findPrevious = (): void => {
     if (input.value !== "") {
-      pane.search.findPrevious(searchTerm(input.value), searchOptions(false));
+      findNormalized(previous, input.value, searchOptions(false));
     }
   };
 
@@ -116,7 +137,7 @@ export function openSearchBar(pane: Pane): void {
       return;
     }
     // Incremental: the current selection expands instead of jumping ahead
-    pane.search.findNext(searchTerm(input.value), searchOptions(true));
+    findNormalized(next, input.value, searchOptions(true));
   });
 
   // The global shortcut handler skips inputs outside .pane__term, so the

--- a/src/ui/settings-panel.tsx
+++ b/src/ui/settings-panel.tsx
@@ -99,12 +99,12 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
   const cycleScrollback = (): void => {
     const clamped = clampScrollback(current.scrollback);
     // Off-choice values (legacy / typed) count as the nearest choice at or below.
-    let index = 0;
-    for (let i = 0; i < SCROLLBACK_CHOICES.length; i++) {
-      if (SCROLLBACK_CHOICES[i] <= clamped) {
-        index = i;
-      }
-    }
+    // CHOICES is sorted ascending, so the count of choices at or below the
+    // current value is one past its index.
+    const index = Math.max(
+      0,
+      SCROLLBACK_CHOICES.filter((choice) => choice <= clamped).length - 1,
+    );
     const next = SCROLLBACK_CHOICES[(index + 1) % SCROLLBACK_CHOICES.length];
     updateSettings({ scrollback: next });
   };

--- a/src/ui/settings-panel.tsx
+++ b/src/ui/settings-panel.tsx
@@ -7,9 +7,11 @@ import {
 } from "../settings/settings-store";
 import {
   clampFontSize,
+  clampScrollback,
   COLOR_KEYS,
   FONT_SIZE_MAX,
   FONT_SIZE_MIN,
+  SCROLLBACK_CHOICES,
   type TabBarPosition,
   type TerminalColors,
 } from "../settings/settings-schema";
@@ -92,6 +94,26 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
     const index = TAB_BAR_CHOICES.indexOf(current.tabBarPosition);
     const next = TAB_BAR_CHOICES[(index + 1) % TAB_BAR_CHOICES.length];
     updateSettings({ tabBarPosition: next });
+  };
+
+  const cycleScrollback = (): void => {
+    const clamped = clampScrollback(current.scrollback);
+    // Off-choice values (legacy / typed) count as the nearest choice at or below.
+    let index = 0;
+    for (let i = 0; i < SCROLLBACK_CHOICES.length; i++) {
+      if (SCROLLBACK_CHOICES[i] <= clamped) {
+        index = i;
+      }
+    }
+    const next = SCROLLBACK_CHOICES[(index + 1) % SCROLLBACK_CHOICES.length];
+    updateSettings({ scrollback: next });
+  };
+
+  const scrollbackLabel = (n: number): string => {
+    if (n >= 1000) {
+      return `${n / 1000}k lines`;
+    }
+    return `${n} lines`;
   };
 
   return (
@@ -202,6 +224,18 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
           checked={current.showPaneBar}
           onToggle={() => updateSettings({ showPaneBar: !current.showPaneBar })}
         />
+        <ConfigRow label="Scrollback" desc="lines kept per pane">
+          <button
+            type="button"
+            class="cfg-btn"
+            title="Next scrollback size"
+            aria-label={`Scrollback: ${scrollbackLabel(current.scrollback)}. Switch to next size`}
+            onClick={cycleScrollback}
+          >
+            {scrollbackLabel(current.scrollback)}
+            <span class="cfg-btn__hint">↹</span>
+          </button>
+        </ConfigRow>
 
         <ConfigGroup label="danger" />
         <ConfigRow


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements đợt-1 quick wins from the xterm core capability review (`docs/plans/2026-07-18-xterm-quick-wins.md`).

- **OSC 8**: `linkHandler` routes ⌘+click through Tauri `LinkClient` (no `window.confirm`/`window.open`)
- **Search**: overview ruler ticks + NFC-normalize search terms for IME input
- **Render/settings**: `smoothScrollDuration`, `minimumContrastRatio`, configurable `scrollback` in Settings
- **PTY**: reader/emitter split with greedy byte batching (cap 64 KB) before decode/emit
- **Identity**: `TERM_PROGRAM=Stackgrid` + `TERM_PROGRAM_VERSION` from `CARGO_PKG_VERSION` (keeps `ConEmuANSI`)
- **Docs**: README notes for OSC 8, ruler, scrollback setting, Shift+Enter workaround in Claude Code
- Version bump **0.6.1 → 0.6.2**

## Test plan
- [x] `npm test` — 326 passed
- [x] `npm run build` — passed
- [x] `cargo test --locked` in `src-tauri` — 37 passed (incl. `collect_batch` + `take_valid_utf8`)
- [ ] Manual: `printf '\e]8;;https://example.com\e\\demo\e]8;;\e\\\n'` → ⌘+click opens browser
- [ ] Manual: Cmd+F shows ruler ticks; Settings scrollback cycles and persists
- [ ] Manual: `echo $TERM_PROGRAM $TERM_PROGRAM_VERSION` → `Stackgrid 0.6.2`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f74d2-5d0e-7140-820b-42a1995b456e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f74d2-5d0e-7140-820b-42a1995b456e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable per-pane scrollback from 1k to 100k lines.
  * Added support for opening OSC 8 hyperlinks with Cmd+click.
  * Improved search for accented and Unicode-normalized text.
  * Added match counts and overview-ruler markers to search results.
* **Bug Fixes**
  * Improved terminal output responsiveness during high-volume activity.
  * Invalid or failed links are handled without disrupting the application.
* **Documentation**
  * Clarified hyperlink support, search behavior, scrollback settings, and Shift+Enter workarounds.
* **Chores**
  * Updated the application version to 0.6.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->