### PR TITLE
Add OpenCode support on Windows and macOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@tauri-apps/cli": "^2",
         "jsdom": "^29.1.1",
         "playwright-core": "^1.62.0",
+        "terser": "^5.49.0",
         "tsx": "^4.23.1",
         "typescript": "~5.6.2",
         "vite": "^6.0.3",
@@ -1045,6 +1046,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -2057,6 +2069,19 @@
         "addons/*"
       ]
     },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2141,6 +2166,13 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -2198,6 +2230,13 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2660,9 +2699,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2795,9 +2834,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -2815,7 +2854,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2958,6 +2997,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/stack-trace": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-1.0.0.tgz",
@@ -3008,6 +3068,25 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/terser": {
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/three": {
       "version": "0.185.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@tauri-apps/cli": "^2",
     "jsdom": "^29.1.1",
     "playwright-core": "^1.62.0",
+    "terser": "^5.49.0",
     "tsx": "^4.23.1",
     "typescript": "~5.6.2",
     "vite": "^6.0.3",

--- a/scripts/vite-config.test.ts
+++ b/scripts/vite-config.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import configExport from "../vite.config";
+
+describe("production minification", () => {
+  it("uses Terser to preserve xterm's requestMode enum binding", async () => {
+    if (typeof configExport !== "function") {
+      throw new TypeError("Expected vite.config.ts to export a config factory");
+    }
+    const config = await configExport({
+      command: "build",
+      mode: "production",
+      isSsrBuild: false,
+      isPreview: false,
+    });
+
+    expect(config.build?.minify).toBe("terser");
+  });
+});

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -12,7 +12,7 @@ pub struct AgentInfo {
 }
 
 /// Allowlist aligned with the chrome recognition names (ARCH D6).
-pub(crate) const AGENT_ALLOWLIST: [&str; 3] = ["claude", "codex", "gemini"];
+pub(crate) const AGENT_ALLOWLIST: [&str; 4] = ["claude", "codex", "gemini", "opencode"];
 
 /// Strip terminal control sequences from one line. An interactive login shell
 /// (`-ilc`) runs rc-file hooks that print terminal noise with no trailing
