### PR TITLE
feat(agents): declare agent CLIs in settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,16 @@ side. Standalone desktop app — no shared DB, no API, no dependency on the web 
   signing and GitHub Releases; auto-check only, then expose an explicit chrome
   `Update` → `Install & Relaunch` action beside Settings. Windows remains an unsigned,
   separately labelled prerelease until paid Authenticode signing is chosen later.
+- Production builds minify with Terser, not esbuild (PR #9, merged 2026-08-04): esbuild
+  0.25 drops xterm 6's function-local enum in `InputHandler.requestMode` but keeps a
+  renamed reference, so the DECRQM query OpenCode sends at startup throws and stops
+  xterm's write queue for good — a blank pane. `scripts/vite-config.test.ts` locks it.
+- User-declared agents (`M2`) are approved (2026-08-04): an agent is a label plus a full
+  command line, declared in a new Settings category, and `AgentChoice` stays a string id
+  whose built-in ids equal their binary names — so every `lastAgent` already on disk
+  keeps resolving and no migration exists to get wrong. The editable list needs a new
+  design-language rule (§12), approved with it. See
+  [spec](docs/specs/2026-08-04-user-declared-agents-design.md) `decided`.
 
 **Forks → STOP and ask before writing code.** Collect them into ONE round at the start
 of the task; if there are none, say "no forks" and just go.

--- a/docs/DESIGN-LANGUAGE.md
+++ b/docs/DESIGN-LANGUAGE.md
@@ -212,6 +212,31 @@ section — these rules govern the frame around it.
 - **DL-11.5** Destructive actions never sit among navigable categories. They
   are pinned to the rail's foot, below a hairline, marked `--red` (DL-3.2).
 
+## 12. Editable lists
+
+Approved as a fork on 2026-08-04, for user-declared agents. §5 allows exactly
+one interactive value per row and forbids list widgets outright, which a list
+the user adds to and deletes from cannot satisfy. These rules say how a list is
+still made of rows rather than becoming a new widget genre.
+
+- **DL-12.1** A list section renders **one `cfg-row` per item** (`.cfg-row--item`).
+  The item's name is the row key, its value fills the right side. There is no
+  table, no card, no drag handle, no reorder affordance.
+- **DL-12.2** An item row may carry **one** destructive affordance: a `×` after
+  the value, `--text-faint`, turning `--red` on hover (DL-3.2). It is the only
+  place in the app where a row holds a second interactive element, and it is
+  allowed **only** for removing that row's own item.
+- **DL-12.3** The list ends with the add affordance: an ordinary `cfg-row` whose
+  pill is the `action` kind (`+`). Adding is a row, not a floating button.
+- **DL-12.4** Items the user cannot edit stay in the same list under their own
+  group label, with the pill in its disabled treatment (DL-5.2) and no `×`. A
+  separate surface for them would imply two kinds of thing; they are one set
+  with different permissions.
+- **DL-12.5** Editing happens **in place**, never in a modal or a drawer. Both
+  the row key and its value may become a `CommitInput` (DL-6.3) — the single
+  documented exception to §5's non-interactive key, and it exists because
+  renaming an item is editing that item, not configuring a setting.
+
 ## Chưa khớp thực tế
 
 _(reality-drift ledger — heading text mandated by the global docs convention)_

--- a/docs/specs/2026-08-04-user-declared-agents-design.md
+++ b/docs/specs/2026-08-04-user-declared-agents-design.md
@@ -1,0 +1,222 @@
+# Spec — User-declared agents
+
+Status: approved 2026-08-04
+Branch: `feat/user-declared-agents` (worktree, based on `main` after PR #9)
+
+This is `M2`, the work [the settings spec](2026-08-02-settings-full-window-design.md)
+named as its next step. Its stated precondition — "diagnose the `opencode` launch
+failure before `M2` ships" — was closed by PR #9: esbuild 0.25 mis-minified xterm 6's
+function-local enum in `InputHandler.requestMode`, and the build now uses Terser.
+
+## 1. Problem
+
+The set of agent CLIs Deck can launch is a compile-time constant in two places:
+[`AGENT_ALLOWLIST`](../../src-tauri/src/agents.rs) `current` in Rust, and
+[`AGENT_LABELS`](../../src/open-board/open-board.tsx) `current` in the Open board.
+Running anything else — a CLI Deck has never heard of, or a known one with flags
+(`claude --resume`, `codex --model o3`) — means editing the source and rebuilding.
+
+Two distinct needs, one shape: **a name plus a command line, declared by the user.**
+
+## 2. Goals (MVP)
+
+- Declare an agent as a label plus a full shell command, in Settings.
+- Declared agents appear in the Open board's agent row beside the built-in four,
+  selectable by click and by digit key, remembered per workspace like any other.
+- A declared agent whose binary is not on `$PATH` degrades exactly like a built-in
+  one does today: the board warns, and the choice falls back.
+- Declaring an agent cannot execute anything at declare time.
+
+## 3. Non-goals (later, not never)
+
+- Editing the built-in four (their command stays the bare binary name). The list
+  shows them locked so the set reads as one, but they are not editable at MVP.
+- Per-workspace agent sets, env vars, or working directories per agent.
+- Importing agent definitions from a file, or syncing them between machines.
+- An icon picker. Declared agents use the existing letter avatar.
+
+## 4. Current source facts
+
+Verified against `23fd43e`.
+
+| Fact                                                                                               | Where                                                                              |
+| -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `AgentChoice = string \| null`; the string is a binary name, `null` is Shell only                  | [`workspace-recents.ts`](../../src/lib/workspace-recents.ts) `current`             |
+| The choice is persisted per workspace as `lastAgent` and resolved by `resolveAgentChoice`          | [`workspace-recents.ts`](../../src/lib/workspace-recents.ts) `current`             |
+| The launcher writes the choice into the pane verbatim: `pty.writePty(id, \`${entry.agent}\r\`)`    | [`agent-launch.ts`](../../src/terminal/agent-launch.ts) `current`                  |
+| macOS discovery builds one shell script: `command -v <name>` joined by `; `, run under `sh -ilc`   | [`macos.rs`](../../src-tauri/src/platform/macos.rs) `current`                      |
+| Windows discovery loops the same allowlist through a search provider, normalising `.exe/.cmd/.bat` | [`agent_discovery.rs`](../../src-tauri/src/platform/windows/agent_discovery.rs)    |
+| Settings persist through one validated schema and a debounced Tauri store                          | [`settings-schema.ts`](../../src/settings/settings-schema.ts) `current`            |
+| A settings category is one registry entry plus one file under `sections/`                          | [`settings-categories.ts`](../../src/ui/settings/settings-categories.ts) `current` |
+
+### 4.1 The fact that shapes everything
+
+`lastAgent` is **already on disk** in every user's recents, holding bare binary
+names. Any design that changes what that string means has to migrate it. The design
+below keeps the string a stable id and makes built-in ids identical to their binary
+names, so every recents entry written before this change keeps resolving unchanged
+and no migration exists to get wrong.
+
+## 5. Data model
+
+```ts
+export interface CustomAgent {
+  /** Stable id, `custom:<slug>`. Generated once; never re-derived from label. */
+  readonly id: string;
+  /** Display name in the chip and the settings list. */
+  readonly label: string;
+  /** The full command line typed into the pane. */
+  readonly command: string;
+}
+```
+
+`Settings` gains `customAgents: readonly CustomAgent[]`, defaulting to `[]`, validated
+by `validateSettings` like every other field: a malformed entry is dropped, not
+repaired, and a malformed array falls back to `[]`.
+
+The id is generated from the label at creation (`custom:aider`), de-duplicated with a
+numeric suffix, and then **frozen**. Renaming an agent keeps its id, so a workspace
+that remembers it keeps opening it.
+
+## 6. Design
+
+### 6.1 Resolving a choice to a command
+
+One new pure module, `src/lib/agent-catalog.ts`:
+
+- `agentBinary(command)` — the first whitespace-separated token.
+- `resolveAgentCommand(id, customAgents)` — built-in id → itself; `custom:*` → that
+  agent's `command`; unknown → `null`.
+- `probeNames(customAgents)` — built-in names plus each custom agent's binary, deduped.
+
+`tab-manager` resolves the id to a command at the call site and passes the command to
+`launcher.arm()`. `agent-launch.ts` is **unchanged**: it still receives a string and
+still writes it verbatim. Keeping the launcher ignorant of the catalog is deliberate —
+its retry/timeout state machine is the trickiest code in the path and this change has
+no business touching it.
+
+### 6.2 Discovery
+
+`detect_agents` gains a parameter: `detect_agents(names: Vec<String>) -> Vec<AgentInfo>`.
+
+- Rust **re-filters** every name through `is_probe_safe` and silently drops the rest.
+  The frontend validates too, but the frontend is not the trust boundary.
+- The built-in names are always probed, whatever the caller sends, so a frontend bug
+  can never collapse the picker to Shell only.
+- The return contract is unchanged and stays keyed by binary name: it answers "which
+  binaries exist", nothing more. Two custom agents sharing a binary (`claude --resume`
+  and `claude -c`) both resolve against the same single `AgentInfo` — which is why the
+  chips are built from settings, not from the discovery result.
+
+`AGENT_ALLOWLIST` is renamed `BUILTIN_AGENTS`; the constant survives, its meaning
+narrows from "the only agents that may exist" to "the agents always probed".
+
+### 6.3 Safety — this is the part that can go wrong
+
+macOS discovery interpolates each name into a shell script run by `sh -ilc`. Today
+that is safe because the names are a compile-time constant. Once a user supplies them
+it is a **command-injection sink**: an agent named `x; rm -rf ~` would run.
+
+`is_probe_safe(name)` accepts only `A–Z a–z 0–9 . _ - / ~ +`, requires non-empty, and
+caps length at 128. Everything that gives a shell power — whitespace, `;`, `&`, `|`,
+`$`, backtick, quotes, parentheses, newline — is absent from that set. It is written
+as a plain `chars().all(…)` check; no `regex` crate, because a new dependency is a
+fork and this does not need one.
+
+The **command's remaining arguments are never escaped and never probed** — they are
+written into the user's own interactive shell, which is exactly what typing them by
+hand would do. Deck is a terminal; running the command a user typed is the product.
+The boundary being defended is the _discovery probe_, which the user did not ask to
+run and which executes before any pane exists.
+
+### 6.4 The Open board
+
+The board stops mapping the discovery result straight to chips. It builds one list:
+
+```
+built-ins found on $PATH  →  chip { id: name, label: AGENT_LABELS[name], logo }
+custom agents (settings)  →  chip { id, label, letter avatar, missing?: bool }
+Shell only                →  chip { id: null }
+```
+
+Digit keys, arrow movement, the selected-chip marker and the stale-choice warning all
+keep working against this list; `resolveAgentChoice` now compares ids instead of
+binary names, which for built-ins is the same string it always compared.
+
+A custom agent whose binary is missing stays visible but marked, rather than vanishing:
+a chip that disappears when a tool is uninstalled reads as data loss.
+
+## 7. Design-language addition — §12 Editable lists
+
+Approved as a fork on 2026-08-04. §5 allows exactly one interactive value per row and
+forbids list widgets outright, so a list the user can add to and delete from needs a
+rule rather than an exception.
+
+- **DL-12.1** A list section renders **one `cfg-row` per item**. The item's name is the
+  row key; its single pill shows the item's value. The list is rows, not a widget.
+- **DL-12.2** An item row may carry **one** destructive affordance (`×`) after the pill.
+  It sits outside the value slot, is `--text-faint`, and turns `--red` on hover (DL-3.2).
+  This is the only place in the app where a row holds a second interactive element, and
+  it is allowed only for removing that row's own item.
+- **DL-12.3** The list's final row is the add affordance: an `action` pill (`+ add`),
+  keyed like any other row.
+- **DL-12.4** Items the user cannot edit appear in the same list, pill disabled and no
+  `×` (DL-5.2's disabled treatment). A separate "built-in" section would imply two
+  different kinds of thing; they are one set with different permissions.
+- **DL-12.5** Editing is in place: the pill becomes a `CommitInput` (DL-6.3). No modal,
+  no drawer — a list that opens a dialog per row is the widget genre §5 rejects.
+
+### 7.1 Migration note for the ledger
+
+§10's migration table gains no entry: no existing component violates §12, because no
+editable list exists yet.
+
+## 8. Module structure
+
+```
+src/lib/agent-catalog.ts              # pure: binary extraction, id generation, resolution
+src/lib/agent-catalog.test.ts
+src/ui/settings/sections/agents-section.tsx       # the list (DL-12)
+src/ui/settings/sections/agents-section.test.tsx
+```
+
+Changed: `settings-schema.ts` (+field, +validation), `settings-categories.ts` (+entry),
+`active-category-store.ts` (+`"agents"` in `CategoryId`), `settings-nav-icons.tsx`
+(+icon), `open-board.tsx` (chip list), `tab-manager.ts` (resolve before arm),
+`pty-client.ts` (`detectAgents(names)`), `agents.rs`, `macos.rs`,
+`windows/agent_discovery.rs`.
+
+Not changed: `agent-launch.ts`, `workspace-recents.ts` (the `AgentChoice` type already
+says `string | null` and still does).
+
+## 9. Error handling
+
+| Case                                   | Behaviour                                                     |
+| -------------------------------------- | ------------------------------------------------------------- |
+| Empty label or command                 | Save blocked, inline error on the row (`.cfg-custom--error`)  |
+| Label duplicates another agent's       | Save blocked, inline error                                    |
+| Binary fails `is_probe_safe`           | Save blocked, inline error naming the character class allowed |
+| Binary valid but absent from `$PATH`   | Saves fine; chip shows as missing; board warns on selection   |
+| Discovery times out or the shell hangs | Unchanged — empty list, board degrades to Shell only          |
+| Store write fails                      | Unchanged — `PersistErrorBar`                                 |
+
+## 10. Verification
+
+- `npm test` — green, including: catalog unit tests (id stability across rename,
+  binary extraction, injection strings rejected), section tests (add / edit / remove /
+  duplicate-label / bad-binary), and a board test that a custom chip is selectable by
+  digit key.
+- `cargo test` in `src-tauri` — `is_probe_safe` rejects each metacharacter; discovery
+  probes built-ins even when the caller sends an empty or fully-invalid list.
+- `npm run build` — green (covers typecheck).
+- Screenshot of the Agents section reviewed by eye against §12 before calling it done
+  (§9, item 6).
+- Manual: declare `aider --model sonnet`, open a workspace with it, confirm the pane
+  receives the full command; rename it, reopen the workspace, confirm it still opens.
+
+## 11. Open questions
+
+| Question                                                                 | Owner   | Blocking?                      |
+| ------------------------------------------------------------------------ | ------- | ------------------------------ |
+| Should the built-in four become editable once §12 exists?                | product | no — non-goal at MVP           |
+| Should a missing custom agent be removable straight from the board chip? | product | no — Settings is the one place |

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -11,8 +11,48 @@ pub struct AgentInfo {
     pub path: String,
 }
 
-/// Allowlist aligned with the chrome recognition names (ARCH D6).
-pub(crate) const AGENT_ALLOWLIST: [&str; 4] = ["claude", "codex", "gemini", "opencode"];
+/// Recognised out of the box; always probed, whatever the caller asks for.
+/// Mirrors `BUILTIN_AGENTS` in src/lib/agent-catalog.ts.
+pub(crate) const BUILTIN_AGENTS: [&str; 4] = ["claude", "codex", "gemini", "opencode"];
+
+/// Upper bound on a probed name; mirrors `PROBE_NAME_MAX` in agent-catalog.ts.
+const PROBE_NAME_MAX: usize = 128;
+
+/// Whether a name may be interpolated into the discovery probe.
+///
+/// This is a security boundary, not a tidiness check. macOS discovery builds
+/// `command -v <name>` strings and runs them through `sh -ilc`, so a name
+/// carrying `;`, `&`, `|`, `$`, a backtick, a quote or whitespace would
+/// execute. The frontend validates too; this check exists because the
+/// frontend is not the trust boundary — the command arrives over IPC and any
+/// page bug or future caller lands here first.
+pub(crate) fn is_probe_safe(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= PROBE_NAME_MAX
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '~' | '+' | '/' | '-'))
+}
+
+/// The names to probe: every built-in, then each safe caller-supplied name not
+/// already present. Built-ins are unconditional so a frontend bug can never
+/// collapse the picker to Shell only.
+pub(crate) fn probe_names(requested: Vec<String>) -> Vec<String> {
+    let mut names: Vec<String> = BUILTIN_AGENTS.iter().map(|name| (*name).to_string()).collect();
+    for name in requested {
+        if is_probe_safe(&name) && !names.iter().any(|existing| *existing == name) {
+            names.push(name);
+        }
+    }
+    names
+}
+
+/// The basename a probed name resolves to. A declared agent may be a path
+/// (`~/bin/agent.sh`), while `command -v` answers with the resolved absolute
+/// path — so both sides are compared by their last segment.
+pub(crate) fn probe_key(name: &str) -> &str {
+    name.rsplit(['/', '\\']).next().unwrap_or(name)
+}
 
 /// Strip terminal control sequences from one line. An interactive login shell
 /// (`-ilc`) runs rc-file hooks that print terminal noise with no trailing
