### PR TITLE
fix(terminal): restore Codex wheel scrolling

### DIFF
--- a/src/terminal/codex-wheel.test.ts
+++ b/src/terminal/codex-wheel.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CODEX_PAGE_DOWN,
+  CODEX_PAGE_UP,
+  createCodexWheelHandler,
+} from "./codex-wheel";
+
+interface WheelFixture {
+  readonly event: WheelEvent;
+  readonly preventDefault: ReturnType<typeof vi.fn>;
+  readonly stopImmediatePropagation: ReturnType<typeof vi.fn>;
+}
+
+function wheel(
+  deltaY: number,
+  options: {
+    deltaMode?: number;
+    ctrlKey?: boolean;
+    shiftKey?: boolean;
+    altKey?: boolean;
+    metaKey?: boolean;
+  } = {},
+): WheelFixture {
+  const preventDefault = vi.fn();
+  const stopImmediatePropagation = vi.fn();
+  return {
+    event: {
+      deltaY,
+      deltaMode: options.deltaMode ?? 1,
+      ctrlKey: options.ctrlKey ?? false,
+      shiftKey: options.shiftKey ?? false,
+      altKey: options.altKey ?? false,
+      metaKey: options.metaKey ?? false,
+      preventDefault,
+      stopImmediatePropagation,
+    } as unknown as WheelEvent,
+    preventDefault,
+    stopImmediatePropagation,
+  };
+}
+
+function setup(platform: "windows" | "macos" = "windows") {
+  let agent: string | null = "codex";
+  const send = vi.fn();
+  const handler = createCodexWheelHandler({
+    platform,
+    isCodex: () => agent === "codex",
+    send,
+  });
+  return {
+    handler,
+    send,
+    setAgent(next: string | null) {
+      agent = next;
+    },
+  };
+}
+
+describe("createCodexWheelHandler", () => {
+  it("maps Windows Codex wheel directions to PageUp and PageDown", () => {
+    const { handler, send } = setup();
+    const up = wheel(-3);
+    const down = wheel(3);
+
+    expect(handler(up.event)).toBe(false);
+    expect(handler(down.event)).toBe(false);
+
+    expect(send).toHaveBeenNthCalledWith(1, CODEX_PAGE_UP);
+    expect(send).toHaveBeenNthCalledWith(2, CODEX_PAGE_DOWN);
+    expect(up.preventDefault).toHaveBeenCalledOnce();
+    expect(up.stopImmediatePropagation).toHaveBeenCalledOnce();
+    expect(down.preventDefault).toHaveBeenCalledOnce();
+    expect(down.stopImmediatePropagation).toHaveBeenCalledOnce();
+  });
+
+  it("accumulates small Windows touchpad deltas before sending one page", () => {
+    const { handler, send } = setup();
+
+    for (const delta of [8, 8, 8, 8]) {
+      expect(handler(wheel(delta, { deltaMode: 0 }).event)).toBe(false);
+    }
+    expect(send).not.toHaveBeenCalled();
+
+    expect(handler(wheel(8, { deltaMode: 0 }).event)).toBe(false);
+    expect(send).toHaveBeenCalledOnce();
+    expect(send).toHaveBeenCalledWith(CODEX_PAGE_DOWN);
+  });
+
+  it("resets a partial touchpad gesture when direction reverses", () => {
+    const { handler, send } = setup();
+
+    handler(wheel(24, { deltaMode: 0 }).event);
+    handler(wheel(-24, { deltaMode: 0 }).event);
+    expect(send).not.toHaveBeenCalled();
+
+    handler(wheel(-16, { deltaMode: 0 }).event);
+    expect(send).toHaveBeenCalledOnce();
+    expect(send).toHaveBeenCalledWith(CODEX_PAGE_UP);
+  });
+
+  it("leaves macOS, other agents, zero deltas and modified wheels to xterm", () => {
+    const mac = setup("macos");
+    expect(mac.handler(wheel(-3).event)).toBe(true);
+    expect(mac.send).not.toHaveBeenCalled();
+
+    const windows = setup();
+    windows.setAgent("opencode");
+    expect(windows.handler(wheel(-3).event)).toBe(true);
+    windows.setAgent("codex");
+    expect(windows.handler(wheel(0).event)).toBe(true);
+    expect(windows.handler(wheel(-3, { ctrlKey: true }).event)).toBe(true);
+    expect(windows.handler(wheel(-3, { shiftKey: true }).event)).toBe(true);
+    expect(windows.handler(wheel(-3, { altKey: true }).event)).toBe(true);
+    expect(windows.handler(wheel(-3, { metaKey: true }).event)).toBe(true);
+    expect(windows.send).not.toHaveBeenCalled();
+  });
+});