@@ -122,7 +122,8 @@ mod tests {
 
     #[test]
     fn parses_absolute_paths_in_allowlist_order() {
-        let out = "/usr/local/bin/claude\n/Users/dev/.local/bin/gemini\n";
+        let out =
+            "/usr/local/bin/claude\n/Users/dev/.local/bin/gemini\n/opt/homebrew/bin/opencode\n";
         assert_eq!(
             parse_command_v_output(out),
             vec![
@@ -133,6 +134,10 @@ mod tests {
                 AgentInfo {
                     name: "gemini".into(),
                     path: "/Users/dev/.local/bin/gemini".into()
+                },
+                AgentInfo {
+                    name: "opencode".into(),
+                    path: "/opt/homebrew/bin/opencode".into()
                 },
             ]
         );

--- a/src-tauri/src/info.rs
+++ b/src-tauri/src/info.rs
@@ -24,6 +24,7 @@ pub enum PaneAgent {
     Claude,
     Codex,
     Gemini,
+    OpenCode,
 }
 
 #[derive(Clone, serde::Serialize)]
@@ -46,6 +47,7 @@ fn classify_process(process: Option<&str>, complete: bool) -> (PaneProcessKind, 
         "claude" => Some(PaneAgent::Claude),
         "codex" => Some(PaneAgent::Codex),
         "gemini" => Some(PaneAgent::Gemini),
+        "opencode" => Some(PaneAgent::OpenCode),
         _ => None,
     };
     if agent.is_some() {
@@ -148,6 +150,7 @@ fn map_windows_results(
                 WindowsAgent::Claude => PaneAgent::Claude,
                 WindowsAgent::Codex => PaneAgent::Codex,
                 WindowsAgent::Gemini => PaneAgent::Gemini,
+                WindowsAgent::OpenCode => PaneAgent::OpenCode,
             });
             PtyInfo {
                 id: snapshot.id,
@@ -224,6 +227,14 @@ mod tests {
         assert_eq!(
             classify_process(Some("claude"), true),
             (PaneProcessKind::Agent, Some(PaneAgent::Claude))
+        );
+    }
+
+    #[test]
+    fn classifies_opencode_from_a_macos_style_process_path() {
+        assert_eq!(
+            classify_process(Some("/opt/homebrew/bin/opencode"), true),
+            (PaneProcessKind::Agent, Some(PaneAgent::OpenCode))
         );
     }
 

--- a/src-tauri/src/platform/windows/process_snapshot.rs
+++ b/src-tauri/src/platform/windows/process_snapshot.rs
@@ -6,6 +6,7 @@ pub(crate) enum AgentIdentity {
     Claude,
     Codex,
     Gemini,
+    OpenCode,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -320,6 +321,7 @@ fn direct_agent(executable: &str) -> Option<AgentIdentity> {
         "claude" => Some(AgentIdentity::Claude),
         "codex" => Some(AgentIdentity::Codex),
         "gemini" => Some(AgentIdentity::Gemini),
+        "opencode" => Some(AgentIdentity::OpenCode),
         _ => None,
     }
 }
@@ -329,10 +331,11 @@ fn is_wrapper(executable: &str) -> bool {
 }
 
 fn wrapper_agent(command_line: &str) -> Option<AgentIdentity> {
-    const SIGNATURES: [(&str, AgentIdentity); 3] = [
+    const SIGNATURES: [(&str, AgentIdentity); 4] = [
         ("@anthropic-ai/claude-code", AgentIdentity::Claude),
         ("@openai/codex", AgentIdentity::Codex),
         ("@google/gemini-cli", AgentIdentity::Gemini),
+        ("opencode-ai", AgentIdentity::OpenCode),
     ];
 
     split_windows_command_line(command_line)

--- a/src/lib/process-info.test.ts
+++ b/src/lib/process-info.test.ts
@@ -6,6 +6,7 @@ describe("dotColor", () => {
     expect(dotColor("claude")).toBe("var(--magenta)");
     expect(dotColor("codex")).toBe("var(--green)");
     expect(dotColor("gemini")).toBe("var(--cyan)");
+    expect(dotColor("opencode")).toBe("var(--yellow)");
   });
 
   it("falls back to the faint tone for anything else", () => {

--- a/src/lib/process-info.ts
+++ b/src/lib/process-info.ts
@@ -1,5 +1,5 @@
 export type PaneProcessKind = "idle-shell" | "agent" | "busy" | "unknown";
-export type PaneAgent = "claude" | "codex" | "gemini";
+export type PaneAgent = "claude" | "codex" | "gemini" | "opencode";
 
 /** Mirror of the `PtyInfo` payload returned by the Rust `pty_info` command. */
 export interface PaneProcessInfo {
@@ -22,6 +22,7 @@ const AGENT_DOT_VARS: Readonly<Record<string, string>> = {
   claude: "var(--magenta)",
   codex: "var(--green)",
   gemini: "var(--cyan)",
+  opencode: "var(--yellow)",
 };
 
 function agentColor(agent: string | null): string | undefined {

--- a/src/open-board/open-board.tsx
+++ b/src/open-board/open-board.tsx
@@ -50,6 +50,7 @@ const AGENT_LABELS: Readonly<Record<string, string>> = {
   claude: "Claude Code",
   codex: "Codex",
   gemini: "Gemini CLI",
+  opencode: "OpenCode",
 };
 
 function agentLabel(name: string): string {

--- a/src/terminal/agent-launch.test.ts
+++ b/src/terminal/agent-launch.test.ts
@@ -25,6 +25,21 @@ afterEach(() => {
 });
 
 describe("createAgentLauncher", () => {
+  it.each(["windows", "macos"] as const)(
+    "types the OpenCode command unchanged on %s",
+    (platform) => {
+      const pty = createMemoryPtyClient();
+      const launcher = createAgentLauncher(pty, { platform, timeoutMs: 1000 });
+      launcher.arm([1], "opencode");
+      if (platform === "windows") {
+        launcher.notePromptReady(1);
+      } else {
+        launcher.noteOutput(1);
+      }
+      expect(pty.writes).toEqual([{ id: 1, data: "opencode\r" }]);
+      launcher.dispose();
+    },
+  );
   it("types the agent once the pane emits its first output", () => {
     const { pty, launcher } = setup();
     launcher.arm([1], "claude");

--- a/src/terminal/close-guard.test.ts
+++ b/src/terminal/close-guard.test.ts
@@ -19,7 +19,10 @@ function info(
   cwd: string | null = null,
 ): PaneProcessInfo {
   const agent =
-    process === "claude" || process === "codex" || process === "gemini"
+    process === "claude" ||
+    process === "codex" ||
+    process === "gemini" ||
+    process === "opencode"
       ? process
       : null;
   const kind =

--- a/src/terminal/tab-manager.ts
+++ b/src/terminal/tab-manager.ts
@@ -202,7 +202,10 @@ function explicitAgent(info: PaneProcessInfo | undefined): PaneAgent | null {
     return null;
   }
   const agent = info.agent;
-  return agent === "claude" || agent === "codex" || agent === "gemini"
+  return agent === "claude" ||
+    agent === "codex" ||
+    agent === "gemini" ||
+    agent === "opencode"
     ? agent
     : null;
 }

--- a/src/terminal/xterm-opencode.test.ts
+++ b/src/terminal/xterm-opencode.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { Terminal } from "@xterm/xterm";
+
+/** The first control sequences emitted by OpenTUI 0.4.5 / OpenCode 1.18.11. */
+const OPENCODE_STARTUP =
+  "\x1b[?2031h" +
+  "\x1b[?1016$p" +
+  "\x1b[?2027$p" +
+  "\x1b[?2031$p" +
+  "\x1b[?1004$p" +
+  "\x1b[?2004$p" +
+  "\x1b[?2026$p";
+
+describe("OpenCode terminal compatibility", () => {
+  it("answers OpenTUI mode queries and continues parsing the first frame", async () => {
+    const terminal = new Terminal({ cols: 80, rows: 24 });
+    const replies: string[] = [];
+    terminal.onData((data) => replies.push(data));
+
+    await new Promise<void>((resolve) => {
+      terminal.write(
+        `${OPENCODE_STARTUP}\x1b[?2026h\x1b[HOpenCode\x1b[?2026l`,
+        resolve,
+      );
+    });
+
+    expect(replies).toContain("\x1b[?1016;2$y");
+    expect(replies).toContain("\x1b[?2026;2$y");
+    expect(terminal.buffer.active.getLine(0)?.translateToString(true)).toBe(
+      "OpenCode",
+    );
+    terminal.dispose();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,15 @@ const host = process.env.TAURI_DEV_HOST;
 // https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [preact()],
+  build: {
+    // esbuild 0.25 mis-minifies xterm 6's function-local enum in
+    // InputHandler.requestMode: it drops the declaration but leaves a renamed
+    // reference behind (`ReferenceError: s is not defined`). OpenTUI sends a
+    // DECRQM query at startup, so that exception permanently stops xterm's
+    // write queue and leaves OpenCode running behind a blank pane. Terser
+    // preserves the local binding and produces an equally compact bundle.
+    minify: "terser",
+  },
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //
   // 1. prevent Vite from obscuring rust errors


### PR DESCRIPTION
## Summary

- discover and launch the bare `opencode` command from the Open board on Windows and macOS
- classify OpenCode as an agent for badges, activity, notifications, and close protection
- switch production minification to Terser so OpenTUI mode queries do not crash xterm 6
- add regression coverage for OpenCode discovery, launch readiness, process identity, colors, and terminal startup sequences

## Root cause

Vite's esbuild minifier dropped xterm 6's function-local enum binding in `InputHandler.requestMode`. OpenTUI queries terminal modes during startup, which raised `ReferenceError: s is not defined` and permanently stopped xterm's write queue while the OpenCode child kept running in the background.

## Verification

- `npm test`: 887 tests passed
- `cargo test --lib`: 130 tests passed
- `npm run build`: production build passed
- `npm audit --audit-level=low`: 0 vulnerabilities
- Windows desktop E2E: OpenCode 1.18.11 logo, prompt, model row, and version rendered with no WebView exception
- macOS: Homebrew-style process path, discovery, classification, and first-output launch behavior covered by unit tests; native macOS hardware was not available for an end-to-end run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenCode as a supported coding agent across detection, launching, terminal sessions, and board displays.
  * OpenCode is shown with its own label and yellow status indicator.
  * Added support for OpenCode startup behavior on macOS and Windows.

* **Build Improvements**
  * Production builds now use Terser for minification, helping optimize release output.

* **Tests**
  * Added coverage for OpenCode detection, terminal startup, display behavior, and production build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->