@@ -64,10 +104,11 @@ fn strip_ansi(line: &str) -> String {
     String::from_utf8_lossy(&out).into_owned()
 }
 
-/// Keep only absolute paths whose basename is allowlisted, first hit per
-/// name wins, result ordered by first appearance (script emits allowlist
-/// order, so numbering in the picker is stable).
-pub(crate) fn parse_command_v_output(output: &str) -> Vec<AgentInfo> {
+/// Keep only absolute paths whose basename was asked for, first hit per name
+/// wins, result ordered by first appearance (the script emits `probed` order,
+/// so numbering in the picker is stable).
+pub(crate) fn parse_command_v_output(output: &str, probed: &[String]) -> Vec<AgentInfo> {
+    let wanted: Vec<&str> = probed.iter().map(|name| probe_key(name)).collect();
     let mut found: Vec<AgentInfo> = Vec::new();
     for line in output.lines() {
         let stripped = strip_ansi(line);
@@ -81,7 +122,7 @@ pub(crate) fn parse_command_v_output(output: &str) -> Vec<AgentInfo> {
         else {
             continue;
         };
-        if AGENT_ALLOWLIST.contains(&name) && !found.iter().any(|a| a.name == name) {
+        if wanted.contains(&name) && !found.iter().any(|a| a.name == name) {
             found.push(AgentInfo {
                 name: name.to_string(),
                 path: path.to_string(),
@@ -102,9 +143,11 @@ pub(crate) fn parse_command_v_output(output: &str) -> Vec<AgentInfo> {
 /// fixes both. Any failure (spawn error, non-blocking-pool panic, or a hung rc
 /// file past `DETECT_TIMEOUT`) degrades to an empty list (picker then shows
 /// Shell only — FR-025) instead of blocking a Tokio worker thread forever.
+/// `names` are the caller's declared agent binaries; they are re-filtered here
+/// and merged with the built-ins by `probe_names`.
 #[tauri::command]
-pub async fn detect_agents() -> Vec<AgentInfo> {
-    crate::platform::discover_agents().await
+pub async fn detect_agents(names: Vec<String>) -> Vec<AgentInfo> {
+    crate::platform::discover_agents(probe_names(names)).await
 }
 
 /// Existence check for workspace recents (FR-003 AC-2); order mirrors input.
@@ -120,12 +163,92 @@ pub async fn dirs_exist(paths: Vec<String>) -> Vec<bool> {
 mod tests {
     use super::*;
 
+    fn builtins() -> Vec<String> {
+        BUILTIN_AGENTS.iter().map(|name| (*name).to_string()).collect()
+    }
+
+    #[test]
+    fn probe_safety_rejects_every_shell_metacharacter() {
+        // Each of these, interpolated into `command -v <name>` under `sh -ilc`,
+        // would run something the user never asked to run.
+        for name in [
+            "x; rm -rf ~",
+            "x && rm -rf ~",
+            "x | tee /tmp/x",
+            "$(id)",
+            "`id`",
+            "x>out",
+            "x<in",
+            "a b",
+            "a\nb",
+            "a\tb",
+            "'x'",
+            "\"x\"",
+            "x(1)",
+            "x{1}",
+            "x[1]",
+            "x*",
+            "x?",
+            "x!",
+            "x#c",
+            "x\\y",
+            "x%y",
+            "x=y",
+            "x:y",
+            "x,y",
+            "x@y",
+            "x^y",
+            "",
+        ] {
+            assert!(!is_probe_safe(name), "{name} must not reach the shell");
+        }
+    }
+
+    #[test]
+    fn probe_safety_accepts_real_binary_names_and_paths() {
+        for name in ["aider", "my-agent_1", "~/bin/agent.sh", "/opt/bin/claude", "g++"] {
+            assert!(is_probe_safe(name), "{name} is a legitimate binary name");
+        }
+        assert!(is_probe_safe(&"a".repeat(PROBE_NAME_MAX)));
+        assert!(!is_probe_safe(&"a".repeat(PROBE_NAME_MAX + 1)));
+    }
+
+    #[test]
+    fn probe_names_keeps_builtins_whatever_the_caller_sends() {
+        // A frontend bug (empty list) or a hostile one (all-invalid) must never
+        // collapse the picker to Shell only.
+        assert_eq!(probe_names(Vec::new()), builtins());
+        assert_eq!(probe_names(vec!["x; rm -rf ~".into()]), builtins());
+    }
+
+    #[test]
+    fn probe_names_appends_safe_requests_once() {
+        let names = probe_names(vec!["aider".into(), "aider".into(), "claude".into()]);
+        let mut expected = builtins();
+        expected.push("aider".into());
+        assert_eq!(names, expected);
+    }
+
+    #[test]
+    fn parse_matches_a_declared_path_by_its_basename() {
+        // `command -v ~/bin/agent.sh` answers with the resolved absolute path,
+        // so the two sides only ever agree on the last segment.
+        let out = "/Users/dev/bin/agent.sh\n";
+        assert_eq!(
+            parse_command_v_output(out, &["~/bin/agent.sh".to_string()]),
+            vec![AgentInfo {
+                name: "agent.sh".into(),
+                path: "/Users/dev/bin/agent.sh".into()
+            }]
+        );
+    }
+
     #[test]
     fn parses_absolute_paths_in_allowlist_order() {
         let out =
             "/usr/local/bin/claude\n/Users/dev/.local/bin/gemini\n/opt/homebrew/bin/opencode\n";
         assert_eq!(
-            parse_command_v_output(out),
+            parse_command_v_output(out, &builtins()),
             vec![
                 AgentInfo {
                     name: "claude".into(),
@@ -149,7 +272,7 @@ mod tests {
         // absolute paths whose basename is on the allowlist.
         let out = "alias claude='claude --tips'\n/usr/local/bin/ripgrep\n\n/opt/bin/codex\n";
         assert_eq!(
-            parse_command_v_output(out),
+            parse_command_v_output(out, &builtins()),
             vec![AgentInfo {
                 name: "codex".into(),
                 path: "/opt/bin/codex".into()
@@ -160,7 +283,7 @@ mod tests {
     #[test]
     fn dedupes_repeated_names() {
         let out = "/a/claude\n/b/claude\n";
-        assert_eq!(parse_command_v_output(out).len(), 1);
+        assert_eq!(parse_command_v_output(out, &builtins()).len(), 1);
     }
 
     #[test]
@@ -174,7 +297,7 @@ mod tests {
             \x1b]1337;ShellIntegrationVersion=14;shell=zsh\x07\
             /Users/dev/.local/bin/claude\n";
         assert_eq!(
-            parse_command_v_output(out),
+            parse_command_v_output(out, &builtins()),
             vec![AgentInfo {
                 name: "claude".into(),
                 path: "/Users/dev/.local/bin/claude".into()
@@ -188,7 +311,7 @@ mod tests {
         let out = "\x1b[32m\x1b[1m/opt/homebrew/bin/codex\x1b[0m\n\
             \x1b]0;title\x1b\\/usr/local/bin/gemini\n";
         assert_eq!(
-            parse_command_v_output(out),
+            parse_command_v_output(out, &builtins()),
             vec![
                 AgentInfo {
                     name: "codex".into(),

--- a/src-tauri/src/platform/macos.rs
+++ b/src-tauri/src/platform/macos.rs
@@ -1,5 +1,5 @@
 use super::{path_to_string, validate_user_home, ProcessInspection, SessionIdentity, ShellLaunch};
-use crate::agents::{parse_command_v_output, AgentInfo, AGENT_ALLOWLIST, DETECT_TIMEOUT};
+use crate::agents::{parse_command_v_output, AgentInfo, DETECT_TIMEOUT};
 use portable_pty::{ChildKiller, MasterPty};
 use std::path::PathBuf;
 use std::thread;
@@ -34,12 +34,14 @@ pub fn shell_launch() -> Result<ShellLaunch, String> {
     Ok(ShellLaunch::new(shell, vec!["-l".into()]))
 }
 
-pub async fn discover_agents() -> Vec<AgentInfo> {
+/// `names` has already passed `is_probe_safe` in `probe_names` — that is what
+/// makes interpolating them into this script safe.
+pub async fn discover_agents(names: Vec<String>) -> Vec<AgentInfo> {
     let launch = match shell_launch() {
         Ok(launch) => launch,
         Err(_) => return Vec::new(),
     };
-    let script = AGENT_ALLOWLIST
+    let script = names
         .iter()
         .map(|name| format!("command -v {name}"))
         .collect::<Vec<_>>()
@@ -53,7 +55,7 @@ pub async fn discover_agents() -> Vec<AgentInfo> {
         Ok(Ok(Ok(output))) => output,
         _ => return Vec::new(),
     };
-    parse_command_v_output(&String::from_utf8_lossy(&output.stdout))
+    parse_command_v_output(&String::from_utf8_lossy(&output.stdout), &names)
 }
 
 pub fn inspect_process(pid: i32) -> ProcessInspection {

--- a/src-tauri/src/platform/unsupported.rs
+++ b/src-tauri/src/platform/unsupported.rs
@@ -27,7 +27,7 @@ pub fn shell_launch() -> Result<ShellLaunch, String> {
     Err("Terminal sessions are unavailable on this platform".into())
 }
 
-pub async fn discover_agents() -> Vec<AgentInfo> {
+pub async fn discover_agents(_names: Vec<String>) -> Vec<AgentInfo> {
     Vec::new()
 }
 

--- a/src-tauri/src/platform/windows/agent_discovery.rs
+++ b/src-tauri/src/platform/windows/agent_discovery.rs
@@ -1,4 +1,4 @@
-use crate::agents::{AgentInfo, AGENT_ALLOWLIST, DETECT_TIMEOUT};
+use crate::agents::{probe_key, AgentInfo, DETECT_TIMEOUT};
 use std::collections::HashSet;
 use std::ffi::{OsStr, OsString};
 use std::time::Duration;
@@ -64,29 +64,36 @@ fn is_absolute_windows_path(value: &str) -> bool {
     drive_absolute || unc_absolute
 }
 
+/// The comparable form of a name: last path segment, lowercased, with the
+/// Windows command suffixes removed. Applied to BOTH sides so that what the
+/// caller asked for and what the search provider found are compared like for
+/// like — `claude` against `C:\…\CLAUDE.EXE`.
 fn normalize_agent_name(path: &str) -> Option<String> {
     let basename = path.rsplit(['\\', '/']).next()?.to_ascii_lowercase();
     let normalized = [".exe", ".cmd", ".bat", ".ps1"]
         .iter()
         .find_map(|suffix| basename.strip_suffix(suffix))
         .unwrap_or(&basename);
-    AGENT_ALLOWLIST
-        .iter()
-        .find(|allowed| **allowed == normalized)
-        .map(|allowed| (*allowed).to_string())
+    (!normalized.is_empty()).then(|| normalized.to_string())
 }
 
-fn discover_sync(provider: &impl AgentSearchProvider) -> Result<Vec<AgentInfo>, String> {
+fn discover_sync(
+    provider: &impl AgentSearchProvider,
+    names: &[String],
+) -> Result<Vec<AgentInfo>, String> {
     let mut seen = HashSet::new();
     let mut agents = Vec::new();
-    for requested_name in AGENT_ALLOWLIST {
+    for requested_name in names {
         let Some(path) = provider.find(requested_name)? else {
             continue;
         };
         let Some(name) = normalize_agent_name(&path) else {
             continue;
         };
-        if name != requested_name || !is_absolute_windows_path(&path) || !seen.insert(name.clone())
+        let expected = normalize_agent_name(probe_key(requested_name));
+        if Some(&name) != expected.as_ref()
+            || !is_absolute_windows_path(&path)
+            || !seen.insert(name.clone())
         {
             continue;
         }
@@ -98,8 +105,9 @@ fn discover_sync(provider: &impl AgentSearchProvider) -> Result<Vec<AgentInfo>, 
 async fn discover_with_provider(
     provider: impl AgentSearchProvider + 'static,
     timeout: Duration,
+    names: Vec<String>,
 ) -> Vec<AgentInfo> {
-    let task = tauri::async_runtime::spawn_blocking(move || discover_sync(&provider));
+    let task = tauri::async_runtime::spawn_blocking(move || discover_sync(&provider, &names));
     match tokio::time::timeout(timeout, task).await {
         Ok(Ok(Ok(agents))) => agents,
         Ok(Ok(Err(error))) => {
@@ -117,10 +125,11 @@ async fn discover_with_provider(
     }
 }
 
-pub(super) async fn discover_agents() -> Vec<AgentInfo> {
+pub(super) async fn discover_agents(names: Vec<String>) -> Vec<AgentInfo> {
     discover_with_provider(
         EnvironmentAgentSearchProvider::from_environment(),
         DETECT_TIMEOUT,
+        names,
     )
     .await
 }
@@ -128,9 +137,16 @@ pub(super) async fn discover_agents() -> Vec<AgentInfo> {
 #[cfg(test)]
 mod tests {
     use super::{discover_sync, discover_with_provider, AgentSearchProvider};
-    use crate::agents::AgentInfo;
+    use crate::agents::{AgentInfo, BUILTIN_AGENTS};
     use std::collections::HashMap;
     use std::time::Duration;
+
+    fn builtins() -> Vec<String> {
+        BUILTIN_AGENTS
+            .iter()
+            .map(|name| (*name).to_string())
+            .collect()
+    }
 
     struct FixtureProvider {
         paths: HashMap<String, String>,
@@ -162,7 +178,7 @@ mod tests {
         ]);
 
         assert_eq!(
-            discover_sync(&provider).unwrap(),
+            discover_sync(&provider, &builtins()).unwrap(),
             vec![
                 AgentInfo {
                     name: "claude".into(),
@@ -188,7 +204,7 @@ mod tests {
             ("gemini", r"C:\Tools\gemini.zip"),
         ]);
 
-        assert!(discover_sync(&provider).unwrap().is_empty());
+        assert!(discover_sync(&provider, &builtins()).unwrap().is_empty());
     }
 
     #[test]
@@ -199,12 +215,25 @@ mod tests {
             ("gemini", r"C:\Tools\GEMINI.PS1"),
         ]);
 
-        let names = discover_sync(&provider)
+        let names = discover_sync(&provider, &builtins())
             .unwrap()
             .into_iter()
             .map(|agent| agent.name)
             .collect::<Vec<_>>();
         assert_eq!(names, ["claude", "codex", "gemini"]);
+    }
+
+    #[test]
+    fn finds_a_declared_agent_that_is_not_a_builtin() {
+        let provider = FixtureProvider::new(&[("aider", r"C:\Tools\aider.cmd")]);
+
+        assert_eq!(
+            discover_sync(&provider, &["aider".to_string()]).unwrap(),
+            vec![AgentInfo {
+                name: "aider".into(),
+                path: r"C:\Tools\aider.cmd".into(),
+            }]
+        );
     }
 
     struct SlowProvider;
@@ -221,6 +250,7 @@ mod tests {
         let agents = tauri::async_runtime::block_on(discover_with_provider(
             SlowProvider,
             Duration::from_millis(1),
+            builtins(),
         ));
 
         assert!(agents.is_empty());

--- a/src-tauri/src/platform/windows/mod.rs
+++ b/src-tauri/src/platform/windows/mod.rs
@@ -87,8 +87,8 @@ pub fn shell_launch() -> Result<ShellLaunch, String> {
     shell::shell_launch()
 }
 
-pub async fn discover_agents() -> Vec<AgentInfo> {
-    agent_discovery::discover_agents().await
+pub async fn discover_agents(names: Vec<String>) -> Vec<AgentInfo> {
+    agent_discovery::discover_agents(names).await
 }
 
 pub fn inspect_process(_pid: i32) -> ProcessInspection {

--- a/src/lib/agent-catalog.test.ts
+++ b/src/lib/agent-catalog.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import {
+  agentBinary,
+  BUILTIN_AGENTS,
+  createCustomAgentId,
+  isProbeSafeName,
+  PROBE_NAME_MAX,
+  probeNames,
+  resolveAgentCommand,
+  type CustomAgent,
+} from "./agent-catalog";
+
+const aider: CustomAgent = {
+  id: "custom:aider",
+  label: "Aider",
+  command: "aider --model sonnet",
+};
+
+describe("agentBinary", () => {
+  it("takes the first token of a command line", () => {
+    expect(agentBinary("aider --model sonnet")).toBe("aider");
+  });
+
+  it("ignores surrounding and repeated whitespace", () => {
+    expect(agentBinary("   aider   --model sonnet  ")).toBe("aider");
+    expect(agentBinary("aider\t--model")).toBe("aider");
+  });
+
+  it("returns an empty string for a blank command", () => {
+    expect(agentBinary("   ")).toBe("");
+  });
+});
+
+describe("isProbeSafeName", () => {
+  it("accepts bare names, paths and the punctuation real binaries use", () => {
+    for (const name of [
+      "aider",
+      "opencode",
+      "my-agent_1",
+      "~/bin/agent.sh",
+      "/opt/homebrew/bin/claude",
+      "g++",
+    ]) {
+      expect(isProbeSafeName(name)).toBe(true);
+    }
+  });
+
+  // The name is interpolated into `sh -ilc "command -v <name>"` (macos.rs), so
+  // every character that gives a shell power has to be absent — this list is
+  // the actual attack surface, not a sample.
+  it("rejects anything a shell would act on", () => {
+    for (const name of [
+      "x; rm -rf ~",
+      "x && rm -rf ~",
+      "x | tee /tmp/x",
+      "$(id)",
+      "`id`",
+      "x>out",
+      "x<in",
+      "a b",
+      "a\nb",
+      "a\tb",
+      "'x'",
+      '"x"',
+      "x(1)",
+      "x{1}",
+      "x[1]",
+      "x*",
+      "x?",
+      "x!",
+      "x#c",
+      "x\\y",
+      "x%y",
+      "x=y",
+      "x:y",
+      "x,y",
+      "x@y",
+      "x^y",
+    ]) {
+      expect(isProbeSafeName(name)).toBe(false);
+    }
+  });
+
+  it("rejects an empty name and anything past the length cap", () => {
+    expect(isProbeSafeName("")).toBe(false);
+    expect(isProbeSafeName("a".repeat(PROBE_NAME_MAX))).toBe(true);
+    expect(isProbeSafeName("a".repeat(PROBE_NAME_MAX + 1))).toBe(false);
+  });
+});
+
+describe("createCustomAgentId", () => {
+  it("slugs the label behind the custom prefix", () => {
+    expect(createCustomAgentId("Aider", [])).toBe("custom:aider");
+    expect(createCustomAgentId("My Script", [])).toBe("custom:my-script");
+  });
+
+  it("suffixes until the id is free", () => {
+    const taken = [aider, { ...aider, id: "custom:aider-2" }];
+    expect(createCustomAgentId("Aider", taken)).toBe("custom:aider-3");
+  });
+
+  it("falls back when the label slugs to nothing", () => {
+    // A label of pure non-ASCII is legal to display and useless as a slug.
+    expect(createCustomAgentId("エージェント", [])).toBe("custom:agent");
+    expect(createCustomAgentId("...", [])).toBe("custom:agent");
+  });
+
+  it("never collides with a built-in id", () => {
+    expect(createCustomAgentId("claude", [])).toBe("custom:claude");
+  });
+});
+
+describe("resolveAgentCommand", () => {
+  it("maps a built-in id to itself", () => {
+    // The id/binary/command being one string is what keeps every lastAgent
+    // already on disk working without a migration.
+    for (const builtin of BUILTIN_AGENTS) {
+      expect(resolveAgentCommand(builtin.id, [])).toBe(builtin.id);
+    }
+  });
+
+  it("maps a custom id to its full command line", () => {
+    expect(resolveAgentCommand("custom:aider", [aider])).toBe(
+      "aider --model sonnet",
+    );
+  });
+
+  it("returns null for an id nothing declares", () => {
+    expect(resolveAgentCommand("custom:gone", [aider])).toBeNull();
+    expect(resolveAgentCommand("nonsense", [aider])).toBeNull();
+  });
+});
+
+describe("probeNames", () => {
+  it("always includes every built-in", () => {
+    expect(probeNames([])).toEqual(BUILTIN_AGENTS.map((agent) => agent.id));
+  });
+
+  it("adds each custom agent's binary once", () => {
+    const twice: readonly CustomAgent[] = [
+      aider,
+      { id: "custom:aider-2", label: "Aider fast", command: "aider --fast" },
+    ];
+    expect(probeNames(twice).filter((name) => name === "aider")).toHaveLength(
+      1,
+    );
+  });
+
+  it("drops a custom binary the probe must not carry into a shell", () => {
+    const evil: CustomAgent = {
+      id: "custom:evil",
+      label: "Evil",
+      command: "x;rm -rf ~",
+    };
+    expect(probeNames([evil])).not.toContain("x;rm");
+    expect(probeNames([evil])).toEqual(BUILTIN_AGENTS.map((a) => a.id));
+  });
+
+  it("does not re-list a custom binary that is already a built-in", () => {
+    const resumed: CustomAgent = {
+      id: "custom:claude-resume",
+      label: "Claude resume",
+      command: "claude --resume",
+    };
+    expect(probeNames([resumed])).toEqual(BUILTIN_AGENTS.map((a) => a.id));
+  });
+});

--- a/src/lib/agent-catalog.ts
+++ b/src/lib/agent-catalog.ts
@@ -1,0 +1,201 @@
+/**
+ * The agent catalog: what Deck can launch, and how a stored choice becomes a
+ * command line. Pure — no signals, no Tauri, no DOM.
+ *
+ * The load-bearing invariant is that a built-in agent's id, its binary name
+ * and its command are the SAME string. `lastAgent` in workspace recents has
+ * been storing bare binary names since long before user-declared agents
+ * existed, so keeping ids identical for the built-ins means every entry
+ * already on disk resolves unchanged and there is no migration to get wrong.
+ */
+
+/** An agent the user declared: a display name plus a full command line. */
+export interface CustomAgent {
+  /** Stable `custom:<slug>` id. Generated once, never re-derived from label. */
+  readonly id: string;
+  readonly label: string;
+  /** The command typed into the pane, arguments included. */
+  readonly command: string;
+}
+
+export interface BuiltinAgent {
+  /** Also the binary name and the command — see the module comment. */
+  readonly id: string;
+  readonly label: string;
+}
+
+/** Recognised out of the box; always probed, whatever the user declared. */
+export const BUILTIN_AGENTS: readonly BuiltinAgent[] = [
+  { id: "claude", label: "Claude Code" },
+  { id: "codex", label: "Codex" },
+  { id: "gemini", label: "Gemini CLI" },
+  { id: "opencode", label: "OpenCode" },
+];
+
+export const CUSTOM_ID_PREFIX = "custom:";
+
+/** Upper bound on a probed binary name; also enforced in Rust. */
+export const PROBE_NAME_MAX = 128;
+
+/** Upper bound on a display label — long enough to name a tool, short enough for a chip. */
+export const AGENT_LABEL_MAX = 32;
+
+const FALLBACK_SLUG = "agent";
+
+/**
+ * Characters a name may carry into the discovery probe. macOS discovery
+ * interpolates the name into `sh -ilc "command -v <name>"` (macos.rs), so this
+ * set deliberately excludes everything a shell acts on — whitespace, `;`, `&`,
+ * `|`, `$`, backticks, quotes, redirects, globs, braces. What remains is what
+ * real binary names and paths are made of.
+ */
+const PROBE_SAFE = /^[A-Za-z0-9._~+/-]+$/;
+
+/** Whether a name may be handed to the discovery probe. */
+export function isProbeSafeName(name: string): boolean {
+  if (name.length === 0 || name.length > PROBE_NAME_MAX) {
+    return false;
+  }
+  return PROBE_SAFE.test(name);
+}
+
+/**
+ * The binary a command line runs: its first token. Only this part is ever
+ * probed; the arguments go into the user's own shell untouched, which is what
+ * typing them by hand would do.
+ */
+export function agentBinary(command: string): string {
+  const trimmed = command.trim();
+  if (trimmed === "") {
+    return "";
+  }
+  return trimmed.split(/\s+/)[0];
+}
+
+/**
+ * How a command's binary is matched against a discovery result. `command -v`
+ * answers with a resolved absolute path, so a declared `~/bin/agent.sh` and the
+ * reported `/Users/dev/bin/agent.sh` only ever agree on the last segment —
+ * `probe_key` in agents.rs is the same function on the Rust side.
+ */
+export function binaryKey(command: string): string {
+  const binary = agentBinary(command);
+  const cut = Math.max(binary.lastIndexOf("/"), binary.lastIndexOf("\\"));
+  return cut === -1 ? binary : binary.slice(cut + 1);
+}
+
+function slugify(label: string): string {
+  return label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * A stable id for a new agent, unique among `existing`. The `custom:` prefix
+ * is what keeps a declared agent from ever colliding with a built-in id, so a
+ * user may legitimately name their agent "claude".
+ */
+export function createCustomAgentId(
+  label: string,
+  existing: readonly CustomAgent[],
+): string {
+  const base = slugify(label) || FALLBACK_SLUG;
+  const taken = new Set(existing.map((agent) => agent.id));
+  const first = `${CUSTOM_ID_PREFIX}${base}`;
+  if (!taken.has(first)) {
+    return first;
+  }
+  for (let suffix = 2; ; suffix += 1) {
+    const candidate = `${CUSTOM_ID_PREFIX}${base}-${suffix}`;
+    if (!taken.has(candidate)) {
+      return candidate;
+    }
+  }
+}
+
+export function isBuiltinAgentId(id: string): boolean {
+  return BUILTIN_AGENTS.some((agent) => agent.id === id);
+}
+
+/**
+ * The command line an agent id launches, or `null` when nothing declares it —
+ * a stale `lastAgent` pointing at an agent the user deleted lands here.
+ */
+export function resolveAgentCommand(
+  id: string,
+  customAgents: readonly CustomAgent[],
+): string | null {
+  if (isBuiltinAgentId(id)) {
+    return id;
+  }
+  const custom = customAgents.find((agent) => agent.id === id);
+  return custom?.command ?? null;
+}
+
+/** One selectable agent, in the order the board offers them. */
+export interface AgentOption {
+  /** The `AgentChoice` this option stands for. */
+  readonly id: string;
+  readonly label: string;
+  /** The resolved binary path, or the declared command line. */
+  readonly detail: string;
+  /** Declared, but its binary was not among the discovered ones. */
+  readonly missing: boolean;
+}
+
+/**
+ * The agent row: built-ins actually found on `$PATH`, then every declared
+ * agent. A declared agent stays in the list when its binary is gone — a chip
+ * that vanishes because a tool was uninstalled reads as lost data, so it is
+ * marked instead. One function so the board's chips and every other caller
+ * agree on membership AND order (digit keys depend on that order).
+ */
+export function agentOptions(
+  detected: readonly { readonly name: string; readonly path: string }[],
+  customAgents: readonly CustomAgent[],
+): readonly AgentOption[] {
+  const paths = new Map(detected.map((agent) => [agent.name, agent.path]));
+  const options: AgentOption[] = [];
+  for (const builtin of BUILTIN_AGENTS) {
+    const path = paths.get(builtin.id);
+    if (path !== undefined) {
+      options.push({
+        id: builtin.id,
+        label: builtin.label,
+        detail: path,
+        missing: false,
+      });
+    }
+  }
+  for (const agent of customAgents) {
+    options.push({
+      id: agent.id,
+      label: agent.label,
+      detail: agent.command,
+      missing: !paths.has(binaryKey(agent.command)),
+    });
+  }
+  return options;
+}
+
+/**
+ * Binary names to hand the discovery probe: every built-in, plus each declared
+ * agent's binary. Unsafe names are dropped here and dropped again in Rust —
+ * the frontend is not the trust boundary.
+ */
+export function probeNames(
+  customAgents: readonly CustomAgent[],
+): readonly string[] {
+  const names = BUILTIN_AGENTS.map((agent) => agent.id);
+  const seen = new Set(names);
+  for (const agent of customAgents) {
+    const binary = agentBinary(agent.command);
+    if (!isProbeSafeName(binary) || seen.has(binary)) {
+      continue;
+    }
+    seen.add(binary);
+    names.push(binary);
+  }
+  return names;
+}

--- a/src/lib/workspace-recents.test.ts
+++ b/src/lib/workspace-recents.test.ts
@@ -14,7 +14,9 @@ import {
 const NOW = 1_800_000_000_000;
 
 describe("resolveAgentChoice", () => {
-  const agents = [{ name: "claude" }, { name: "codex" }];
+  // Ids, not binary names: a built-in's id IS its binary name, and a declared
+  // agent's is `custom:<slug>` (see lib/agent-catalog.ts).
+  const agents = [{ id: "claude" }, { id: "codex" }];
 
   it("defaults to the first detected agent when nothing was picked", () => {
     expect(resolveAgentChoice(undefined, agents)).toBe("claude");
@@ -203,5 +205,17 @@ describe("display helpers", () => {
     expect(formatRelativeTime(NOW - 200 * DAY, NOW)).toBe("6 months ago");
     expect(formatRelativeTime(NOW - 365 * DAY, NOW)).toBe("1 year ago");
     expect(formatRelativeTime(NOW - 800 * DAY, NOW)).toBe("2 years ago");
+  });
+});
+
+describe("resolveAgentChoice — declared agents", () => {
+  const agents = [{ id: "claude" }, { id: "custom:aider" }];
+
+  it("keeps a declared agent id", () => {
+    expect(resolveAgentChoice("custom:aider", agents)).toBe("custom:aider");
+  });
+
+  it("falls back when the declared agent was deleted", () => {
+    expect(resolveAgentChoice("custom:gone", agents)).toBe("claude");
   });
 });

--- a/src/lib/workspace-recents.ts
+++ b/src/lib/workspace-recents.ts
@@ -137,15 +137,15 @@ export function removeRecents(
  */
 export function resolveAgentChoice(
   choice: AgentChoice | undefined,
-  agents: readonly { readonly name: string }[],
+  agents: readonly { readonly id: string }[],
 ): AgentChoice {
   if (choice === null) {
     return null;
   }
-  if (choice !== undefined && agents.some((agent) => agent.name === choice)) {
+  if (choice !== undefined && agents.some((agent) => agent.id === choice)) {
     return choice;
   }
-  return agents[0]?.name ?? null;
+  return agents[0]?.id ?? null;
 }
 
 export function folderName(path: string): string {

--- a/src/open-board/open-board.tsx
+++ b/src/open-board/open-board.tsx
@@ -12,11 +12,17 @@ import {
 } from "../lib/workspace-recents";
 import type { AgentChoice, RecentWorkspace } from "../lib/workspace-recents";
 import { tildify } from "../lib/process-info";
-import {
-  getDesktopEnvironment,
-  hasPrimaryModifier,
-} from "../lib/platform";
+import { getDesktopEnvironment, hasPrimaryModifier } from "../lib/platform";
 import { defaultPtyClient, type DetectedAgent } from "../terminal/pty-client";
+import {
+  agentOptions,
+  BUILTIN_AGENTS,
+  probeNames,
+  type AgentOption,
+  type CustomAgent,
+} from "../lib/agent-catalog";
+import { letterAvatar } from "../lib/letter-avatar";
+import { settings } from "../settings/settings-store";
 import {
   boardPresets,
   deletePreset,
@@ -45,27 +51,30 @@ export interface OpenBoardProps {
 
 type BoardSection = "workspace" | "layout" | "agent";
 
-/** Human names for allowlisted agent binaries (chip label). */
-const AGENT_LABELS: Readonly<Record<string, string>> = {
-  claude: "Claude Code",
-  codex: "Codex",
-  gemini: "Gemini CLI",
-  opencode: "OpenCode",
-};
-
-function agentLabel(name: string): string {
-  return AGENT_LABELS[name] ?? name;
-}
-
-/** Brand logo (chip icon) per allowlisted agent binary; url resolved by Vite. */
+/** Brand logo (chip icon) per built-in agent; url resolved by Vite. */
 const AGENT_LOGOS: Readonly<Record<string, string>> = {
   claude: claudeLogo,
   codex: codexLogo,
   gemini: geminiLogo,
 };
 
-function agentLogo(name: string): string | undefined {
-  return AGENT_LOGOS[name];
+function agentLabel(id: string, customAgents: readonly CustomAgent[]): string {
+  const builtin = BUILTIN_AGENTS.find((agent) => agent.id === id);
+  if (builtin !== undefined) {
+    return builtin.label;
+  }
+  return customAgents.find((agent) => agent.id === id)?.label ?? id;
+}
+
+/** `agentOptions` decides membership and order; the board only adds the logo. */
+function buildAgentChips(
+  detected: readonly DetectedAgent[],
+  customAgents: readonly CustomAgent[],
+): readonly (AgentOption & { readonly logo?: string })[] {
+  return agentOptions(detected, customAgents).map((option) => ({
+    ...option,
+    logo: AGENT_LOGOS[option.id],
+  }));
 }
 
 /** The default Deck mark, shown until the user sets a logo in Settings. */
@@ -112,6 +121,7 @@ export function OpenBoard({
     typeof first?.lastAgent === "string" ? first.lastAgent : undefined,
   );
   const agents = useSignal<readonly DetectedAgent[]>([]);
+  const customAgents = settings.value.customAgents;
   const section = useSignal<BoardSection>("workspace");
   const missing = useSignal<ReadonlySet<string>>(new Set());
   const renamingId = useSignal<string | null>(null);
@@ -133,16 +143,29 @@ export function OpenBoard({
 
   useEffect(() => {
     containerRef.current?.focus();
+  }, []);
+
+  // Re-probes whenever the declared set changes: adding an agent in Settings
+  // and coming straight back to the board has to show it without a relaunch.
+  useEffect(() => {
+    let cancelled = false;
     defaultPtyClient
-      .detectAgents()
+      .detectAgents(probeNames(customAgents))
       .then((found) => {
-        agents.value = found;
+        if (!cancelled) {
+          agents.value = found;
+        }
       })
       .catch((err: unknown) => {
         console.warn("detect_agents failed:", err);
-        agents.value = []; // board degrades to Shell only
+        if (!cancelled) {
+          agents.value = []; // board degrades to Shell only
+        }
       });
-  }, []);
+    return () => {
+      cancelled = true;
+    };
+  }, [customAgents]);
 
   useEffect(() => {
     const paths = recents.map((recent) => recent.path);
@@ -169,7 +192,8 @@ export function OpenBoard({
   const selectedPreset =
     presets.find((preset) => preset.id === selectedPresetId.value) ??
     presets[0];
-  const effectiveAgent = resolveAgentChoice(selectedAgent.value, agents.value);
+  const chips = buildAgentChips(agents.value, customAgents);
+  const effectiveAgent = resolveAgentChoice(selectedAgent.value, chips);
   const workspaceValid =
     selectedPath.value !== null && !missing.value.has(selectedPath.value);
 
@@ -181,9 +205,16 @@ export function OpenBoard({
   const pendingAgent = selectedAgent.value;
   const staleAgent =
     typeof pendingAgent === "string" &&
-    agents.value.length > 0 &&
-    !agents.value.some((agent) => agent.name === pendingAgent)
+    chips.length > 0 &&
+    !chips.some((chip) => chip.id === pendingAgent)
       ? pendingAgent
+      : null;
+  // A declared agent whose binary is gone stays selectable, so the warning
+  // moves to the footer rather than the chip disappearing from the row.
+  const missingAgent =
+    typeof effectiveAgent === "string" &&
+    chips.some((chip) => chip.id === effectiveAgent && chip.missing)
+      ? effectiveAgent
       : null;
 
   // A just-picked folder that is not in Recents yet shows as a live entry at
@@ -220,12 +251,19 @@ export function OpenBoard({
             }
           : staleAgent !== null
             ? {
-                text: `${agentLabel(staleAgent)} isn't installed — opens with ${
-                  effectiveAgent === null ? "Shell" : agentLabel(effectiveAgent)
+                text: `${agentLabel(staleAgent, customAgents)} isn't installed — opens with ${
+                  effectiveAgent === null
+                    ? "Shell"
+                    : agentLabel(effectiveAgent, customAgents)
                 }`,
                 warn: true,
               }
-            : null;
+            : missingAgent !== null
+              ? {
+                  text: `${agentLabel(missingAgent, customAgents)} isn't on $PATH — the pane will open, the command won't run`,
+                  warn: true,
+                }
+              : null;
 
   /** Apply a recent's remembered combo when it is picked (still overridable). */
   function selectWorkspace(path: string): void {
@@ -336,10 +374,7 @@ export function OpenBoard({
 
   function moveAgent(step: 1 | -1): void {
     // Options are [agent0 … agentN, Shell only]; index N === Shell only.
-    const options: AgentChoice[] = [
-      ...agents.value.map((agent) => agent.name),
-      null,
-    ];
+    const options: AgentChoice[] = [...chips.map((chip) => chip.id), null];
     const current =
       effectiveAgent === null
         ? options.length - 1
@@ -361,8 +396,8 @@ export function OpenBoard({
       return true;
     }
     const index = Number(key) - 1;
-    if (index >= 0 && index < agents.value.length) {
-      selectedAgent.value = agents.value[index].name;
+    if (index >= 0 && index < chips.length) {
+      selectedAgent.value = chips[index].id;
       section.value = "agent";
       return true;
     }
@@ -484,7 +519,7 @@ export function OpenBoard({
     const combo = [
       preset?.name ?? null,
       typeof recent.lastAgent === "string"
-        ? agentLabel(recent.lastAgent)
+        ? agentLabel(recent.lastAgent, customAgents)
         : null,
     ]
       .filter((part): part is string => part !== null)
@@ -724,22 +759,38 @@ export function OpenBoard({
               <span class="sect__hint">Runs in every pane</span>
             </div>
             <div class="agents">
-              {agents.value.map((agent, index) => {
-                const logo = agentLogo(agent.name);
+              {chips.map((chip, index) => {
+                const avatar =
+                  chip.logo === undefined
+                    ? letterAvatar(chip.label, chip.id)
+                    : null;
                 return (
                   <button
-                    key={agent.name}
-                    class={`achip ${effectiveAgent === agent.name ? "is-selected" : ""}`}
-                    title={agent.path}
+                    key={chip.id}
+                    class={`achip ${effectiveAgent === chip.id ? "is-selected" : ""} ${chip.missing ? "is-missing" : ""}`}
+                    title={
+                      chip.missing
+                        ? `${chip.detail} — not on $PATH`
+                        : chip.detail
+                    }
                     onClick={() => {
-                      selectedAgent.value = agent.name;
+                      selectedAgent.value = chip.id;
                       section.value = "agent";
                     }}
                     onDblClick={() => void confirmOpen()}
                   >
                     <kbd>{index + 1}</kbd>
-                    {logo && <img class="achip__logo" src={logo} alt="" />}
-                    {agentLabel(agent.name)}
+                    {chip.logo !== undefined ? (
+                      <img class="achip__logo" src={chip.logo} alt="" />
+                    ) : (
+                      <span
+                        class="achip__letter"
+                        style={{ color: `var(--${avatar?.color})` }}
+                      >
+                        {avatar?.letter}
+                      </span>
+                    )}
+                    {chip.label}
                   </button>
                 );
               })}
@@ -773,7 +824,7 @@ export function OpenBoard({
                   <strong>
                     {effectiveAgent === null
                       ? "Shell"
-                      : agentLabel(effectiveAgent)}
+                      : agentLabel(effectiveAgent, customAgents)}
                   </strong>
                 </>
               ) : (

--- a/src/settings/settings-schema.test.ts
+++ b/src/settings/settings-schema.test.ts
@@ -114,3 +114,58 @@ describe("scrollback", () => {
     expect(validateSettings({ scrollback: 5000 }).scrollback).toBe(5000);
   });
 });
+
+describe("customAgents", () => {
+  const valid = {
+    id: "custom:aider",
+    label: "Aider",
+    command: "aider --model sonnet",
+  };
+
+  it("defaults to none declared", () => {
+    expect(DEFAULT_SETTINGS.customAgents).toEqual([]);
+    expect(validateSettings({}).customAgents).toEqual([]);
+  });
+
+  it("falls back to none when the stored value is not an array", () => {
+    expect(validateSettings({ customAgents: "aider" }).customAgents).toEqual(
+      [],
+    );
+  });
+
+  it("keeps a well-formed entry verbatim", () => {
+    expect(validateSettings({ customAgents: [valid] }).customAgents).toEqual([
+      valid,
+    ]);
+  });
+
+  it("drops an entry whose binary a shell would act on", () => {
+    // The stored file is user-writable, so this is a real input path — not
+    // only what the settings form produced.
+    const evil = { ...valid, id: "custom:evil", command: "x; rm -rf ~" };
+    expect(
+      validateSettings({ customAgents: [valid, evil] }).customAgents,
+    ).toEqual([valid]);
+  });
+
+  it("drops entries with a missing id prefix, blank label or blank command", () => {
+    const broken = [
+      { ...valid, id: "aider" },
+      { ...valid, id: "custom:" },
+      { ...valid, id: "custom:blank", label: "   " },
+      { ...valid, id: "custom:long", label: "l".repeat(33) },
+      { ...valid, id: "custom:nocmd", command: "  " },
+      { id: "custom:partial", label: "Partial" },
+      null,
+      "aider",
+    ];
+    expect(validateSettings({ customAgents: broken }).customAgents).toEqual([]);
+  });
+
+  it("keeps the first of two entries sharing an id", () => {
+    const clash = { ...valid, label: "Aider clone" };
+    expect(
+      validateSettings({ customAgents: [valid, clash] }).customAgents,
+    ).toEqual([valid]);
+  });
+});

--- a/src/settings/settings-schema.ts
+++ b/src/settings/settings-schema.ts
@@ -1,4 +1,11 @@
 import { isEditorId, type EditorId } from "../lib/editor-command";
+import {
+  agentBinary,
+  AGENT_LABEL_MAX,
+  CUSTOM_ID_PREFIX,
+  isProbeSafeName,
+  type CustomAgent,
+} from "../lib/agent-catalog";
 
 export interface TerminalColors {
   background: string;
@@ -25,6 +32,8 @@ export interface Settings {
   editorCommand: string;
   /** Lines of scrollback kept per pane. */
   scrollback: number;
+  /** Agent CLIs the user declared, beyond the built-in set. */
+  customAgents: readonly CustomAgent[];
 }
 
 export const FONT_SIZE_MIN = 10;
@@ -57,6 +66,7 @@ export const DEFAULT_SETTINGS: Settings = {
   editorId: "vscode",
   editorCommand: "",
   scrollback: 10_000,
+  customAgents: [],
 };
 
 const HEX_COLOR = /^#[0-9a-fA-F]{6}$/;
@@ -90,6 +100,62 @@ function validateColorOverrides(raw: unknown): Partial<TerminalColors> {
     if (isHexColor(value)) {
       result[key] = value;
     }
+  }
+  return result;
+}
+
+/**
+ * Whether one declared agent is well-formed. Shared with the settings UI so
+ * that what the form accepts and what survives a reload cannot drift apart.
+ * The binary check is the security-relevant one: it is what the discovery
+ * probe interpolates into a shell.
+ */
+export function isValidCustomAgent(value: unknown): value is CustomAgent {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const agent = value as Record<string, unknown>;
+  if (
+    typeof agent.id !== "string" ||
+    !agent.id.startsWith(CUSTOM_ID_PREFIX) ||
+    agent.id.length <= CUSTOM_ID_PREFIX.length
+  ) {
+    return false;
+  }
+  if (
+    typeof agent.label !== "string" ||
+    agent.label.trim() === "" ||
+    agent.label.length > AGENT_LABEL_MAX
+  ) {
+    return false;
+  }
+  return (
+    typeof agent.command === "string" &&
+    isProbeSafeName(agentBinary(agent.command))
+  );
+}
+
+/**
+ * A malformed entry is dropped rather than repaired — a half-understood
+ * command is exactly the thing not to guess at, since it ends up typed into a
+ * shell. A malformed array falls back to none declared.
+ */
+function validateCustomAgents(raw: unknown): readonly CustomAgent[] {
+  if (!Array.isArray(raw)) {
+    return DEFAULT_SETTINGS.customAgents;
+  }
+  const seen = new Set<string>();
+  const result: CustomAgent[] = [];
+  for (const entry of raw) {
+    if (!isValidCustomAgent(entry) || seen.has(entry.id)) {
+      continue;
+    }
+    seen.add(entry.id);
+    result.push({
+      id: entry.id,
+      label: entry.label,
+      command: entry.command,
+    });
   }
   return result;
 }
@@ -141,5 +207,6 @@ export function validateSettings(raw: unknown): Settings {
       Number.isFinite(source.scrollback)
         ? clampScrollback(source.scrollback)
         : DEFAULT_SETTINGS.scrollback,
+    customAgents: validateCustomAgents(source.customAgents),
   };
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1339,6 +1339,68 @@ button.attn-mark:hover {
   font-size: 11.5px;
 }
 
+/* ── Editable list rows (DL-12) ──────────────────────────── */
+
+/* An item row differs from a config row in one way: its key is editable too,
+   so both sides are inputs and the destructive affordance follows the value
+   (DL-12.2). Everything else — hover bar, spacing, hairline — is inherited. */
+.cfg-row--item > .cfg-row__key {
+  flex: 0 1 40%;
+  min-width: 0;
+}
+
+.cfg-row--item .text-input {
+  width: 100%;
+  min-width: 160px;
+}
+
+/* The key at rest reads as a plain row label; it only looks interactive on
+   hover, so a list of items still scans like a list of rows (DL-12.1). */
+.cfg-row__label--edit {
+  border: none;
+  background: none;
+  padding: 0;
+  font: inherit;
+  font-size: 12.5px;
+  color: var(--text-primary);
+  text-align: left;
+  cursor: text;
+}
+
+.cfg-row__label--edit:hover {
+  color: var(--accent);
+}
+
+.cfg-row__label--edit:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.cfg-row__remove {
+  flex: none;
+  margin-left: 8px;
+  padding: 0 4px;
+  border: none;
+  background: none;
+  font: inherit;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--text-faint);
+  cursor: pointer;
+  transition: color 0.16s ease;
+}
+
+.cfg-row__remove:hover {
+  color: var(--red);
+}
+
+.cfg-row__remove:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 /* Reduced motion: kill every chrome transition by scope, not by an allowlist —
    an allowlist silently misses each new class (DL-1.5). */
 @media (prefers-reduced-motion: reduce) {
@@ -2049,6 +2111,24 @@ button.attn-mark:hover {
   height: 15px;
   flex: none;
   display: block;
+}
+/* Declared agents ship no brand mark, so they wear the same letter avatar the
+   workspace rail uses (lib/letter-avatar.ts) rather than a generic glyph. */
+.achip__letter {
+  width: 15px;
+  height: 15px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+}
+/* Declared, but its binary is not on $PATH. Still selectable — the footer says
+   what will happen — so this dims rather than disables (DL-3.2). */
+.achip.is-missing {
+  color: var(--text-faint);
+  border-style: dashed;
 }
 .achip.is-shell {
   color: var(--text-muted);

--- a/src/terminal/pty-client.ts
+++ b/src/terminal/pty-client.ts
@@ -28,8 +28,12 @@ export interface PtyClient {
    * tab that claims a folder its shells are not actually in.
    */
   dirsExist(paths: readonly string[]): Promise<boolean[]>;
-  /** Agent CLIs found on the login shell's `$PATH` (allowlist order). */
-  detectAgents(): Promise<DetectedAgent[]>;
+  /**
+   * Which of `names` are on the login shell's `$PATH`, in probe order.
+   * Rust always probes the built-ins on top of whatever is passed, and
+   * re-filters every name — see `probe_names` in agents.rs.
+   */
+  detectAgents(names: readonly string[]): Promise<DetectedAgent[]>;
   confirmQuit(): Promise<void>;
   listenOutput(
     handler: (id: number, data: string) => void,
@@ -81,8 +85,8 @@ export function createTauriPtyClient(): PtyClient {
       }
       return invoke<boolean[]>("dirs_exist", { paths: [...paths] });
     },
-    detectAgents() {
-      return invoke<DetectedAgent[]>("detect_agents");
+    detectAgents(names) {
+      return invoke<DetectedAgent[]>("detect_agents", { names: [...names] });
     },
     confirmQuit() {
       return invoke("confirm_quit");
@@ -159,8 +163,13 @@ export function createMemoryPtyClient(
       const dirs = options.dirs;
       return paths.map((path) => dirs === undefined || dirs.includes(path));
     },
-    async detectAgents() {
-      return [...(options.agents ?? [])];
+    async detectAgents(names) {
+      // Mirrors the real backend: it answers only about what was probed, so a
+      // test that declares an agent has to pass its binary to see it back.
+      const probed = new Set(names);
+      return [...(options.agents ?? [])].filter((agent) =>
+        probed.has(agent.name),
+      );
     },
     async confirmQuit() {},
     async listenOutput(handler) {

--- a/src/terminal/tab-manager.ts
+++ b/src/terminal/tab-manager.ts
@@ -16,6 +16,7 @@ import { normalizeWorkspacePath, workspaceLabel } from "../lib/workspace-label";
 import { sendAgentNotification } from "../lib/native-notification";
 import { getDesktopEnvironment } from "../lib/platform";
 import type { AgentChoice } from "../lib/workspace-recents";
+import { resolveAgentCommand } from "../lib/agent-catalog";
 import {
   MACOS_KEYMAP,
   matchBinding,
@@ -735,8 +736,19 @@ export function createTabManager(
     selectTab(tabs.length - 1);
     void poller.poll();
     // Each pane types its agent once its shell prints the first byte; `null`
-    // (Shell only / reopen) arms nothing.
-    launcher.arm(entry.manager.paneIds(), intent.agent ?? null);
+    // (Shell only / reopen) arms nothing. The id becomes a command line HERE
+    // rather than inside the launcher: `arm` still takes a plain string and
+    // writes it verbatim, so its readiness/timeout state machine stays out of
+    // the catalog's business. A declared agent deleted since the workspace
+    // remembered it resolves to null and arms nothing — an empty shell, not a
+    // pane that types a stale command.
+    const agentId = intent.agent ?? null;
+    launcher.arm(
+      entry.manager.paneIds(),
+      agentId === null
+        ? null
+        : resolveAgentCommand(agentId, settings.value.customAgents),
+    );
     return true;
   }
 

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -16,6 +16,7 @@ import { deriveChromeColors } from "../lib/derive-colors";
 import { resolveCwds, type Preset } from "../lib/preset-schema";
 import { resolveInheritedCwds } from "../terminal/tab-materialize";
 import { settings, updateSettings } from "../settings/settings-store";
+import { agentOptions, probeNames } from "../lib/agent-catalog";
 import { resolveTheme } from "../settings/themes";
 import { isShortcutAction } from "../terminal/keymap";
 import { createTabManager, type TabManager } from "../terminal/tab-manager";
@@ -440,8 +441,9 @@ export function App() {
       }
       // A preset created from the board opens like Open does: first detected
       // agent by default (Shell is opt-in, and only the board offers the opt).
-      const agents = await defaultPtyClient
-        .detectAgents()
+      const customAgents = settings.value.customAgents;
+      const detected = await defaultPtyClient
+        .detectAgents(probeNames(customAgents))
         .catch((err: unknown) => {
           console.warn("detect_agents failed:", err);
           return [];
@@ -449,7 +451,7 @@ export function App() {
       await handleOpen(
         request.workspace,
         preset,
-        resolveAgentChoice(undefined, agents),
+        resolveAgentChoice(undefined, agentOptions(detected, customAgents)),
       );
       return;
     }

--- a/src/ui/controls/commit-input.tsx
+++ b/src/ui/controls/commit-input.tsx
@@ -7,6 +7,12 @@ interface CommitInputProps {
   ariaLabel: string;
   /** Called with the trimmed draft on blur or Enter — never per keystroke. */
   onCommit: (value: string) => void;
+  /**
+   * Focus on mount. For a field that only exists while editing (DL-12.5): the
+   * click that revealed it landed on the pill, not on the input, so without
+   * this the user has to click twice.
+   */
+  autoFocus?: boolean;
 }
 
 /**
@@ -23,6 +29,7 @@ export function CommitInput({
   placeholder,
   ariaLabel,
   onCommit,
+  autoFocus = false,
 }: CommitInputProps) {
   const [draft, setDraft] = useState(value);
   const committed = useRef(value);
@@ -51,6 +58,7 @@ export function CommitInput({
       class="text-input text-input--small"
       placeholder={placeholder}
       aria-label={ariaLabel}
+      autofocus={autoFocus}
       value={draft}
       onInput={(event) => setDraft(event.currentTarget.value)}
       onBlur={commit}

--- a/src/ui/settings/active-category-store.ts
+++ b/src/ui/settings/active-category-store.ts
@@ -10,6 +10,7 @@ export type CategoryId =
   | "appearance"
   | "colors"
   | "terminal"
+  | "agents"
   | "links-editor"
   | "notifications";
 

--- a/src/ui/settings/sections/agents-section.test.tsx
+++ b/src/ui/settings/sections/agents-section.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The section pulls in the Tauri-backed settings store; stub it so the
+// component tree mounts under jsdom.
+vi.mock("@tauri-apps/plugin-store", () => ({
+  Store: {
+    load: vi.fn(async () => ({
+      get: vi.fn(async () => undefined),
+      set: vi.fn(async () => {}),
+      save: vi.fn(async () => {}),
+    })),
+  },
+}));
+
+import { AgentsSection } from "./agents-section";
+import { settings, updateSettings } from "../../../settings/settings-store";
+import { DEFAULT_SETTINGS } from "../../../settings/settings-schema";
+import { BUILTIN_AGENTS } from "../../../lib/agent-catalog";
+
+describe("AgentsSection", () => {
+  let host: HTMLDivElement;
+
+  beforeEach(() => {
+    settings.value = DEFAULT_SETTINGS;
+    host = document.createElement("div");
+    document.body.appendChild(host);
+  });
+
+  afterEach(() => {
+    act(() => {
+      render(null, host);
+    });
+    host.remove();
+    settings.value = DEFAULT_SETTINGS;
+  });
+
+  const mount = (): void => {
+    act(() => {
+      render(<AgentsSection />, host);
+    });
+  };
+
+  const click = (element: Element): void => {
+    act(() => {
+      element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+  };
+
+  const type = (input: HTMLInputElement, value: string): void => {
+    act(() => {
+      input.value = value;
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  };
+
+  const draftInputs = (): HTMLInputElement[] =>
+    Array.from(
+      host.querySelectorAll<HTMLInputElement>(
+        '[aria-label="New agent name"], [aria-label="New agent command"]',
+      ),
+    );
+
+  // The add pill is the LAST enabled one: every declared row also carries an
+  // enabled pill for its command.
+  const addButton = (): HTMLButtonElement =>
+    Array.from(host.querySelectorAll<HTMLButtonElement>(".cfg-btn"))
+      .filter((button) => !button.disabled)
+      .pop()!;
+
+  /** Open a declared row's key or value for editing (DL-12.5) and return it. */
+  const openField = (trigger: string, ariaLabel: string): HTMLInputElement => {
+    const button = Array.from(
+      host.querySelectorAll<HTMLButtonElement>(
+        ".cfg-row--item .cfg-row__label--edit, .cfg-row--item .cfg-btn",
+      ),
+    ).find((candidate) => candidate.textContent?.trim() === trigger)!;
+    click(button);
+    return host.querySelector<HTMLInputElement>(`[aria-label="${ariaLabel}"]`)!;
+  };
+
+  const declare = (label: string, command: string): void => {
+    click(addButton());
+    const [name, cmd] = draftInputs();
+    type(name, label);
+    type(cmd, command);
+    click(addButton());
+  };
+
+  it("lists every built-in as a locked row (DL-12.4)", () => {
+    mount();
+    const locked = Array.from(
+      host.querySelectorAll<HTMLButtonElement>(".cfg-btn--disabled"),
+    );
+    expect(locked).toHaveLength(BUILTIN_AGENTS.length);
+    expect(locked.every((button) => button.disabled)).toBe(true);
+    // A built-in carries no remove affordance — only declared rows do.
+    expect(host.querySelectorAll(".cfg-row__remove")).toHaveLength(0);
+  });
+
+  it("declares an agent with a generated id", () => {
+    mount();
+    declare("Aider", "aider --model sonnet");
+
+    expect(settings.value.customAgents).toEqual([
+      { id: "custom:aider", label: "Aider", command: "aider --model sonnet" },
+    ]);
+  });
+
+  it("refuses a command whose binary would reach the shell", () => {
+    mount();
+    declare("Evil", "x; rm -rf ~");
+
+    expect(settings.value.customAgents).toEqual([]);
+    expect(host.querySelector(".cfg-custom--error")?.textContent).toContain(
+      "letters, digits",
+    );
+  });
+
+  it("refuses a name already taken by a built-in", () => {
+    mount();
+    declare("Claude Code", "aider");
+
+    expect(settings.value.customAgents).toEqual([]);
+    expect(host.querySelector(".cfg-custom--error")?.textContent).toContain(
+      "already used",
+    );
+  });
+
+  it("refuses a second agent with the same name", () => {
+    mount();
+    declare("Aider", "aider");
+    declare("Aider", "aider --fast");
+
+    expect(settings.value.customAgents).toHaveLength(1);
+  });
+
+  it("removes a declared agent", () => {
+    mount();
+    declare("Aider", "aider");
+    click(host.querySelector(".cfg-row__remove")!);
+
+    expect(settings.value.customAgents).toEqual([]);
+  });
+
+  it("keeps the id when the label is edited, so recents keep resolving", () => {
+    updateSettings({
+      customAgents: [{ id: "custom:aider", label: "Aider", command: "aider" }],
+    });
+    mount();
+
+    const nameInput = openField("Aider", "Name for Aider");
+    type(nameInput, "Aider fast");
+    act(() => {
+      nameInput.dispatchEvent(new FocusEvent("blur", { bubbles: true }));
+    });
+
+    expect(settings.value.customAgents).toEqual([
+      { id: "custom:aider", label: "Aider fast", command: "aider" },
+    ]);
+  });
+
+  it("rejects an edited command that is not probe-safe, leaving the stored one", () => {
+    updateSettings({
+      customAgents: [{ id: "custom:aider", label: "Aider", command: "aider" }],
+    });
+    mount();
+
+    const commandInput = openField("aider", "Command for Aider");
+    type(commandInput, "$(id)");
+    act(() => {
+      commandInput.dispatchEvent(new FocusEvent("blur", { bubbles: true }));
+    });
+
+    expect(settings.value.customAgents[0].command).toBe("aider");
+  });
+});

--- a/src/ui/settings/sections/agents-section.tsx
+++ b/src/ui/settings/sections/agents-section.tsx
@@ -1,0 +1,276 @@
+import { useSignal } from "@preact/signals";
+import {
+  agentBinary,
+  AGENT_LABEL_MAX,
+  BUILTIN_AGENTS,
+  createCustomAgentId,
+  isProbeSafeName,
+  type CustomAgent,
+} from "../../../lib/agent-catalog";
+import { settings, updateSettings } from "../../../settings/settings-store";
+import { ConfigGroup, ConfigRow } from "../../controls/config-row";
+import { CommitInput } from "../../controls/commit-input";
+
+/**
+ * Why a declared command is rejected, or `null` when it is fine. The binary is
+ * the security-relevant part: it is interpolated into the discovery probe's
+ * shell script, so the same character class Rust enforces is enforced here to
+ * say WHY rather than let the agent silently never resolve.
+ */
+function commandProblem(command: string): string | null {
+  const binary = agentBinary(command);
+  if (binary === "") {
+    return "a command is required";
+  }
+  if (!isProbeSafeName(binary)) {
+    return "the command name may only use letters, digits and . _ - / ~ +";
+  }
+  return null;
+}
+
+function labelProblem(
+  label: string,
+  others: readonly CustomAgent[],
+): string | null {
+  const trimmed = label.trim();
+  if (trimmed === "") {
+    return "a name is required";
+  }
+  if (trimmed.length > AGENT_LABEL_MAX) {
+    return `names stay under ${AGENT_LABEL_MAX} characters`;
+  }
+  const taken =
+    others.some((agent) => agent.label === trimmed) ||
+    BUILTIN_AGENTS.some((agent) => agent.label === trimmed);
+  return taken ? "that name is already used" : null;
+}
+
+/** Which field is open for editing — one row's key or its value, never both. */
+const labelKey = (id: string): string => `${id}:label`;
+const commandKey = (id: string): string => `${id}:command`;
+
+/**
+ * The Agents category: the built-in four, locked, then every declared agent
+ * with its command — one `cfg-row` each, edited in place (DL-12).
+ */
+export function AgentsSection() {
+  const customAgents = settings.value.customAgents;
+  const editing = useSignal<string | null>(null);
+  const draftOpen = useSignal(false);
+  const draftLabel = useSignal("");
+  const draftCommand = useSignal("");
+  const draftError = useSignal<string | null>(null);
+
+  const replace = (next: readonly CustomAgent[]): void => {
+    updateSettings({ customAgents: next });
+  };
+
+  const renameAgent = (id: string, label: string): void => {
+    const others = customAgents.filter((agent) => agent.id !== id);
+    if (labelProblem(label, others) !== null) {
+      return; // CommitInput keeps the draft; the row simply does not change
+    }
+    replace(
+      customAgents.map((agent) =>
+        agent.id === id ? { ...agent, label: label.trim() } : agent,
+      ),
+    );
+  };
+
+  const retargetAgent = (id: string, command: string): void => {
+    if (commandProblem(command) !== null) {
+      return;
+    }
+    replace(
+      customAgents.map((agent) =>
+        agent.id === id ? { ...agent, command: command.trim() } : agent,
+      ),
+    );
+  };
+
+  const removeAgent = (id: string): void => {
+    replace(customAgents.filter((agent) => agent.id !== id));
+  };
+
+  const commitDraft = (): void => {
+    const label = draftLabel.value;
+    const command = draftCommand.value;
+    const problem =
+      labelProblem(label, customAgents) ?? commandProblem(command);
+    if (problem !== null) {
+      draftError.value = problem;
+      return;
+    }
+    replace([
+      ...customAgents,
+      {
+        id: createCustomAgentId(label, customAgents),
+        label: label.trim(),
+        command: command.trim(),
+      },
+    ]);
+    draftOpen.value = false;
+    draftLabel.value = "";
+    draftCommand.value = "";
+    draftError.value = null;
+  };
+
+  return (
+    <>
+      <ConfigGroup label="built in" />
+      {BUILTIN_AGENTS.map((agent) => (
+        <ConfigRow key={agent.id} label={agent.label} desc="always available">
+          <button
+            type="button"
+            class="cfg-btn cfg-btn--disabled"
+            disabled
+            title={`${agent.id} — built in, not editable`}
+          >
+            {agent.id}
+          </button>
+        </ConfigRow>
+      ))}
+
+      <ConfigGroup label="declared" />
+      {customAgents.map((agent) => (
+        <div
+          class="cfg-row cfg-row--item"
+          key={agent.id}
+          // Leaving the row commits and closes whichever field was open. A
+          // click elsewhere is how people leave a field; without this the row
+          // would stay a form until something else took focus.
+          onFocusOut={() => {
+            editing.value = null;
+          }}
+        >
+          <div class="cfg-row__key">
+            {editing.value === labelKey(agent.id) ? (
+              <CommitInput
+                value={agent.label}
+                placeholder="name"
+                ariaLabel={`Name for ${agent.label}`}
+                autoFocus
+                onCommit={(label) => renameAgent(agent.id, label)}
+              />
+            ) : (
+              <button
+                type="button"
+                class="cfg-row__label cfg-row__label--edit"
+                title="Rename"
+                onClick={() => {
+                  editing.value = labelKey(agent.id);
+                }}
+              >
+                {agent.label}
+              </button>
+            )}
+          </div>
+          <div class="cfg-row__value">
+            {editing.value === commandKey(agent.id) ? (
+              <CommitInput
+                value={agent.command}
+                placeholder="command"
+                ariaLabel={`Command for ${agent.label}`}
+                autoFocus
+                onCommit={(command) => retargetAgent(agent.id, command)}
+              />
+            ) : (
+              <button
+                type="button"
+                class="cfg-btn"
+                title={`${agent.command} — click to edit`}
+                onClick={() => {
+                  editing.value = commandKey(agent.id);
+                }}
+              >
+                {agent.command}
+              </button>
+            )}
+          </div>
+          <button
+            type="button"
+            class="cfg-row__remove"
+            aria-label={`Remove ${agent.label}`}
+            title={`Remove ${agent.label}`}
+            onClick={() => removeAgent(agent.id)}
+          >
+            ×
+          </button>
+        </div>
+      ))}
+
+      {draftOpen.value ? (
+        <>
+          <div class="cfg-row cfg-row--item">
+            <div class="cfg-row__key">
+              <input
+                type="text"
+                class="text-input text-input--small"
+                placeholder="name"
+                aria-label="New agent name"
+                value={draftLabel.value}
+                onInput={(event) => {
+                  draftLabel.value = event.currentTarget.value;
+                  draftError.value = null;
+                }}
+              />
+            </div>
+            <div class="cfg-row__value">
+              <input
+                type="text"
+                class="text-input text-input--small"
+                placeholder="aider --model sonnet"
+                aria-label="New agent command"
+                value={draftCommand.value}
+                onInput={(event) => {
+                  draftCommand.value = event.currentTarget.value;
+                  draftError.value = null;
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    commitDraft();
+                  }
+                }}
+              />
+            </div>
+            <button
+              type="button"
+              class="cfg-row__remove"
+              aria-label="Discard the new agent"
+              onClick={() => {
+                draftOpen.value = false;
+                draftError.value = null;
+              }}
+            >
+              ×
+            </button>
+          </div>
+          {draftError.value !== null && (
+            <div class="cfg-custom--error" role="status">
+              {draftError.value}
+            </div>
+          )}
+        </>
+      ) : null}
+
+      <ConfigRow
+        label="Add agent"
+        desc="a name and the command to type into each pane"
+      >
+        <button
+          type="button"
+          class="cfg-btn"
+          onClick={() => {
+            if (draftOpen.value) {
+              commitDraft();
+              return;
+            }
+            draftOpen.value = true;
+          }}
+        >
+          {draftOpen.value ? "add" : "+"}
+        </button>
+      </ConfigRow>
+    </>
+  );
+}

--- a/src/ui/settings/settings-categories.test.ts
+++ b/src/ui/settings/settings-categories.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, it } from "vitest";
 import { SETTINGS_CATEGORIES } from "./settings-categories";
 
 describe("SETTINGS_CATEGORIES", () => {
-  it("lists exactly the five navigable categories, in rail display order", () => {
+  it("lists exactly the six navigable categories, in rail display order", () => {
     const ids: readonly string[] = SETTINGS_CATEGORIES.map((c) => c.id);
     expect(ids).toEqual([
       "appearance",
       "colors",
       "terminal",
+      "agents",
       "links-editor",
       "notifications",
     ]);

--- a/src/ui/settings/settings-categories.ts
+++ b/src/ui/settings/settings-categories.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from "preact";
 import type { CategoryId } from "./active-category-store";
 import {
+  AgentsIcon,
   AppearanceIcon,
   ColorsIcon,
   LinksEditorIcon,
@@ -10,6 +11,7 @@ import {
 import { AppearanceSection } from "./sections/appearance-section";
 import { ColorsSection } from "./sections/colors-section";
 import { TerminalSection } from "./sections/terminal-section";
+import { AgentsSection } from "./sections/agents-section";
 import { LinksEditorSection } from "./sections/links-editor-section";
 import { NotificationsSection } from "./sections/notifications-section";
 
@@ -35,7 +37,7 @@ export interface SettingsCategory {
 }
 
 /**
- * The five navigable rail categories, in display order — the extension point
+ * The six navigable rail categories, in display order — the extension point
  * for a future category (agent config, keybindings) is one entry here plus
  * one file under `sections/`, no edit to `settings-screen.tsx`.
  *
@@ -56,6 +58,7 @@ export const SETTINGS_CATEGORIES: readonly SettingsCategory[] = [
     Icon: TerminalIcon,
     Section: TerminalSection,
   },
+  { id: "agents", label: "agents", Icon: AgentsIcon, Section: AgentsSection },
   {
     id: "links-editor",
     label: "links & editor",

--- a/src/ui/settings/settings-nav-icons.tsx
+++ b/src/ui/settings/settings-nav-icons.tsx
@@ -103,3 +103,24 @@ export function NotificationsIcon() {
     </svg>
   );
 }
+
+export function AgentsIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="4.5" y="7" width="15" height="12" rx="2.5" />
+      <path d="M12 3.5v3.5" />
+      <path d="M9.5 12.5v1.5" />
+      <path d="M14.5 12.5v1.5" />
+    </svg>
+  );
+}

--- a/src/ui/settings/settings-nav.test.tsx
+++ b/src/ui/settings/settings-nav.test.tsx
@@ -51,10 +51,10 @@ describe("SettingsNav", () => {
   const getTabs = (): HTMLButtonElement[] =>
     Array.from(host.querySelectorAll('[role="tab"]'));
 
-  it("renders exactly the five categories as tabs, in registry order", () => {
+  it("renders every registered category as a tab, in registry order", () => {
     mount();
     const tabs = getTabs();
-    expect(tabs).toHaveLength(5);
+    expect(tabs).toHaveLength(SETTINGS_CATEGORIES.length);
     expect(tabs.map((tab) => tab.textContent)).toEqual(
       SETTINGS_CATEGORIES.map((category) => category.label),
     );
@@ -88,10 +88,10 @@ describe("SettingsNav", () => {
     activeCategory.value = "notifications"; // last category
     mount();
     const tabs = getTabs();
-    tabs[4].focus();
+    tabs[tabs.length - 1].focus();
 
     act(() => {
-      tabs[4].dispatchEvent(
+      tabs[tabs.length - 1].dispatchEvent(
         new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
       );
     });
@@ -113,17 +113,17 @@ describe("SettingsNav", () => {
     });
 
     expect(activeCategory.value).toBe("notifications");
-    expect(document.activeElement).toBe(tabs[4]);
+    expect(document.activeElement).toBe(tabs[tabs.length - 1]);
   });
 
-  it("renders the reset action once, outside the five tabs, and clicking it does not change activeCategory", () => {
+  it("renders the reset action once, outside the tabs, and clicking it does not change activeCategory", () => {
     mount();
     const resetButtons = host.querySelectorAll(".cfg-btn--danger");
     expect(resetButtons).toHaveLength(1);
 
     const resetButton = resetButtons[0] as HTMLButtonElement;
     expect(resetButton.getAttribute("role")).not.toBe("tab");
-    expect(getTabs()).toHaveLength(5);
+    expect(getTabs()).toHaveLength(SETTINGS_CATEGORIES.length);
 
     act(() => {
       resetButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));

--- a/src/ui/settings/settings-screen.test.tsx
+++ b/src/ui/settings/settings-screen.test.tsx
@@ -130,6 +130,12 @@ const EXPECTED_ROWS = [
   "Selection",
   // terminal
   "Scrollback",
+  // agents (built-ins are locked rows; declared ones are added by the user)
+  "Claude Code",
+  "Codex",
+  "Gemini CLI",
+  "OpenCode",
+  "Add agent",
   // links & editor
   "Editor",
   // notifications
@@ -154,7 +160,7 @@ describe("SettingsScreen — every setting survived the move", () => {
     });
   });
 
-  it("reaches all 14 rows by walking the rail", () => {
+  it("reaches all 19 rows by walking the rail", () => {
     act(() => {
       render(<SettingsScreen open onClose={vi.fn()} />, host);
     });


### PR DESCRIPTION
`M2` from the [settings spec](docs/specs/2026-08-02-settings-full-window-design.md) — an agent becomes a **label plus a full command line**, declared in a new Settings category and offered in the Open board beside the built-in four.

Spec: [`docs/specs/2026-08-04-user-declared-agents-design.md`](docs/specs/2026-08-04-user-declared-agents-design.md)

## What changes

- **New `agents` settings category** — built-ins listed locked, declared agents added/renamed/retargeted/removed in place.
- **Open board** — declared agents appear as chips with a letter avatar, selectable by click and digit key, remembered per workspace. One whose binary left `$PATH` stays visible, marked, and the footer says what will happen.
- **`detect_agents(names)`** replaces the compile-time allowlist. Rust always probes the built-ins on top of whatever the caller sends.
- **DESIGN-LANGUAGE §12 (editable lists)** — §5 allows one control per row and forbids list widgets, which an add/remove list cannot satisfy. Approved as a fork on 2026-08-04.

## No migration

Built-in ids stay identical to their binary names (`claude` → `claude`), declared ones are `custom:<slug>`. Every `lastAgent` already in workspace recents keeps resolving; ids are frozen at creation so renaming an agent does not make a workspace forget it.

## The security-relevant part

macOS discovery interpolates each probed name into `sh -ilc "command -v <name>"`. That was safe while the names were a compile-time constant; once a user supplies them it is a command-injection sink. `is_probe_safe` restricts names to `A–Z a–z 0–9 . _ - / ~ +`, enforced **in Rust as well as the UI** — the frontend is not the trust boundary, and Rust drops unsafe names rather than trusting the caller.

A command's *arguments* are deliberately not escaped: they are written into the user's own interactive shell, exactly as typing them by hand would be. Deck is a terminal.

## Not touched

`agent-launch.ts`. `tab-manager` resolves an id to a command at the call site, so `arm()` still takes a plain string and its readiness/timeout state machine stays out of the catalog's business.

## Verification

```
npm test      → 80 files, 938 tests passed   (+33 new)
npm run build → ✓ built (tsc + vite)
cargo test    → 132 passed; 0 failed
```

Screenshot of the Agents section eye-reviewed against §12 — the first pass rendered declared rows as a permanent two-field form, which did not read as a list beside the built-in rows; it now shows label + pill at rest and only becomes a field on click (DL-12.5).

https://claude.ai/code/session_013HT6U2dQUhAc8ZywFFM75F

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent discovery IPC and a Rust shell-interpolation security boundary, plus the path from stored agent id to PTY input; mitigated by dual validation, frozen ids, and broad tests, but regressions could affect picker, launch, or probe safety.
> 
> **Overview**
> Adds **user-declared agents**: a display label plus a full command line, managed in a new **agents** Settings category and offered on the Open board next to the built-in four.
> 
> **Settings & persistence** — `customAgents` is validated on load (drop bad rows, probe-safe binary only). Built-ins stay locked rows; declared agents use **DESIGN-LANGUAGE §12** (editable `cfg-row` list, in-place edit, `×` remove). Stable ids are `custom:<slug>`; built-in ids stay the binary name so existing `lastAgent` recents need **no migration**.
> 
> **Open board & launch** — Chips come from `agentOptions()` (detected built-ins, then all custom agents). Custom entries use letter avatars; missing binaries stay visible with dashed styling and a footer warning. `tab-manager` resolves the stored **id** to a command via `resolveAgentCommand` before `launcher.arm()`; `agent-launch.ts` is unchanged.
> 
> **Discovery (Rust + IPC)** — `detect_agents(names)` replaces a fixed allowlist: Rust always probes built-ins and merges caller names through `probe_names` / `is_probe_safe` (macOS `sh -ilc` injection boundary). Windows discovery matches requested names by normalized basename. Frontend passes `probeNames(customAgents)` and re-probes when settings change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ca1758cb2549d25664a5509db5e1b2d536b11c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Agents settings section for managing built-in and custom agents.
  * Custom agents can be added, edited, removed, and selected from the Open Board.
  * Missing agent tools remain selectable with clear availability warnings.
  * Agent discovery now supports configured custom commands across supported platforms.

* **Bug Fixes**
  * Improved agent selection compatibility and fallback behavior.
  * Production builds now use Terser to avoid a terminal startup failure.

* **Documentation**
  * Documented editable-list design guidelines and the approved custom-agent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->