--- a/src/terminal/codex-wheel.ts
+++ b/src/terminal/codex-wheel.ts
@@ -1,0 +1,70 @@
+import type { DesktopPlatform } from "../lib/platform";
+
+export const CODEX_PAGE_UP = "\x1b[5~";
+export const CODEX_PAGE_DOWN = "\x1b[6~";
+
+const DOM_DELTA_PIXEL = 0;
+const PIXEL_PAGE_THRESHOLD = 40;
+
+interface CodexWheelDeps {
+  readonly platform: DesktopPlatform;
+  readonly isCodex: () => boolean;
+  readonly send: (data: string) => void;
+}
+
+/**
+ * Codex's Windows TUI uses the alternate screen but does not consistently
+ * consume xterm/WebView2 mouse-wheel reports. Keyboard PageUp/PageDown still
+ * drive its internal transcript pager, so translate an unmodified wheel only
+ * while the pane is explicitly classified as Codex.
+ *
+ * Returning false stops xterm from also translating the same gesture to arrow
+ * keys or an SGR mouse report. Pixel-mode touchpad events are accumulated to
+ * avoid turning every tiny delta into a whole-page jump.
+ */
+export function createCodexWheelHandler(
+  deps: CodexWheelDeps,
+): (event: WheelEvent) => boolean {
+  let pixelRemainder = 0;
+
+  return (event) => {
+    const modified =
+      event.ctrlKey || event.shiftKey || event.altKey || event.metaKey;
+    if (
+      deps.platform !== "windows" ||
+      !deps.isCodex() ||
+      modified ||
+      event.deltaY === 0
+    ) {
+      pixelRemainder = 0;
+      return true;
+    }
+
+    let sequence: string | null = null;
+    if (event.deltaMode === DOM_DELTA_PIXEL) {
+      if (
+        pixelRemainder !== 0 &&
+        Math.sign(pixelRemainder) !== Math.sign(event.deltaY)
+      ) {
+        pixelRemainder = 0;
+      }
+      pixelRemainder += event.deltaY;
+      if (Math.abs(pixelRemainder) >= PIXEL_PAGE_THRESHOLD) {
+        sequence = pixelRemainder < 0 ? CODEX_PAGE_UP : CODEX_PAGE_DOWN;
+        pixelRemainder = 0;
+      }
+    } else {
+      pixelRemainder = 0;
+      sequence = event.deltaY < 0 ? CODEX_PAGE_UP : CODEX_PAGE_DOWN;
+    }
+
+    // xterm registers a second wheel listener while a TUI has mouse tracking
+    // enabled. Stop it on this same event or the gesture can be delivered twice.
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    if (sequence !== null) {
+      deps.send(sequence);
+    }
+    return false;
+  };
+}

--- a/src/terminal/pane.ts
+++ b/src/terminal/pane.ts
@@ -13,6 +13,8 @@ import { createOscLinkHandler } from "./osc-link-handler";
 import { paneCwd } from "./pane-cwd";
 import { classifyOscNotification } from "../lib/osc-notification";
 import { copyTerminalSelection, pasteIntoTerminal } from "./terminal-clipboard";
+import { getDesktopEnvironment } from "../lib/platform";
+import { createCodexWheelHandler } from "./codex-wheel";
 
 /** Structured attention signal a pane can emit — never a native notification. */
 export interface PaneAttentionSignal {
@@ -154,6 +156,15 @@ export function createPane(
   const searchAddon = new SearchAddon();
   term.loadAddon(searchAddon);
 
+  let activeAgent: string | null = null;
+  term.attachCustomWheelEventHandler(
+    createCodexWheelHandler({
+      platform: getDesktopEnvironment().platform,
+      isCodex: () => activeAgent === "codex",
+      send: (data) => events.onData(id, data),
+    }),
+  );
+
   // Primary-modifier+click opens URLs in the browser and file paths in the
   // editor. This replaces WebLinksAddon: that one underlines and activates on
   // a plain click, which an agent TUI needs for its own mouse handling.
@@ -268,6 +279,7 @@ export function createPane(
   }
 
   function setHeaderInfo(info: PaneHeaderInfo): void {
+    activeAgent = info.agent ? info.badge : null;
     dot.style.background = info.dotColor;
     cwdEl.textContent = info.cwd;
     anchorCwd.textContent = info.cwd;


### PR DESCRIPTION
## Summary

- restore mouse-wheel and touchpad scrolling in Windows Codex panes
- translate unmodified wheel gestures to Page Up/Down only after the pane is classified as Codex
- preserve xterm's native behavior for macOS, other agents, and modified gestures

## Why

Codex uses an alternate-screen TUI whose mouse-wheel reports are not consistently consumed through xterm/WebView2 on Windows. Keyboard Page Up/Down still controls the transcript, so this adds a narrow compatibility path instead of changing terminal behavior globally.

## Testing

- `npm test` - 87 files, 983 tests passed
- `npm run build` - TypeScript and Vite production build passed
- `npm ci` audit - 0 vulnerabilities
- Windows desktop E2E - launched Codex 0.146.0 inside the installed app, sent wheel gestures in both directions, and verified the window remained responsive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved scrolling in Codex terminal panes on Windows.
  - Mouse-wheel gestures now trigger Page Up and Page Down navigation, with touchpad movements accumulated for smoother, threshold-based scrolling.
  - Regular scrolling remains unchanged on macOS, for other terminal agents, and when using modified or unsupported wheel events.
  - Handled gestures are passed directly to the terminal and no longer cause unintended page movement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## CI note

Both hosted jobs currently stop at `cargo fmt --check` on pre-existing formatting in `src-tauri/src/agents.rs` and `src-tauri/src/menu.rs`. This PR changes no Rust files; its frontend tests and production build pass before that baseline check.