### PR TITLE
feat(windows): embed native Alacritty panes

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,9 +53,12 @@ wmi = "0.18"
 windows-core = "=0.61.2"
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
+    "Win32_Graphics_Gdi",
     "Win32_Security",
     "Win32_System_JobObjects",
     "Win32_System_Threading",
+    "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_UI_WindowsAndMessaging",
 ] }
 # Already in the lock transitively via tauri; declared directly so the
 # ICoreWebView2Settings3 call has a supported path. Must stay on the same

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -13,6 +13,10 @@ pub struct AgentInfo {
 
 /// Recognised out of the box; always probed, whatever the caller asks for.
 /// Mirrors `BUILTIN_AGENTS` in src/lib/agent-catalog.ts.
+#[cfg(target_os = "windows")]
+pub(crate) const BUILTIN_AGENTS: [&str; 6] =
+    ["claude", "codex", "opencode", "agy", "gemini", "alacritty"];
+#[cfg(not(target_os = "windows"))]
 pub(crate) const BUILTIN_AGENTS: [&str; 5] = ["claude", "codex", "opencode", "agy", "gemini"];
 
 /// Upper bound on a probed name; mirrors `PROBE_NAME_MAX` in agent-catalog.ts.
@@ -43,6 +47,12 @@ pub(crate) fn probe_names(requested: Vec<String>) -> Vec<String> {
         .map(|name| (*name).to_string())
         .collect();
     for name in requested {
+        // Alacritty is a native pane renderer, not an agent command. Keep it
+        // out of non-Windows pickers, where the native embedding backend is a
+        // deliberate unsupported stub.
+        if cfg!(not(target_os = "windows")) && name == "alacritty" {
+            continue;
+        }
         if is_probe_safe(&name) && !names.iter().any(|existing| *existing == name) {
             names.push(name);
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod links;
 mod menu;
 mod menu_registry;
 mod migrate;
+mod native_terminal;
 mod platform;
 mod prompt_assets;
 mod pty;
@@ -20,8 +21,13 @@ struct QuitState {
 }
 
 #[tauri::command]
-fn confirm_quit(app: tauri::AppHandle, state: tauri::State<'_, QuitState>) {
+fn confirm_quit(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, QuitState>,
+    native: tauri::State<'_, native_terminal::NativeTerminalState>,
+) {
     state.confirmed.store(true, Ordering::SeqCst);
+    native.terminate_all();
     app.exit(0);
 }
 
@@ -46,6 +52,7 @@ pub fn run() {
     builder
         .manage(pty::PtyState::default())
         .manage(coordinator::WindowCoordinator::default())
+        .manage(native_terminal::NativeTerminalState::default())
         .manage(QuitState::default())
         .setup(|app| {
             // Before anything reads the store: the frontend loads settings
@@ -78,6 +85,12 @@ pub fn run() {
             images::scan_workspace_favicon,
             links::resolve_paths,
             links::open_editor,
+            native_terminal::spawn_alacritty,
+            native_terminal::apply_alacritty_appearance,
+            native_terminal::perform_alacritty_action,
+            native_terminal::update_alacritty,
+            native_terminal::focus_alacritty,
+            native_terminal::kill_alacritty,
             confirm_quit
         ])
         .build(tauri::generate_context!())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -90,6 +90,7 @@ pub fn run() {
             native_terminal::perform_alacritty_action,
             native_terminal::update_alacritty,
             native_terminal::focus_alacritty,
+            native_terminal::set_alacritty_occluded,
             native_terminal::kill_alacritty,
             confirm_quit
         ])

--- a/src-tauri/src/native_terminal.rs
+++ b/src-tauri/src/native_terminal.rs
@@ -38,8 +38,8 @@ mod imp {
     use std::path::{Path, PathBuf};
     use std::process::{Child, Command};
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
-    use std::sync::{Arc, Mutex};
-    use std::time::{Duration, Instant};
+    use std::sync::{Arc, Mutex, OnceLock};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
     use tauri::{AppHandle, Emitter, Manager, WebviewWindow};
     use windows_sys::core::BOOL;
     use windows_sys::Win32::Foundation::{HWND, LPARAM, POINT};
@@ -216,7 +216,7 @@ mod imp {
         }
         let _ = pane.child.kill();
         let _ = pane.child.wait();
-        let _ = std::fs::remove_file(pane.config_path);
+        cleanup_runtime_config(&pane.config_path);
     }
 
     fn valid_color(value: &str) -> bool {
@@ -286,10 +286,31 @@ mod imp {
             .app_local_data_dir()
             .map_err(|error| format!("Couldn't locate SpaceVibe's local data directory: {error}"))?
             .join("runtime")
+            .join(runtime_run_id())
             .join("alacritty");
         std::fs::create_dir_all(&root)
             .map_err(|error| format!("Couldn't create Alacritty runtime directory: {error}"))?;
         Ok(root.join(format!("pane-{id}.toml")))
+    }
+
+    fn runtime_run_id() -> &'static str {
+        static RUN_ID: OnceLock<String> = OnceLock::new();
+        RUN_ID.get_or_init(|| {
+            let started = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos();
+            format!("run-{}-{started:x}", std::process::id())
+        })
+    }
+
+    fn cleanup_runtime_config(path: &Path) {
+        let _ = std::fs::remove_file(path);
+        if let Some(directory) = path.parent() {
+            // Succeeds only after the last pane in this process-specific run
+            // directory closes; a non-empty directory is intentionally kept.
+            let _ = std::fs::remove_dir(directory);
+        }
     }
 
     fn write_config(path: &Path, contents: &str) -> Result<(), String> {
@@ -388,7 +409,7 @@ mod imp {
             {
                 Ok(child) => child,
                 Err(error) => {
-                    let _ = std::fs::remove_file(&config_path);
+                    cleanup_runtime_config(&config_path);
                     return Err(format!("Failed to launch Alacritty: {error}"));
                 }
             };
@@ -397,14 +418,14 @@ mod imp {
                 Err(error) => {
                     let _ = child.kill();
                     let _ = child.wait();
-                    let _ = std::fs::remove_file(&config_path);
+                    cleanup_runtime_config(&config_path);
                     return Err(error);
                 }
             };
             if let Err(error) = attach_overlay(hwnd, parent as HWND) {
                 let _ = child.kill();
                 let _ = child.wait();
-                let _ = std::fs::remove_file(&config_path);
+                cleanup_runtime_config(&config_path);
                 return Err(error);
             }
             Ok(NativePane {

--- a/src-tauri/src/native_terminal.rs
+++ b/src-tauri/src/native_terminal.rs
@@ -52,9 +52,10 @@ mod imp {
         EnumWindows, GetClassNameW, GetForegroundWindow, GetGUIThreadInfo, GetParent, GetWindow,
         GetWindowLongPtrW, GetWindowThreadProcessId, IsChild, IsWindow, IsWindowVisible,
         SetForegroundWindow, SetWindowLongPtrW, SetWindowPos, ShowWindow, GUITHREADINFO,
-        GWLP_HWNDPARENT, GWL_EXSTYLE, GWL_STYLE, GW_OWNER, SWP_FRAMECHANGED, SWP_NOACTIVATE,
-        SWP_NOZORDER, SW_HIDE, SW_SHOW, WS_CAPTION, WS_EX_APPWINDOW, WS_EX_TOOLWINDOW,
-        WS_MAXIMIZEBOX, WS_MINIMIZEBOX, WS_POPUP, WS_SYSMENU, WS_THICKFRAME,
+        GWLP_HWNDPARENT, GWL_EXSTYLE, GWL_STYLE, GW_OWNER, SWP_FRAMECHANGED, SWP_HIDEWINDOW,
+        SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER, SW_HIDE, SW_SHOW, WS_CAPTION,
+        WS_EX_APPWINDOW, WS_EX_TOOLWINDOW, WS_MAXIMIZEBOX, WS_MINIMIZEBOX, WS_POPUP, WS_SYSMENU,
+        WS_THICKFRAME,
     };
 
     const FIRST_NATIVE_PANE_ID: u32 = 0x8000_0000;
@@ -67,11 +68,20 @@ mod imp {
         config_path: PathBuf,
         config_contents: String,
         focus_monitor_alive: Arc<AtomicBool>,
+        visible: bool,
+        presentation_epoch: u64,
+    }
+
+    #[derive(Clone, Copy)]
+    struct PresentationState {
+        epoch: u64,
+        occluded: bool,
     }
 
     pub struct NativeTerminalState {
         next_id: AtomicU32,
         panes: Mutex<HashMap<u32, NativePane>>,
+        presentation: Mutex<PresentationState>,
     }
 
     impl Default for NativeTerminalState {
@@ -79,6 +89,10 @@ mod imp {
             Self {
                 next_id: AtomicU32::new(FIRST_NATIVE_PANE_ID),
                 panes: Mutex::new(HashMap::new()),
+                presentation: Mutex::new(PresentationState {
+                    epoch: 0,
+                    occluded: true,
+                }),
             }
         }
     }
@@ -211,7 +225,7 @@ mod imp {
         pane.focus_monitor_alive.store(false, Ordering::Release);
         unsafe {
             if IsWindow(pane.hwnd as HWND) != 0 {
-                ShowWindow(pane.hwnd as HWND, SW_HIDE);
+                hide_overlay(pane.hwnd as HWND);
             }
         }
         let _ = pane.child.kill();
@@ -281,15 +295,21 @@ mod imp {
     }
 
     fn runtime_config_path(app: &AppHandle, id: u32) -> Result<PathBuf, String> {
-        let root = app
+        let portable_root = std::env::current_exe()
+            .ok()
+            .and_then(|path| path.parent().map(Path::to_path_buf))
+            .map(|directory| directory.join(".spacevibe-runtime"));
+        let fallback_root = app
             .path()
             .app_local_data_dir()
             .map_err(|error| format!("Couldn't locate SpaceVibe's local data directory: {error}"))?
-            .join("runtime")
-            .join(runtime_run_id())
-            .join("alacritty");
-        std::fs::create_dir_all(&root)
-            .map_err(|error| format!("Couldn't create Alacritty runtime directory: {error}"))?;
+            .join("runtime");
+        let root = portable_root
+            .into_iter()
+            .chain(std::iter::once(fallback_root))
+            .map(|root| root.join(runtime_run_id()).join("alacritty"))
+            .find(|root| std::fs::create_dir_all(root).is_ok())
+            .ok_or_else(|| "Couldn't create Alacritty runtime directory".to_string())?;
         Ok(root.join(format!("pane-{id}.toml")))
     }
 
@@ -398,7 +418,7 @@ mod imp {
         let focus_monitor_alive = Arc::new(AtomicBool::new(true));
         let pane_monitor_alive = Arc::clone(&focus_monitor_alive);
 
-        let pane = tauri::async_runtime::spawn_blocking(move || {
+        let mut pane = tauri::async_runtime::spawn_blocking(move || {
             let mut child = match Command::new(executable)
                 .arg("--config-file")
                 .arg(&config_path)
@@ -434,11 +454,18 @@ mod imp {
                 config_path,
                 config_contents: config,
                 focus_monitor_alive: pane_monitor_alive,
+                visible: false,
+                presentation_epoch: 0,
             })
         })
         .await
         .map_err(|error| format!("Alacritty launch task failed: {error}"))??;
 
+        let presentation = *state
+            .presentation
+            .lock()
+            .map_err(|_| "Native terminal presentation state is unavailable".to_string())?;
+        pane.presentation_epoch = presentation.epoch;
         let hwnd = pane.hwnd;
         match state.panes.lock() {
             Ok(mut panes) => {
@@ -556,8 +583,16 @@ mod imp {
         id: u32,
         bounds: NativePaneBounds,
         visible: bool,
+        epoch: u64,
     ) -> Result<(), String> {
         validate_bounds(bounds)?;
+        let presentation = *state
+            .presentation
+            .lock()
+            .map_err(|_| "Native terminal presentation state is unavailable".to_string())?;
+        if epoch != presentation.epoch {
+            return Ok(());
+        }
         let scale = window.scale_factor().map_err(|error| error.to_string())?;
         let mut panes = state
             .panes
@@ -566,6 +601,10 @@ mod imp {
         let pane = panes
             .get_mut(&id)
             .ok_or_else(|| format!("Unknown native pane {id}"))?;
+        if epoch < pane.presentation_epoch {
+            return Ok(());
+        }
+        pane.presentation_epoch = epoch;
         if pane
             .child
             .try_wait()
@@ -588,8 +627,9 @@ mod imp {
             }
             return Err("The embedded Alacritty window is no longer available".to_string());
         }
-        if !visible || bounds.width < 1.0 || bounds.height < 1.0 {
-            unsafe { ShowWindow(hwnd, SW_HIDE) };
+        if presentation.occluded || !visible || bounds.width < 1.0 || bounds.height < 1.0 {
+            pane.visible = false;
+            hide_overlay(hwnd);
             return Ok(());
         }
         let x = (bounds.left * scale).round() as i32;
@@ -616,10 +656,22 @@ mod imp {
             }
             ShowWindow(hwnd, SW_SHOW);
         }
+        pane.visible = true;
         Ok(())
     }
 
-    pub fn focus(state: tauri::State<'_, NativeTerminalState>, id: u32) -> Result<(), String> {
+    pub fn focus(
+        state: tauri::State<'_, NativeTerminalState>,
+        id: u32,
+        epoch: u64,
+    ) -> Result<(), String> {
+        let presentation = *state
+            .presentation
+            .lock()
+            .map_err(|_| "Native terminal presentation state is unavailable".to_string())?;
+        if presentation.occluded || epoch != presentation.epoch {
+            return Ok(());
+        }
         let panes = state
             .panes
             .lock()
@@ -627,11 +679,59 @@ mod imp {
         let pane = panes
             .get(&id)
             .ok_or_else(|| format!("Unknown native pane {id}"))?;
+        if !pane.visible || pane.presentation_epoch != epoch {
+            return Ok(());
+        }
         let hwnd = pane.hwnd as HWND;
         unsafe {
-            ShowWindow(hwnd, SW_SHOW);
             SetForegroundWindow(hwnd);
             SetFocus(hwnd);
+        }
+        Ok(())
+    }
+
+    fn hide_overlay(hwnd: HWND) {
+        unsafe {
+            ShowWindow(hwnd, SW_HIDE);
+            SetWindowPos(
+                hwnd,
+                std::ptr::null_mut(),
+                0,
+                0,
+                0,
+                0,
+                SWP_HIDEWINDOW | SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOZORDER,
+            );
+        }
+    }
+
+    pub fn set_occluded(
+        state: tauri::State<'_, NativeTerminalState>,
+        epoch: u64,
+        occluded: bool,
+    ) -> Result<(), String> {
+        {
+            let mut presentation = state
+                .presentation
+                .lock()
+                .map_err(|_| "Native terminal presentation state is unavailable".to_string())?;
+            if epoch < presentation.epoch {
+                return Ok(());
+            }
+            presentation.epoch = epoch;
+            presentation.occluded = occluded;
+        }
+        if !occluded {
+            return Ok(());
+        }
+        let mut panes = state
+            .panes
+            .lock()
+            .map_err(|_| "Native terminal state is unavailable".to_string())?;
+        for pane in panes.values_mut() {
+            pane.presentation_epoch = epoch;
+            pane.visible = false;
+            hide_overlay(pane.hwnd as HWND);
         }
         Ok(())
     }
@@ -740,12 +840,25 @@ mod imp {
         _id: u32,
         _bounds: NativePaneBounds,
         _visible: bool,
+        _epoch: u64,
     ) -> Result<(), String> {
         Err("Native Alacritty panes are only supported on Windows".to_string())
     }
 
-    pub fn focus(_state: tauri::State<'_, NativeTerminalState>, _id: u32) -> Result<(), String> {
+    pub fn focus(
+        _state: tauri::State<'_, NativeTerminalState>,
+        _id: u32,
+        _epoch: u64,
+    ) -> Result<(), String> {
         Err("Native Alacritty panes are only supported on Windows".to_string())
+    }
+
+    pub fn set_occluded(
+        _state: tauri::State<'_, NativeTerminalState>,
+        _epoch: u64,
+        _occluded: bool,
+    ) -> Result<(), String> {
+        Ok(())
     }
 
     pub fn kill(_state: tauri::State<'_, NativeTerminalState>, _id: u32) -> Result<(), String> {
@@ -791,16 +904,27 @@ pub fn update_alacritty(
     id: u32,
     bounds: NativePaneBounds,
     visible: bool,
+    epoch: u64,
 ) -> Result<(), String> {
-    imp::update(window, state, id, bounds, visible)
+    imp::update(window, state, id, bounds, visible, epoch)
 }
 
 #[tauri::command]
 pub fn focus_alacritty(
     state: tauri::State<'_, NativeTerminalState>,
     id: u32,
+    epoch: u64,
 ) -> Result<(), String> {
-    imp::focus(state, id)
+    imp::focus(state, id, epoch)
+}
+
+#[tauri::command]
+pub fn set_alacritty_occluded(
+    state: tauri::State<'_, NativeTerminalState>,
+    epoch: u64,
+    occluded: bool,
+) -> Result<(), String> {
+    imp::set_occluded(state, epoch, occluded)
 }
 
 #[tauri::command]

--- a/src-tauri/src/native_terminal.rs
+++ b/src-tauri/src/native_terminal.rs
@@ -53,9 +53,8 @@ mod imp {
         GetWindowLongPtrW, GetWindowThreadProcessId, IsChild, IsWindow, IsWindowVisible,
         SetForegroundWindow, SetWindowLongPtrW, SetWindowPos, ShowWindow, GUITHREADINFO,
         GWLP_HWNDPARENT, GWL_EXSTYLE, GWL_STYLE, GW_OWNER, SWP_FRAMECHANGED, SWP_HIDEWINDOW,
-        SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER, SW_HIDE, SW_SHOW, WS_CAPTION,
-        WS_EX_APPWINDOW, WS_EX_TOOLWINDOW, WS_MAXIMIZEBOX, WS_MINIMIZEBOX, WS_POPUP, WS_SYSMENU,
-        WS_THICKFRAME,
+        SWP_NOACTIVATE, SWP_NOZORDER, SW_HIDE, SW_SHOW, WS_CAPTION, WS_EX_APPWINDOW,
+        WS_EX_TOOLWINDOW, WS_MAXIMIZEBOX, WS_MINIMIZEBOX, WS_POPUP, WS_SYSMENU, WS_THICKFRAME,
     };
 
     const FIRST_NATIVE_PANE_ID: u32 = 0x8000_0000;
@@ -279,7 +278,7 @@ mod imp {
                 .join("\n")
         };
         Ok(format!(
-            "live_config_reload = true\n\n[window]\nopacity = {:.3}\ndecorations = \"None\"\n\n[scrolling]\nhistory = {}\n\n[font]\nsize = {:.2}\n\n[font.normal]\nfamily = {}\nstyle = \"Regular\"\n\n[colors.primary]\nbackground = \"{}\"\nforeground = \"{}\"\n\n[colors.cursor]\ntext = \"{}\"\ncursor = \"{}\"\n\n[colors.selection]\ntext = \"CellForeground\"\nbackground = \"{}\"\n\n[colors.normal]\n{}\n\n[colors.bright]\n{}\n",
+            "[general]\nlive_config_reload = true\n\n[window]\nopacity = {:.3}\ndecorations = \"None\"\n\n[scrolling]\nhistory = {}\n\n[font]\nsize = {:.2}\n\n[font.normal]\nfamily = {}\nstyle = \"Regular\"\n\n[colors.primary]\nbackground = \"{}\"\nforeground = \"{}\"\n\n[colors.cursor]\ntext = \"{}\"\ncursor = \"{}\"\n\n[colors.selection]\ntext = \"CellForeground\"\nbackground = \"{}\"\n\n[colors.normal]\n{}\n\n[colors.bright]\n{}\n",
             value.opacity,
             value.scrollback,
             value.font_size,
@@ -461,10 +460,13 @@ mod imp {
         .await
         .map_err(|error| format!("Alacritty launch task failed: {error}"))??;
 
-        let presentation = *state
-            .presentation
-            .lock()
-            .map_err(|_| "Native terminal presentation state is unavailable".to_string())?;
+        let presentation = match state.presentation.lock() {
+            Ok(presentation) => *presentation,
+            Err(_) => {
+                terminate(pane);
+                return Err("Native terminal presentation state is unavailable".to_string());
+            }
+        };
         pane.presentation_epoch = presentation.epoch;
         let hwnd = pane.hwnd;
         match state.panes.lock() {
@@ -552,7 +554,15 @@ mod imp {
         state: tauri::State<'_, NativeTerminalState>,
         id: u32,
         action: String,
+        epoch: u64,
     ) -> Result<(), String> {
+        let presentation = *state
+            .presentation
+            .lock()
+            .map_err(|_| "Native terminal presentation state is unavailable".to_string())?;
+        if presentation.occluded || epoch != presentation.epoch {
+            return Ok(());
+        }
         let panes = state
             .panes
             .lock()
@@ -560,6 +570,9 @@ mod imp {
         let pane = panes
             .get(&id)
             .ok_or_else(|| format!("Unknown native pane {id}"))?;
+        if !pane.visible || pane.presentation_epoch != epoch {
+            return Ok(());
+        }
         let hwnd = pane.hwnd as HWND;
         match action.as_str() {
             "copy" => send_chord(hwnd, &[VK_CONTROL, VK_SHIFT], b'C' as u16)?,
@@ -696,11 +709,11 @@ mod imp {
             SetWindowPos(
                 hwnd,
                 std::ptr::null_mut(),
-                0,
-                0,
-                0,
-                0,
-                SWP_HIDEWINDOW | SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOZORDER,
+                -32_000,
+                -32_000,
+                1,
+                1,
+                SWP_HIDEWINDOW | SWP_NOACTIVATE | SWP_NOZORDER,
             );
         }
     }
@@ -830,6 +843,7 @@ mod imp {
         _state: tauri::State<'_, NativeTerminalState>,
         _id: u32,
         _action: String,
+        _epoch: u64,
     ) -> Result<(), String> {
         Err("Native Alacritty panes are only supported on Windows".to_string())
     }
@@ -893,8 +907,9 @@ pub fn perform_alacritty_action(
     state: tauri::State<'_, NativeTerminalState>,
     id: u32,
     action: String,
+    epoch: u64,
 ) -> Result<(), String> {
-    imp::perform_action(state, id, action)
+    imp::perform_action(state, id, action, epoch)
 }
 
 #[tauri::command]

--- a/src-tauri/src/native_terminal.rs
+++ b/src-tauri/src/native_terminal.rs
@@ -37,24 +37,24 @@ mod imp {
     use std::collections::HashMap;
     use std::path::{Path, PathBuf};
     use std::process::{Child, Command};
-    use std::sync::atomic::{AtomicU32, Ordering};
-    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+    use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
-    use tauri::{AppHandle, Emitter, WebviewWindow};
+    use tauri::{AppHandle, Emitter, Manager, WebviewWindow};
     use windows_sys::core::BOOL;
     use windows_sys::Win32::Foundation::{HWND, LPARAM, POINT};
     use windows_sys::Win32::Graphics::Gdi::ClientToScreen;
     use windows_sys::Win32::UI::Input::KeyboardAndMouse::{
-        keybd_event, SetFocus, KEYEVENTF_KEYUP, VK_CONTROL, VK_END, VK_HOME, VK_NEXT, VK_PRIOR,
-        VK_RETURN, VK_SHIFT,
+        SendInput, SetFocus, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP,
+        VK_CONTROL, VK_END, VK_HOME, VK_NEXT, VK_PRIOR, VK_RETURN, VK_SHIFT,
     };
     use windows_sys::Win32::UI::WindowsAndMessaging::{
-        EnumWindows, GetClassNameW, GetGUIThreadInfo, GetParent, GetWindow, GetWindowLongPtrW,
-        GetWindowThreadProcessId, IsChild, IsWindow, IsWindowVisible, SetForegroundWindow,
-        SetWindowLongPtrW, SetWindowPos, ShowWindow, GUITHREADINFO, GWLP_HWNDPARENT, GWL_EXSTYLE,
-        GWL_STYLE, GW_OWNER, SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOZORDER, SW_HIDE, SW_SHOW,
-        WS_CAPTION, WS_EX_APPWINDOW, WS_EX_TOOLWINDOW, WS_MAXIMIZEBOX, WS_MINIMIZEBOX, WS_POPUP,
-        WS_SYSMENU, WS_THICKFRAME,
+        EnumWindows, GetClassNameW, GetForegroundWindow, GetGUIThreadInfo, GetParent, GetWindow,
+        GetWindowLongPtrW, GetWindowThreadProcessId, IsChild, IsWindow, IsWindowVisible,
+        SetForegroundWindow, SetWindowLongPtrW, SetWindowPos, ShowWindow, GUITHREADINFO,
+        GWLP_HWNDPARENT, GWL_EXSTYLE, GWL_STYLE, GW_OWNER, SWP_FRAMECHANGED, SWP_NOACTIVATE,
+        SWP_NOZORDER, SW_HIDE, SW_SHOW, WS_CAPTION, WS_EX_APPWINDOW, WS_EX_TOOLWINDOW,
+        WS_MAXIMIZEBOX, WS_MINIMIZEBOX, WS_POPUP, WS_SYSMENU, WS_THICKFRAME,
     };
 
     const FIRST_NATIVE_PANE_ID: u32 = 0x8000_0000;
@@ -66,6 +66,7 @@ mod imp {
         hwnd: isize,
         config_path: PathBuf,
         config_contents: String,
+        focus_monitor_alive: Arc<AtomicBool>,
     }
 
     pub struct NativeTerminalState {
@@ -207,6 +208,7 @@ mod imp {
     }
 
     fn terminate(mut pane: NativePane) {
+        pane.focus_monitor_alive.store(false, Ordering::Release);
         unsafe {
             if IsWindow(pane.hwnd as HWND) != 0 {
                 ShowWindow(pane.hwnd as HWND, SW_HIDE);
@@ -278,12 +280,12 @@ mod imp {
         ))
     }
 
-    fn runtime_config_path(id: u32) -> Result<PathBuf, String> {
-        let executable = std::env::current_exe().map_err(|error| error.to_string())?;
-        let root = executable
-            .parent()
-            .ok_or("Couldn't locate the SpaceVibe installation directory")?
-            .join(".spacevibe-runtime")
+    fn runtime_config_path(app: &AppHandle, id: u32) -> Result<PathBuf, String> {
+        let root = app
+            .path()
+            .app_local_data_dir()
+            .map_err(|error| format!("Couldn't locate SpaceVibe's local data directory: {error}"))?
+            .join("runtime")
             .join("alacritty");
         std::fs::create_dir_all(&root)
             .map_err(|error| format!("Couldn't create Alacritty runtime directory: {error}"))?;
@@ -311,13 +313,13 @@ mod imp {
         Ok(())
     }
 
-    fn monitor_focus(app: AppHandle, id: u32, hwnd: HWND) {
+    fn monitor_focus(app: AppHandle, id: u32, hwnd: HWND, alive: Arc<AtomicBool>) {
         let hwnd = hwnd as isize;
         std::thread::spawn(move || {
             let hwnd = hwnd as HWND;
             let thread_id = unsafe { GetWindowThreadProcessId(hwnd, std::ptr::null_mut()) };
             let mut had_focus = false;
-            while unsafe { IsWindow(hwnd) } != 0 {
+            while alive.load(Ordering::Acquire) && unsafe { IsWindow(hwnd) } != 0 {
                 let mut info = GUITHREADINFO {
                     cbSize: std::mem::size_of::<GUITHREADINFO>() as u32,
                     flags: 0,
@@ -369,9 +371,11 @@ mod imp {
             .map(std::path::PathBuf::from)
             .filter(|path| path.is_dir())
             .unwrap_or(platform::user_home()?);
-        let config_path = runtime_config_path(id)?;
+        let config_path = runtime_config_path(&app, id)?;
         let config = config_contents(&appearance)?;
         write_config(&config_path, &config)?;
+        let focus_monitor_alive = Arc::new(AtomicBool::new(true));
+        let pane_monitor_alive = Arc::clone(&focus_monitor_alive);
 
         let pane = tauri::async_runtime::spawn_blocking(move || {
             let mut child = match Command::new(executable)
@@ -408,6 +412,7 @@ mod imp {
                 hwnd: hwnd as isize,
                 config_path,
                 config_contents: config,
+                focus_monitor_alive: pane_monitor_alive,
             })
         })
         .await
@@ -423,7 +428,7 @@ mod imp {
                 return Err("Native terminal state is unavailable".to_string());
             }
         }
-        monitor_focus(app, id, hwnd as HWND);
+        monitor_focus(app, id, hwnd as HWND, focus_monitor_alive);
         Ok(id)
     }
 
@@ -448,19 +453,51 @@ mod imp {
         Ok(())
     }
 
-    fn send_chord(hwnd: HWND, modifiers: &[u16], key: u16) {
+    fn keyboard_input(key: u16, flags: u32) -> INPUT {
+        INPUT {
+            r#type: INPUT_KEYBOARD,
+            Anonymous: INPUT_0 {
+                ki: KEYBDINPUT {
+                    wVk: key,
+                    wScan: 0,
+                    dwFlags: flags,
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        }
+    }
+
+    fn send_chord(hwnd: HWND, modifiers: &[u16], key: u16) -> Result<(), String> {
         unsafe {
-            SetForegroundWindow(hwnd);
-            SetFocus(hwnd);
-            for modifier in modifiers {
-                keybd_event(*modifier as u8, 0, 0, 0);
+            if SetForegroundWindow(hwnd) == 0 || GetForegroundWindow() != hwnd {
+                return Err("Alacritty could not be focused safely".to_string());
             }
-            keybd_event(key as u8, 0, 0, 0);
-            keybd_event(key as u8, 0, KEYEVENTF_KEYUP, 0);
-            for modifier in modifiers.iter().rev() {
-                keybd_event(*modifier as u8, 0, KEYEVENTF_KEYUP, 0);
+            SetFocus(hwnd);
+            let mut inputs = Vec::with_capacity(modifiers.len() * 2 + 2);
+            inputs.extend(
+                modifiers
+                    .iter()
+                    .map(|modifier| keyboard_input(*modifier, 0)),
+            );
+            inputs.push(keyboard_input(key, 0));
+            inputs.push(keyboard_input(key, KEYEVENTF_KEYUP));
+            inputs.extend(
+                modifiers
+                    .iter()
+                    .rev()
+                    .map(|modifier| keyboard_input(*modifier, KEYEVENTF_KEYUP)),
+            );
+            let sent = SendInput(
+                inputs.len() as u32,
+                inputs.as_ptr(),
+                std::mem::size_of::<INPUT>() as i32,
+            );
+            if sent != inputs.len() as u32 {
+                return Err("Windows could not deliver the Alacritty shortcut safely".to_string());
             }
         }
+        Ok(())
     }
 
     pub fn perform_action(
@@ -477,16 +514,16 @@ mod imp {
             .ok_or_else(|| format!("Unknown native pane {id}"))?;
         let hwnd = pane.hwnd as HWND;
         match action.as_str() {
-            "copy" => send_chord(hwnd, &[VK_CONTROL, VK_SHIFT], b'C' as u16),
-            "paste" => send_chord(hwnd, &[VK_CONTROL, VK_SHIFT], b'V' as u16),
-            "search" => send_chord(hwnd, &[VK_CONTROL, VK_SHIFT], b'F' as u16),
-            "search-next" => send_chord(hwnd, &[], VK_RETURN),
-            "search-previous" => send_chord(hwnd, &[VK_SHIFT], VK_RETURN),
-            "clear" => send_chord(hwnd, &[VK_CONTROL], b'L' as u16),
-            "page-up" => send_chord(hwnd, &[VK_SHIFT], VK_PRIOR),
-            "page-down" => send_chord(hwnd, &[VK_SHIFT], VK_NEXT),
-            "scroll-top" => send_chord(hwnd, &[VK_CONTROL, VK_SHIFT], VK_HOME),
-            "scroll-bottom" => send_chord(hwnd, &[VK_CONTROL, VK_SHIFT], VK_END),
+            "copy" => send_chord(hwnd, &[VK_CONTROL, VK_SHIFT], b'C' as u16)?,
+            "paste" => send_chord(hwnd, &[VK_CONTROL, VK_SHIFT], b'V' as u16)?,
+            "search" => send_chord(hwnd, &[VK_CONTROL, VK_SHIFT], b'F' as u16)?,
+            "search-next" => send_chord(hwnd, &[], VK_RETURN)?,
+            "search-previous" => send_chord(hwnd, &[VK_SHIFT], VK_RETURN)?,
+            "clear" => send_chord(hwnd, &[VK_CONTROL], b'L' as u16)?,
+            "page-up" => send_chord(hwnd, &[VK_SHIFT], VK_PRIOR)?,
+            "page-down" => send_chord(hwnd, &[VK_SHIFT], VK_NEXT)?,
+            "scroll-top" => send_chord(hwnd, &[VK_CONTROL, VK_SHIFT], VK_HOME)?,
+            "scroll-bottom" => send_chord(hwnd, &[VK_CONTROL, VK_SHIFT], VK_END)?,
             _ => return Err(format!("Unknown Alacritty action {action}")),
         }
         Ok(())
@@ -517,13 +554,17 @@ mod imp {
             let pane = panes.remove(&id);
             drop(panes);
             if let Some(pane) = pane {
-                let _ = std::fs::remove_file(pane.config_path);
+                terminate(pane);
             }
             return Err("Alacritty exited".to_string());
         }
         let hwnd = pane.hwnd as HWND;
         if unsafe { IsWindow(hwnd) } == 0 {
-            panes.remove(&id);
+            let pane = panes.remove(&id);
+            drop(panes);
+            if let Some(pane) = pane {
+                terminate(pane);
+            }
             return Err("The embedded Alacritty window is no longer available".to_string());
         }
         if !visible || bounds.width < 1.0 || bounds.height < 1.0 {

--- a/src-tauri/src/native_terminal.rs
+++ b/src-tauri/src/native_terminal.rs
@@ -1,0 +1,747 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativePaneBounds {
+    pub left: f64,
+    pub top: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeTerminalAppearance {
+    pub font_family: String,
+    pub font_size: f64,
+    pub background: String,
+    pub foreground: String,
+    pub cursor: String,
+    pub selection_background: String,
+    pub normal: Vec<String>,
+    pub bright: Vec<String>,
+    pub opacity: f64,
+    pub scrollback: u32,
+}
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct NativePaneFocusPayload {
+    id: u32,
+}
+
+#[cfg(target_os = "windows")]
+mod imp {
+    use super::{NativePaneBounds, NativePaneFocusPayload, NativeTerminalAppearance};
+    use crate::platform;
+    use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
+    use std::process::{Child, Command};
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Mutex;
+    use std::time::{Duration, Instant};
+    use tauri::{AppHandle, Emitter, WebviewWindow};
+    use windows_sys::core::BOOL;
+    use windows_sys::Win32::Foundation::{HWND, LPARAM, POINT};
+    use windows_sys::Win32::Graphics::Gdi::ClientToScreen;
+    use windows_sys::Win32::UI::Input::KeyboardAndMouse::{
+        keybd_event, SetFocus, KEYEVENTF_KEYUP, VK_CONTROL, VK_END, VK_HOME, VK_NEXT, VK_PRIOR,
+        VK_RETURN, VK_SHIFT,
+    };
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        EnumWindows, GetClassNameW, GetGUIThreadInfo, GetParent, GetWindow, GetWindowLongPtrW,
+        GetWindowThreadProcessId, IsChild, IsWindow, IsWindowVisible, SetForegroundWindow,
+        SetWindowLongPtrW, SetWindowPos, ShowWindow, GUITHREADINFO, GWLP_HWNDPARENT, GWL_EXSTYLE,
+        GWL_STYLE, GW_OWNER, SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOZORDER, SW_HIDE, SW_SHOW,
+        WS_CAPTION, WS_EX_APPWINDOW, WS_EX_TOOLWINDOW, WS_MAXIMIZEBOX, WS_MINIMIZEBOX, WS_POPUP,
+        WS_SYSMENU, WS_THICKFRAME,
+    };
+
+    const FIRST_NATIVE_PANE_ID: u32 = 0x8000_0000;
+    const WINDOW_WAIT_TIMEOUT: Duration = Duration::from_secs(8);
+    const WINDOW_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+    struct NativePane {
+        child: Child,
+        hwnd: isize,
+        config_path: PathBuf,
+        config_contents: String,
+    }
+
+    pub struct NativeTerminalState {
+        next_id: AtomicU32,
+        panes: Mutex<HashMap<u32, NativePane>>,
+    }
+
+    impl Default for NativeTerminalState {
+        fn default() -> Self {
+            Self {
+                next_id: AtomicU32::new(FIRST_NATIVE_PANE_ID),
+                panes: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl NativeTerminalState {
+        fn allocate_id(&self) -> Result<u32, String> {
+            let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+            if id < FIRST_NATIVE_PANE_ID {
+                return Err("Native pane id space is exhausted".to_string());
+            }
+            Ok(id)
+        }
+
+        pub fn terminate_all(&self) {
+            let mut panes = match self.panes.lock() {
+                Ok(panes) => panes,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            for (_, pane) in panes.drain() {
+                terminate(pane);
+            }
+        }
+    }
+
+    impl Drop for NativeTerminalState {
+        fn drop(&mut self) {
+            self.terminate_all();
+        }
+    }
+
+    struct FindWindowContext {
+        pid: u32,
+        hwnd: HWND,
+    }
+
+    unsafe extern "system" fn find_process_window(hwnd: HWND, lparam: LPARAM) -> BOOL {
+        let context = &mut *(lparam as *mut FindWindowContext);
+        let mut pid = 0;
+        GetWindowThreadProcessId(hwnd, &mut pid);
+        // Alacritty owns several OpenGL/winit helper windows. The real terminal
+        // surface consistently uses `Window Class`; the earlier visible
+        // `Winit Thread Event Target` is only a message/event helper.
+        let mut class_name = [0u16; 64];
+        let class_len = GetClassNameW(hwnd, class_name.as_mut_ptr(), class_name.len() as i32);
+        let is_terminal = class_len > 0
+            && String::from_utf16_lossy(&class_name[..class_len as usize]) == "Window Class";
+        if pid == context.pid
+            && GetParent(hwnd).is_null()
+            && IsWindowVisible(hwnd) != 0
+            && is_terminal
+        {
+            context.hwnd = hwnd;
+            return 0;
+        }
+        1
+    }
+
+    fn top_level_window(pid: u32) -> Option<HWND> {
+        let mut context = FindWindowContext {
+            pid,
+            hwnd: std::ptr::null_mut(),
+        };
+        unsafe {
+            EnumWindows(
+                Some(find_process_window),
+                &mut context as *mut FindWindowContext as LPARAM,
+            );
+        }
+        (!context.hwnd.is_null()).then_some(context.hwnd)
+    }
+
+    fn wait_for_window(child: &mut Child) -> Result<HWND, String> {
+        let deadline = Instant::now() + WINDOW_WAIT_TIMEOUT;
+        loop {
+            if let Some(status) = child.try_wait().map_err(|error| error.to_string())? {
+                return Err(format!(
+                    "Alacritty exited before its window was ready ({status})"
+                ));
+            }
+            if let Some(hwnd) = top_level_window(child.id()) {
+                return Ok(hwnd);
+            }
+            if Instant::now() >= deadline {
+                return Err("Timed out waiting for the Alacritty window".to_string());
+            }
+            std::thread::sleep(WINDOW_POLL_INTERVAL);
+        }
+    }
+
+    fn attach_overlay(hwnd: HWND, owner: HWND) -> Result<(), String> {
+        unsafe {
+            ShowWindow(hwnd, SW_HIDE);
+            let old_style = GetWindowLongPtrW(hwnd, GWL_STYLE) as u32;
+            let remove = WS_POPUP
+                | WS_CAPTION
+                | WS_THICKFRAME
+                | WS_SYSMENU
+                | WS_MINIMIZEBOX
+                | WS_MAXIMIZEBOX;
+            // Alacritty's OpenGL surface renders black after WS_CHILD
+            // reparenting. Keep it as a borderless popup owned by SpaceVibe:
+            // owned windows stay above/minimize with their owner, while the
+            // frontend explicitly hides them for tabs and WebView overlays.
+            let style = (old_style & !remove) | WS_POPUP;
+            SetWindowLongPtrW(hwnd, GWL_STYLE, style as isize);
+            let old_ex_style = GetWindowLongPtrW(hwnd, GWL_EXSTYLE) as u32;
+            let ex_style = (old_ex_style & !WS_EX_APPWINDOW) | WS_EX_TOOLWINDOW;
+            SetWindowLongPtrW(hwnd, GWL_EXSTYLE, ex_style as isize);
+            SetWindowLongPtrW(hwnd, GWLP_HWNDPARENT, owner as isize);
+            if GetWindow(hwnd, GW_OWNER) != owner {
+                return Err("Windows refused to attach Alacritty to the app".to_string());
+            }
+            if SetWindowPos(
+                hwnd,
+                std::ptr::null_mut(),
+                0,
+                0,
+                1,
+                1,
+                SWP_FRAMECHANGED | SWP_NOACTIVATE | SWP_NOZORDER,
+            ) == 0
+            {
+                return Err("Failed to initialize the embedded Alacritty window".to_string());
+            }
+        }
+        Ok(())
+    }
+
+    fn terminate(mut pane: NativePane) {
+        unsafe {
+            if IsWindow(pane.hwnd as HWND) != 0 {
+                ShowWindow(pane.hwnd as HWND, SW_HIDE);
+            }
+        }
+        let _ = pane.child.kill();
+        let _ = pane.child.wait();
+        let _ = std::fs::remove_file(pane.config_path);
+    }
+
+    fn valid_color(value: &str) -> bool {
+        value.len() == 7
+            && value.starts_with('#')
+            && value[1..].bytes().all(|byte| byte.is_ascii_hexdigit())
+    }
+
+    fn validate_appearance(value: &NativeTerminalAppearance) -> Result<(), String> {
+        if value.font_family.trim().is_empty()
+            || !value.font_size.is_finite()
+            || !(6.0..=72.0).contains(&value.font_size)
+            || !value.opacity.is_finite()
+            || !(0.4..=1.0).contains(&value.opacity)
+            || value.normal.len() != 8
+            || value.bright.len() != 8
+            || ![
+                &value.background,
+                &value.foreground,
+                &value.cursor,
+                &value.selection_background,
+            ]
+            .into_iter()
+            .all(|color| valid_color(color))
+            || !value.normal.iter().all(|color| valid_color(color))
+            || !value.bright.iter().all(|color| valid_color(color))
+        {
+            return Err("Invalid Alacritty appearance settings".to_string());
+        }
+        Ok(())
+    }
+
+    fn config_contents(value: &NativeTerminalAppearance) -> Result<String, String> {
+        validate_appearance(value)?;
+        let family =
+            serde_json::to_string(value.font_family.trim()).map_err(|error| error.to_string())?;
+        let names = [
+            "black", "red", "green", "yellow", "blue", "magenta", "cyan", "white",
+        ];
+        let colors = |values: &[String]| {
+            names
+                .iter()
+                .zip(values)
+                .map(|(name, color)| format!("{name} = \"{color}\""))
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        Ok(format!(
+            "live_config_reload = true\n\n[window]\nopacity = {:.3}\ndecorations = \"None\"\n\n[scrolling]\nhistory = {}\n\n[font]\nsize = {:.2}\n\n[font.normal]\nfamily = {}\nstyle = \"Regular\"\n\n[colors.primary]\nbackground = \"{}\"\nforeground = \"{}\"\n\n[colors.cursor]\ntext = \"{}\"\ncursor = \"{}\"\n\n[colors.selection]\ntext = \"CellForeground\"\nbackground = \"{}\"\n\n[colors.normal]\n{}\n\n[colors.bright]\n{}\n",
+            value.opacity,
+            value.scrollback,
+            value.font_size,
+            family,
+            value.background,
+            value.foreground,
+            value.background,
+            value.cursor,
+            value.selection_background,
+            colors(&value.normal),
+            colors(&value.bright),
+        ))
+    }
+
+    fn runtime_config_path(id: u32) -> Result<PathBuf, String> {
+        let executable = std::env::current_exe().map_err(|error| error.to_string())?;
+        let root = executable
+            .parent()
+            .ok_or("Couldn't locate the SpaceVibe installation directory")?
+            .join(".spacevibe-runtime")
+            .join("alacritty");
+        std::fs::create_dir_all(&root)
+            .map_err(|error| format!("Couldn't create Alacritty runtime directory: {error}"))?;
+        Ok(root.join(format!("pane-{id}.toml")))
+    }
+
+    fn write_config(path: &Path, contents: &str) -> Result<(), String> {
+        let pending = path.with_extension("toml.pending");
+        if let Err(error) = std::fs::write(&pending, contents) {
+            let _ = std::fs::remove_file(&pending);
+            return Err(format!("Couldn't write Alacritty configuration: {error}"));
+        }
+        if path.exists() {
+            if let Err(error) = std::fs::remove_file(path) {
+                let _ = std::fs::remove_file(&pending);
+                return Err(format!("Couldn't replace Alacritty configuration: {error}"));
+            }
+        }
+        if let Err(error) = std::fs::rename(&pending, path) {
+            let _ = std::fs::remove_file(&pending);
+            return Err(format!(
+                "Couldn't activate Alacritty configuration: {error}"
+            ));
+        }
+        Ok(())
+    }
+
+    fn monitor_focus(app: AppHandle, id: u32, hwnd: HWND) {
+        let hwnd = hwnd as isize;
+        std::thread::spawn(move || {
+            let hwnd = hwnd as HWND;
+            let thread_id = unsafe { GetWindowThreadProcessId(hwnd, std::ptr::null_mut()) };
+            let mut had_focus = false;
+            while unsafe { IsWindow(hwnd) } != 0 {
+                let mut info = GUITHREADINFO {
+                    cbSize: std::mem::size_of::<GUITHREADINFO>() as u32,
+                    flags: 0,
+                    hwndActive: std::ptr::null_mut(),
+                    hwndFocus: std::ptr::null_mut(),
+                    hwndCapture: std::ptr::null_mut(),
+                    hwndMenuOwner: std::ptr::null_mut(),
+                    hwndMoveSize: std::ptr::null_mut(),
+                    hwndCaret: std::ptr::null_mut(),
+                    rcCaret: Default::default(),
+                };
+                let focused = unsafe { GetGUIThreadInfo(thread_id, &mut info) } != 0
+                    && (info.hwndFocus == hwnd
+                        || (!info.hwndFocus.is_null()
+                            && unsafe { IsChild(hwnd, info.hwndFocus) } != 0));
+                if focused && !had_focus {
+                    let _ = app.emit("native-terminal:focus", NativePaneFocusPayload { id });
+                }
+                had_focus = focused;
+                std::thread::sleep(Duration::from_millis(100));
+            }
+        });
+    }
+
+    fn validate_bounds(bounds: NativePaneBounds) -> Result<(), String> {
+        if !bounds.left.is_finite()
+            || !bounds.top.is_finite()
+            || !bounds.width.is_finite()
+            || !bounds.height.is_finite()
+            || bounds.width < 0.0
+            || bounds.height < 0.0
+        {
+            return Err("Invalid native pane bounds".to_string());
+        }
+        Ok(())
+    }
+
+    pub async fn spawn(
+        app: AppHandle,
+        window: WebviewWindow,
+        state: tauri::State<'_, NativeTerminalState>,
+        cwd: Option<String>,
+        appearance: NativeTerminalAppearance,
+    ) -> Result<u32, String> {
+        let id = state.allocate_id()?;
+        let parent = window.hwnd().map_err(|error| error.to_string())?.0 as isize;
+        let executable = platform::windows::find_alacritty_executable()?;
+        let cwd = cwd
+            .map(std::path::PathBuf::from)
+            .filter(|path| path.is_dir())
+            .unwrap_or(platform::user_home()?);
+        let config_path = runtime_config_path(id)?;
+        let config = config_contents(&appearance)?;
+        write_config(&config_path, &config)?;
+
+        let pane = tauri::async_runtime::spawn_blocking(move || {
+            let mut child = match Command::new(executable)
+                .arg("--config-file")
+                .arg(&config_path)
+                .arg("--working-directory")
+                .arg(&cwd)
+                .current_dir(&cwd)
+                .spawn()
+            {
+                Ok(child) => child,
+                Err(error) => {
+                    let _ = std::fs::remove_file(&config_path);
+                    return Err(format!("Failed to launch Alacritty: {error}"));
+                }
+            };
+            let hwnd = match wait_for_window(&mut child) {
+                Ok(hwnd) => hwnd,
+                Err(error) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    let _ = std::fs::remove_file(&config_path);
+                    return Err(error);
+                }
+            };
+            if let Err(error) = attach_overlay(hwnd, parent as HWND) {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = std::fs::remove_file(&config_path);
+                return Err(error);
+            }
+            Ok(NativePane {
+                child,
+                hwnd: hwnd as isize,
+                config_path,
+                config_contents: config,
+            })
+        })
+        .await
+        .map_err(|error| format!("Alacritty launch task failed: {error}"))??;
+
+        let hwnd = pane.hwnd;
+        match state.panes.lock() {
+            Ok(mut panes) => {
+                panes.insert(id, pane);
+            }
+            Err(_) => {
+                terminate(pane);
+                return Err("Native terminal state is unavailable".to_string());
+            }
+        }
+        monitor_focus(app, id, hwnd as HWND);
+        Ok(id)
+    }
+
+    pub fn apply_appearance(
+        state: tauri::State<'_, NativeTerminalState>,
+        id: u32,
+        appearance: NativeTerminalAppearance,
+    ) -> Result<(), String> {
+        let contents = config_contents(&appearance)?;
+        let mut panes = state
+            .panes
+            .lock()
+            .map_err(|_| "Native terminal state is unavailable".to_string())?;
+        let pane = panes
+            .get_mut(&id)
+            .ok_or_else(|| format!("Unknown native pane {id}"))?;
+        if pane.config_contents == contents {
+            return Ok(());
+        }
+        write_config(&pane.config_path, &contents)?;
+        pane.config_contents = contents;
+        Ok(())
+    }
+
+    fn send_chord(hwnd: HWND, modifiers: &[u16], key: u16) {
+        unsafe {
+            SetForegroundWindow(hwnd);
+            SetFocus(hwnd);
+            for modifier in modifiers {
+                keybd_event(*modifier as u8, 0, 0, 0);
+            }
+            keybd_event(key as u8, 0, 0, 0);
+            keybd_event(key as u8, 0, KEYEVENTF_KEYUP, 0);
+            for modifier in modifiers.iter().rev() {
+                keybd_event(*modifier as u8, 0, KEYEVENTF_KEYUP, 0);
+            }
+        }
+    }
+
+    pub fn perform_action(
+        state: tauri::State<'_, NativeTerminalState>,
+        id: u32,
+        action: String,
+    ) -> Result<(), String> {
+        let panes = state
+            .panes
+            .lock()
+            .map_err(|_| "Native terminal state is unavailable".to_string())?;
+        let pane = panes
+            .get(&id)
+            .ok_or_else(|| format!("Unknown native pane {id}"))?;
+        let hwnd = pane.hwnd as HWND;
+        match action.as_str() {
+            "copy" => send_chord(hwnd, &[VK_CONTROL, VK_SHIFT], b'C' as u16),
+            "paste" => send_chord(hwnd, &[VK_CONTROL, VK_SHIFT], b'V' as u16),
+            "search" => send_chord(hwnd, &[VK_CONTROL, VK_SHIFT], b'F' as u16),
+            "search-next" => send_chord(hwnd, &[], VK_RETURN),
+            "search-previous" => send_chord(hwnd, &[VK_SHIFT], VK_RETURN),
+            "clear" => send_chord(hwnd, &[VK_CONTROL], b'L' as u16),
+            "page-up" => send_chord(hwnd, &[VK_SHIFT], VK_PRIOR),
+            "page-down" => send_chord(hwnd, &[VK_SHIFT], VK_NEXT),
+            "scroll-top" => send_chord(hwnd, &[VK_CONTROL, VK_SHIFT], VK_HOME),
+            "scroll-bottom" => send_chord(hwnd, &[VK_CONTROL, VK_SHIFT], VK_END),
+            _ => return Err(format!("Unknown Alacritty action {action}")),
+        }
+        Ok(())
+    }
+
+    pub fn update(
+        window: WebviewWindow,
+        state: tauri::State<'_, NativeTerminalState>,
+        id: u32,
+        bounds: NativePaneBounds,
+        visible: bool,
+    ) -> Result<(), String> {
+        validate_bounds(bounds)?;
+        let scale = window.scale_factor().map_err(|error| error.to_string())?;
+        let mut panes = state
+            .panes
+            .lock()
+            .map_err(|_| "Native terminal state is unavailable".to_string())?;
+        let pane = panes
+            .get_mut(&id)
+            .ok_or_else(|| format!("Unknown native pane {id}"))?;
+        if pane
+            .child
+            .try_wait()
+            .map_err(|error| error.to_string())?
+            .is_some()
+        {
+            let pane = panes.remove(&id);
+            drop(panes);
+            if let Some(pane) = pane {
+                let _ = std::fs::remove_file(pane.config_path);
+            }
+            return Err("Alacritty exited".to_string());
+        }
+        let hwnd = pane.hwnd as HWND;
+        if unsafe { IsWindow(hwnd) } == 0 {
+            panes.remove(&id);
+            return Err("The embedded Alacritty window is no longer available".to_string());
+        }
+        if !visible || bounds.width < 1.0 || bounds.height < 1.0 {
+            unsafe { ShowWindow(hwnd, SW_HIDE) };
+            return Ok(());
+        }
+        let x = (bounds.left * scale).round() as i32;
+        let y = (bounds.top * scale).round() as i32;
+        let width = (bounds.width * scale).round().max(1.0) as i32;
+        let height = (bounds.height * scale).round().max(1.0) as i32;
+        unsafe {
+            let parent = window.hwnd().map_err(|error| error.to_string())?.0;
+            let mut origin = POINT { x: 0, y: 0 };
+            if ClientToScreen(parent, &mut origin) == 0 {
+                return Err("Failed to locate the SpaceVibe client area".to_string());
+            }
+            if SetWindowPos(
+                hwnd,
+                std::ptr::null_mut(),
+                origin.x + x,
+                origin.y + y,
+                width,
+                height,
+                SWP_NOACTIVATE | SWP_NOZORDER,
+            ) == 0
+            {
+                return Err("Failed to resize the embedded Alacritty window".to_string());
+            }
+            ShowWindow(hwnd, SW_SHOW);
+        }
+        Ok(())
+    }
+
+    pub fn focus(state: tauri::State<'_, NativeTerminalState>, id: u32) -> Result<(), String> {
+        let panes = state
+            .panes
+            .lock()
+            .map_err(|_| "Native terminal state is unavailable".to_string())?;
+        let pane = panes
+            .get(&id)
+            .ok_or_else(|| format!("Unknown native pane {id}"))?;
+        let hwnd = pane.hwnd as HWND;
+        unsafe {
+            ShowWindow(hwnd, SW_SHOW);
+            SetForegroundWindow(hwnd);
+            SetFocus(hwnd);
+        }
+        Ok(())
+    }
+
+    pub fn kill(state: tauri::State<'_, NativeTerminalState>, id: u32) -> Result<(), String> {
+        let pane = state
+            .panes
+            .lock()
+            .map_err(|_| "Native terminal state is unavailable".to_string())?
+            .remove(&id);
+        if let Some(pane) = pane {
+            terminate(pane);
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn appearance() -> NativeTerminalAppearance {
+            NativeTerminalAppearance {
+                font_family: "Cascadia Mono".to_string(),
+                font_size: 10.5,
+                background: "#16161e".to_string(),
+                foreground: "#c0caf5".to_string(),
+                cursor: "#c0caf5".to_string(),
+                selection_background: "#33467c".to_string(),
+                normal: vec!["#111111".to_string(); 8],
+                bright: vec!["#eeeeee".to_string(); 8],
+                opacity: 0.9,
+                scrollback: 10_000,
+            }
+        }
+
+        #[test]
+        fn generated_config_contains_spacevibe_appearance() {
+            let config = config_contents(&appearance()).unwrap();
+            assert!(config.contains("family = \"Cascadia Mono\""));
+            assert!(config.contains("opacity = 0.900"));
+            assert!(config.contains("history = 10000"));
+            assert!(config.contains("background = \"#16161e\""));
+        }
+
+        #[test]
+        fn invalid_colors_and_palette_lengths_are_rejected() {
+            let mut value = appearance();
+            value.background = "red".to_string();
+            assert!(config_contents(&value).is_err());
+            value = appearance();
+            value.normal.pop();
+            assert!(config_contents(&value).is_err());
+        }
+
+        #[test]
+        fn font_family_is_escaped_as_a_toml_string() {
+            let mut value = appearance();
+            value.font_family = "A \"quoted\" font".to_string();
+            let config = config_contents(&value).unwrap();
+            assert!(config.contains("family = \"A \\\"quoted\\\" font\""));
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+mod imp {
+    use super::{NativePaneBounds, NativeTerminalAppearance};
+    use tauri::WebviewWindow;
+
+    #[derive(Default)]
+    pub struct NativeTerminalState;
+
+    impl NativeTerminalState {
+        pub fn terminate_all(&self) {}
+    }
+
+    pub async fn spawn(
+        _app: tauri::AppHandle,
+        _window: WebviewWindow,
+        _state: tauri::State<'_, NativeTerminalState>,
+        _cwd: Option<String>,
+        _appearance: NativeTerminalAppearance,
+    ) -> Result<u32, String> {
+        Err("Native Alacritty panes are only supported on Windows".to_string())
+    }
+
+    pub fn apply_appearance(
+        _state: tauri::State<'_, NativeTerminalState>,
+        _id: u32,
+        _appearance: NativeTerminalAppearance,
+    ) -> Result<(), String> {
+        Err("Native Alacritty panes are only supported on Windows".to_string())
+    }
+
+    pub fn perform_action(
+        _state: tauri::State<'_, NativeTerminalState>,
+        _id: u32,
+        _action: String,
+    ) -> Result<(), String> {
+        Err("Native Alacritty panes are only supported on Windows".to_string())
+    }
+
+    pub fn update(
+        _window: WebviewWindow,
+        _state: tauri::State<'_, NativeTerminalState>,
+        _id: u32,
+        _bounds: NativePaneBounds,
+        _visible: bool,
+    ) -> Result<(), String> {
+        Err("Native Alacritty panes are only supported on Windows".to_string())
+    }
+
+    pub fn focus(_state: tauri::State<'_, NativeTerminalState>, _id: u32) -> Result<(), String> {
+        Err("Native Alacritty panes are only supported on Windows".to_string())
+    }
+
+    pub fn kill(_state: tauri::State<'_, NativeTerminalState>, _id: u32) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+pub use imp::NativeTerminalState;
+
+#[tauri::command]
+pub async fn spawn_alacritty(
+    app: tauri::AppHandle,
+    window: tauri::WebviewWindow,
+    state: tauri::State<'_, NativeTerminalState>,
+    cwd: Option<String>,
+    appearance: NativeTerminalAppearance,
+) -> Result<u32, String> {
+    imp::spawn(app, window, state, cwd, appearance).await
+}
+
+#[tauri::command]
+pub fn apply_alacritty_appearance(
+    state: tauri::State<'_, NativeTerminalState>,
+    id: u32,
+    appearance: NativeTerminalAppearance,
+) -> Result<(), String> {
+    imp::apply_appearance(state, id, appearance)
+}
+
+#[tauri::command]
+pub fn perform_alacritty_action(
+    state: tauri::State<'_, NativeTerminalState>,
+    id: u32,
+    action: String,
+) -> Result<(), String> {
+    imp::perform_action(state, id, action)
+}
+
+#[tauri::command]
+pub fn update_alacritty(
+    window: tauri::WebviewWindow,
+    state: tauri::State<'_, NativeTerminalState>,
+    id: u32,
+    bounds: NativePaneBounds,
+    visible: bool,
+) -> Result<(), String> {
+    imp::update(window, state, id, bounds, visible)
+}
+
+#[tauri::command]
+pub fn focus_alacritty(
+    state: tauri::State<'_, NativeTerminalState>,
+    id: u32,
+) -> Result<(), String> {
+    imp::focus(state, id)
+}
+
+#[tauri::command]
+pub fn kill_alacritty(state: tauri::State<'_, NativeTerminalState>, id: u32) -> Result<(), String> {
+    imp::kill(state, id)
+}

--- a/src-tauri/src/platform/windows/agent_discovery.rs
+++ b/src-tauri/src/platform/windows/agent_discovery.rs
@@ -168,10 +168,18 @@ mod tests {
     use std::time::Duration;
 
     fn builtins() -> Vec<String> {
-        BUILTIN_AGENTS
+        let mut names: Vec<String> = BUILTIN_AGENTS
             .iter()
             .map(|name| (*name).to_string())
-            .collect()
+            .collect();
+        // This module's tests run on Linux CI too (`platform::windows` is
+        // compiled under cfg(test)), while the production built-in catalog is
+        // correctly platform-gated there. Explicitly include the Windows-only
+        // renderer so these fixtures continue to exercise its discovery path.
+        if !names.iter().any(|name| name == "alacritty") {
+            names.push("alacritty".to_string());
+        }
+        names
     }
 
     struct FixtureProvider {

--- a/src-tauri/src/platform/windows/agent_discovery.rs
+++ b/src-tauri/src/platform/windows/agent_discovery.rs
@@ -321,10 +321,7 @@ mod tests {
     #[cfg(target_os = "windows")]
     #[test]
     fn finds_alacritty_under_program_files_when_it_is_not_on_path() {
-        let root = std::env::current_dir()
-            .unwrap()
-            .join("target")
-            .join(format!("alacritty-discovery-{}", std::process::id()));
+        let root = std::env::temp_dir().join(format!("alacritty-discovery-{}", std::process::id()));
         let directory = root.join("Alacritty");
         std::fs::create_dir_all(&directory).unwrap();
         let executable = directory.join("alacritty.exe");
@@ -349,6 +346,8 @@ pub(crate) fn find_alacritty_executable() -> Result<String, String> {
     EnvironmentAgentSearchProvider::from_environment()
         .find("alacritty")?
         .ok_or_else(|| {
-            "Alacritty was not found on PATH or under Program Files\\Alacritty".to_string()
+            "Alacritty was not found on PATH, under Program Files\\Alacritty, under \
+             ProgramFiles(x86)\\Alacritty, or under LOCALAPPDATA\\Programs\\Alacritty"
+                .to_string()
         })
 }

--- a/src-tauri/src/platform/windows/agent_discovery.rs
+++ b/src-tauri/src/platform/windows/agent_discovery.rs
@@ -30,22 +30,48 @@ pub(crate) fn resolve_on_path(name: &str, path: &OsStr) -> Option<String> {
 
 struct EnvironmentAgentSearchProvider {
     path: Option<OsString>,
+    program_files: Option<OsString>,
+    program_files_x86: Option<OsString>,
+    local_app_data: Option<OsString>,
 }
 
 impl EnvironmentAgentSearchProvider {
     fn from_environment() -> Self {
         Self {
             path: std::env::var_os("PATH"),
+            program_files: std::env::var_os("ProgramFiles"),
+            program_files_x86: std::env::var_os("ProgramFiles(x86)"),
+            local_app_data: std::env::var_os("LOCALAPPDATA"),
         }
     }
 }
 
 impl AgentSearchProvider for EnvironmentAgentSearchProvider {
     fn find(&self, name: &str) -> Result<Option<String>, String> {
-        let Some(path) = self.path.as_ref() else {
-            return Ok(None);
-        };
-        Ok(resolve_on_path(name, path))
+        if let Some(path) = self.path.as_ref() {
+            if let Some(found) = resolve_on_path(name, path) {
+                return Ok(Some(found));
+            }
+        }
+        if name == "alacritty" {
+            let mut roots = Vec::new();
+            if let Some(root) = self.program_files.as_ref() {
+                roots.push(std::path::PathBuf::from(root));
+            }
+            if let Some(root) = self.program_files_x86.as_ref() {
+                roots.push(std::path::PathBuf::from(root));
+            }
+            if let Some(root) = self.local_app_data.as_ref() {
+                roots.push(std::path::Path::new(root).join("Programs"));
+            }
+            for root in roots {
+                let candidate = root.join("Alacritty").join("alacritty.exe");
+                if candidate.is_file() {
+                    return Ok(Some(candidate.to_string_lossy().into_owned()));
+                }
+            }
+        }
+        Ok(None)
     }
 }
 
@@ -175,6 +201,7 @@ mod tests {
             ("claude", r"C:\Users\dev\bin\claude.cmd"),
             ("codex", r"\\tools\agents\codex.exe"),
             ("gemini", "D:/Agents/gemini.ps1"),
+            ("alacritty", r"C:\Program Files\Alacritty\alacritty.exe"),
         ]);
 
         assert_eq!(
@@ -191,6 +218,10 @@ mod tests {
                 AgentInfo {
                     name: "gemini".into(),
                     path: "D:/Agents/gemini.ps1".into(),
+                },
+                AgentInfo {
+                    name: "alacritty".into(),
+                    path: r"C:\Program Files\Alacritty\alacritty.exe".into(),
                 },
             ]
         );
@@ -264,7 +295,12 @@ mod tests {
         let executable = directory.join("claude.cmd");
         std::fs::write(&executable, "@echo off").unwrap();
         let path = std::env::join_paths([&directory]).unwrap();
-        let provider = super::EnvironmentAgentSearchProvider { path: Some(path) };
+        let provider = super::EnvironmentAgentSearchProvider {
+            path: Some(path),
+            program_files: None,
+            program_files_x86: None,
+            local_app_data: None,
+        };
 
         assert_eq!(
             provider.find("claude").unwrap().as_deref(),
@@ -273,4 +309,38 @@ mod tests {
 
         std::fs::remove_dir_all(directory).unwrap();
     }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn finds_alacritty_under_program_files_when_it_is_not_on_path() {
+        let root = std::env::current_dir()
+            .unwrap()
+            .join("target")
+            .join(format!("alacritty-discovery-{}", std::process::id()));
+        let directory = root.join("Alacritty");
+        std::fs::create_dir_all(&directory).unwrap();
+        let executable = directory.join("alacritty.exe");
+        std::fs::write(&executable, []).unwrap();
+        let provider = super::EnvironmentAgentSearchProvider {
+            path: Some(std::ffi::OsString::new()),
+            program_files: Some(root.as_os_str().to_os_string()),
+            program_files_x86: None,
+            local_app_data: None,
+        };
+
+        assert_eq!(
+            provider.find("alacritty").unwrap().as_deref(),
+            Some(executable.to_string_lossy().as_ref())
+        );
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+}
+
+pub(crate) fn find_alacritty_executable() -> Result<String, String> {
+    EnvironmentAgentSearchProvider::from_environment()
+        .find("alacritty")?
+        .ok_or_else(|| {
+            "Alacritty was not found on PATH or under Program Files\\Alacritty".to_string()
+        })
 }

--- a/src-tauri/src/platform/windows/mod.rs
+++ b/src-tauri/src/platform/windows/mod.rs
@@ -91,6 +91,10 @@ pub async fn discover_agents(names: Vec<String>) -> Vec<AgentInfo> {
     agent_discovery::discover_agents(names).await
 }
 
+pub(crate) fn find_alacritty_executable() -> Result<String, String> {
+    agent_discovery::find_alacritty_executable()
+}
+
 pub fn inspect_process(_pid: i32) -> ProcessInspection {
     ProcessInspection {
         cwd: None,

--- a/src-tauri/src/prompt_assets.rs
+++ b/src-tauri/src/prompt_assets.rs
@@ -459,7 +459,8 @@ mod tests {
 
     #[test]
     fn reads_a_top_level_toml_description() {
-        let head = "name = \"plan-reviewer\"\ndescription = \"Reviews plans.\"\nmodel = \"inherit\"\n";
+        let head =
+            "name = \"plan-reviewer\"\ndescription = \"Reviews plans.\"\nmodel = \"inherit\"\n";
         assert_eq!(
             parse_toml_description(head),
             Some("Reviews plans.".to_string())
@@ -602,12 +603,14 @@ mod tests {
         write_skill(&plugin, "brainstorming", "plugin one");
         let plugins_dir = home.join(".claude/plugins");
         std::fs::create_dir_all(&plugins_dir).unwrap();
+        let registry = serde_json::json!({
+            "plugins": {
+                "superpowers@official": [{ "installPath": plugin }]
+            }
+        });
         std::fs::write(
             plugins_dir.join("installed_plugins.json"),
-            format!(
-                "{{\"plugins\":{{\"superpowers@official\":[{{\"installPath\":\"{}\"}}]}}}}",
-                plugin.to_string_lossy()
-            ),
+            registry.to_string(),
         )
         .unwrap();
 

--- a/src/lib/agent-catalog.ts
+++ b/src/lib/agent-catalog.ts
@@ -36,6 +36,9 @@ export const BUILTIN_AGENTS: readonly BuiltinAgent[] = [
   // order and the digit key that opens each one.
   { id: "agy", label: "Antigravity" },
   { id: "gemini", label: "Gemini CLI" },
+  // On Windows this is handled as a native pane renderer rather than typed
+  // into an xterm shell. The backend excludes it from discovery elsewhere.
+  { id: "alacritty", label: "Alacritty" },
 ];
 
 export const CUSTOM_ID_PREFIX = "custom:";

--- a/src/lib/layout-validation.test.ts
+++ b/src/lib/layout-validation.test.ts
@@ -2,6 +2,20 @@ import { describe, expect, it } from "vitest";
 import { validateLayout } from "./layout-validation";
 
 describe("validateLayout", () => {
+  it("preserves supported pane renderer types and defaults unknown values", () => {
+    expect(validateLayout({ type: "leaf", paneType: "alacritty" })).toEqual({
+      type: "leaf",
+      paneType: "alacritty",
+    });
+    expect(validateLayout({ type: "leaf", paneType: "xterm" })).toEqual({
+      type: "leaf",
+      paneType: "xterm",
+    });
+    expect(validateLayout({ type: "leaf", paneType: "future" })).toEqual({
+      type: "leaf",
+    });
+  });
+
   it("accepts a leaf", () => {
     expect(validateLayout({ type: "leaf" })).toEqual({ type: "leaf" });
   });

--- a/src/lib/layout-validation.ts
+++ b/src/lib/layout-validation.ts
@@ -13,6 +13,9 @@ export function validateLayout(
   }
   const node = raw as Record<string, unknown>;
   if (node.type === "leaf") {
+    if (node.paneType === "xterm" || node.paneType === "alacritty") {
+      return { type: "leaf", paneType: node.paneType };
+    }
     return { type: "leaf" };
   }
   if (node.type !== "split") {

--- a/src/lib/split-tree.test.ts
+++ b/src/lib/split-tree.test.ts
@@ -7,6 +7,7 @@ import {
   movePane,
   ratioEntries,
   serializeTree,
+  serializedPaneTypes,
   setRatio,
   splitLeaf,
   swapLeaves,
@@ -31,6 +32,18 @@ describe("serializeTree", () => {
         second: { type: "leaf" },
       },
     });
+  });
+
+  it("optionally preserves pane renderer types", () => {
+    const tree = splitLeaf(leaf(10), 10, 20, "row");
+    const serialized = serializeTree(tree, (id) =>
+      id === 20 ? "alacritty" : "xterm",
+    );
+    expect(serialized).toMatchObject({
+      first: { type: "leaf", paneType: "xterm" },
+      second: { type: "leaf", paneType: "alacritty" },
+    });
+    expect(serializedPaneTypes(serialized)).toEqual(["xterm", "alacritty"]);
   });
 });
 

--- a/src/lib/split-tree.ts
+++ b/src/lib/split-tree.ts
@@ -246,6 +246,8 @@ export function ratioEntries(node: TreeNode): RatioEntry[] {
 
 export interface SerializedLeaf {
   readonly type: "leaf";
+  /** Missing in legacy layouts; callers must treat it as xterm. */
+  readonly paneType?: "xterm" | "alacritty";
 }
 
 export interface SerializedSplit {
@@ -259,17 +261,34 @@ export interface SerializedSplit {
 export type SerializedNode = SerializedLeaf | SerializedSplit;
 
 /** Structure-only snapshot for session persistence — pane ids are dropped. */
-export function serializeTree(node: TreeNode): SerializedNode {
+export function serializeTree(
+  node: TreeNode,
+  paneTypeFor?: (paneId: number) => "xterm" | "alacritty",
+): SerializedNode {
   if (node.kind === "leaf") {
-    return { type: "leaf" };
+    const paneType = paneTypeFor?.(node.paneId);
+    return paneType === undefined ? { type: "leaf" } : { type: "leaf", paneType };
   }
   return {
     type: "split",
     direction: node.dir,
     ratio: node.ratio,
-    first: serializeTree(node.a),
-    second: serializeTree(node.b),
+    first: serializeTree(node.a, paneTypeFor),
+    second: serializeTree(node.b, paneTypeFor),
   };
+}
+
+/** Serialized pane types in the same left-to-right order used by treeFromLayout. */
+export function serializedPaneTypes(
+  layout: SerializedNode,
+): Array<"xterm" | "alacritty"> {
+  if (layout.type === "leaf") {
+    return [layout.paneType === "alacritty" ? "alacritty" : "xterm"];
+  }
+  return [
+    ...serializedPaneTypes(layout.first),
+    ...serializedPaneTypes(layout.second),
+  ];
 }
 
 export function countLeaves(layout: SerializedNode): number {

--- a/src/settings/settings-schema.test.ts
+++ b/src/settings/settings-schema.test.ts
@@ -213,3 +213,44 @@ describe("promptTemplates validation", () => {
     expect(validateSettings(raw).promptTemplates).toEqual([good]);
   });
 });
+
+describe("terminalBackground", () => {
+  it("supplies backward-compatible defaults", () => {
+    expect(validateSettings({}).terminalBackground).toEqual(
+      DEFAULT_SETTINGS.terminalBackground,
+    );
+  });
+
+  it("keeps supported image options and clamps numeric controls", () => {
+    expect(
+      validateSettings({
+        terminalBackground: {
+          imageDataUrl: "data:image/png;base64,AA==",
+          target: "alacritty",
+          fit: "contain",
+          dim: 5,
+          nativeOpacity: 0.1,
+        },
+      }).terminalBackground,
+    ).toEqual({
+      imageDataUrl: "data:image/png;base64,AA==",
+      target: "alacritty",
+      fit: "contain",
+      dim: 0.9,
+      nativeOpacity: 0.4,
+    });
+  });
+
+  it("rejects unsafe image values and unknown selectors", () => {
+    const value = validateSettings({
+      terminalBackground: {
+        imageDataUrl: "https://example.test/image.png",
+        target: "other",
+        fit: "tile",
+      },
+    }).terminalBackground;
+    expect(value.imageDataUrl).toBe("");
+    expect(value.target).toBe("all");
+    expect(value.fit).toBe("cover");
+  });
+});

--- a/src/settings/settings-schema.ts
+++ b/src/settings/settings-schema.ts
@@ -18,6 +18,20 @@ export interface TerminalColors {
   selectionBackground: string;
 }
 
+export type TerminalBackgroundTarget = "all" | "xterm" | "alacritty";
+export type TerminalBackgroundFit = "cover" | "contain" | "stretch";
+
+export interface TerminalBackgroundSettings {
+  /** Persisted data URL; empty means no image. */
+  imageDataUrl: string;
+  target: TerminalBackgroundTarget;
+  fit: TerminalBackgroundFit;
+  /** Darkness painted above the image, from 0 (none) to 0.9. */
+  dim: number;
+  /** Native Alacritty background opacity, from 0.4 to 1. */
+  nativeOpacity: number;
+}
+
 /** `left` = workspace sidebar (default), `top` = the classic horizontal bar. */
 export type TabBarPosition = "top" | "left";
 
@@ -40,6 +54,7 @@ export interface Settings {
   customAgents: readonly CustomAgent[];
   /** Reusable prompt bodies the user declared for the Prompt Board. */
   promptTemplates: readonly PromptTemplate[];
+  terminalBackground: TerminalBackgroundSettings;
 }
 
 export const FONT_SIZE_MIN = 10;
@@ -74,6 +89,13 @@ export const DEFAULT_SETTINGS: Settings = {
   scrollback: 10_000,
   customAgents: [],
   promptTemplates: [],
+  terminalBackground: {
+    imageDataUrl: "",
+    target: "all",
+    fit: "cover",
+    dim: 0.35,
+    nativeOpacity: 0.9,
+  },
 };
 
 const HEX_COLOR = /^#[0-9a-fA-F]{6}$/;
@@ -195,6 +217,45 @@ function validatePromptTemplates(raw: unknown): readonly PromptTemplate[] {
   return result;
 }
 
+function validateTerminalBackground(raw: unknown): TerminalBackgroundSettings {
+  if (typeof raw !== "object" || raw === null) {
+    return DEFAULT_SETTINGS.terminalBackground;
+  }
+  const source = raw as Record<string, unknown>;
+  const targets: readonly TerminalBackgroundTarget[] = [
+    "all",
+    "xterm",
+    "alacritty",
+  ];
+  const fits: readonly TerminalBackgroundFit[] = [
+    "cover",
+    "contain",
+    "stretch",
+  ];
+  return {
+    imageDataUrl:
+      typeof source.imageDataUrl === "string" &&
+      (source.imageDataUrl === "" || source.imageDataUrl.startsWith("data:image/"))
+        ? source.imageDataUrl
+        : "",
+    target: targets.includes(source.target as TerminalBackgroundTarget)
+      ? (source.target as TerminalBackgroundTarget)
+      : DEFAULT_SETTINGS.terminalBackground.target,
+    fit: fits.includes(source.fit as TerminalBackgroundFit)
+      ? (source.fit as TerminalBackgroundFit)
+      : DEFAULT_SETTINGS.terminalBackground.fit,
+    dim:
+      typeof source.dim === "number" && Number.isFinite(source.dim)
+        ? Math.min(0.9, Math.max(0, source.dim))
+        : DEFAULT_SETTINGS.terminalBackground.dim,
+    nativeOpacity:
+      typeof source.nativeOpacity === "number" &&
+      Number.isFinite(source.nativeOpacity)
+        ? Math.min(1, Math.max(0.4, source.nativeOpacity))
+        : DEFAULT_SETTINGS.terminalBackground.nativeOpacity,
+  };
+}
+
 /** Validate data read from the store — invalid fields fall back to defaults. */
 export function validateSettings(raw: unknown): Settings {
   if (typeof raw !== "object" || raw === null) {
@@ -244,5 +305,6 @@ export function validateSettings(raw: unknown): Settings {
         : DEFAULT_SETTINGS.scrollback,
     customAgents: validateCustomAgents(source.customAgents),
     promptTemplates: validatePromptTemplates(source.promptTemplates),
+    terminalBackground: validateTerminalBackground(source.terminalBackground),
   };
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -717,6 +717,14 @@ button.attn-mark:hover {
   display: flex;
 }
 
+/* Native terminal windows and xterm canvases must never paint through a
+   board/settings/modal transition. Keep layout geometry stable for the next
+   reveal while suppressing the covered terminal surface completely. */
+.stage__tabs.is-covered {
+  visibility: hidden;
+  pointer-events: none;
+}
+
 .tab-stage {
   flex: 1;
   min-width: 0;

--- a/src/styles.css
+++ b/src/styles.css
@@ -840,6 +840,33 @@ button.attn-mark:hover {
   transition: box-shadow 0.18s ease;
 }
 
+.pane::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(
+      rgb(0 0 0 / var(--pane-background-dim, 0)),
+      rgb(0 0 0 / var(--pane-background-dim, 0))
+    ),
+    var(--pane-background-image, none);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: var(--pane-background-size, cover);
+  opacity: 0;
+}
+
+.pane.pane--has-background::before {
+  opacity: 1;
+}
+
+.pane > * {
+  position: relative;
+  z-index: 1;
+}
+
 /* Active pane (only when >1 pane): an inset accent hairline, no border box
    and no radius — panes sit flush, separated only by the 1px dividers. */
 .pane-slot.is-active .pane {
@@ -1011,6 +1038,65 @@ button.attn-mark:hover {
   padding: 0;
 }
 
+.pane--has-background .pane__term,
+.pane--has-background .xterm,
+.pane--has-background .xterm-screen {
+  background: transparent !important;
+}
+
+.pane__native-error {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: 12px;
+  z-index: 8;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in srgb, var(--red) 55%, var(--hair));
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--chrome-2) 92%, transparent);
+  color: var(--red);
+  font: 11px var(--ui-font);
+}
+
+.pane__native-error[hidden] {
+  display: none;
+}
+
+.pane__native-error button {
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+}
+
+.cfg-background-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.cfg-background-preview {
+  width: 28px;
+  height: 20px;
+  border: 1px solid var(--hair-strong);
+  border-radius: 4px;
+  background-position: center;
+  background-size: cover;
+}
+
+.cfg-btn--compact {
+  padding-inline: 7px;
+}
+
+.cfg-range {
+  width: 116px;
+  accent-color: var(--accent);
+}
+
 .pane__term .xterm {
   height: 100%;
 }
@@ -1114,8 +1200,6 @@ button.attn-mark:hover {
   border-radius: 50%;
   background: var(--green);
 }
-
-/* ── Settings panel: slide-over anchored to the stage's right edge ── */
 
 /* ── Config rows: the one control (docs/DESIGN-LANGUAGE.md §5–6) ── */
 

--- a/src/terminal/close-coordinator.test.ts
+++ b/src/terminal/close-coordinator.test.ts
@@ -3,104 +3,132 @@ import { createCloseCoordinator } from "./close-coordinator";
 import type { TerminalManager } from "./terminal-manager";
 
 function mockManager(
-    overrides: Partial<TerminalManager> & {
-        paneCount(): number;
-        activePaneId(): number | null;
-        paneIds(): number[];
-    },
+  overrides: Partial<TerminalManager> & {
+    paneCount(): number;
+    activePaneId(): number | null;
+    paneIds(): number[];
+  },
 ): TerminalManager {
-    return overrides as TerminalManager;
+  return {
+    ptyPaneIds: () => overrides.paneIds(),
+    ...overrides,
+  } as TerminalManager;
 }
 
 describe("createCloseCoordinator", () => {
-    it("routes last pane to closeTab", async () => {
-        const disposeTab = vi.fn(async () => undefined);
-        const confirmClose = vi.fn(async () => true);
-        const manager = mockManager({
-            paneCount: () => 1,
-            activePaneId: () => 1,
-            paneIds: () => [1],
-            closePaneById: vi.fn(),
-        });
-        const entry = { manager };
-        const coord = createCloseCoordinator({
-            confirmClose,
-            activeManager: () => manager,
-            activeIndex: () => 0,
-            tabAt: () => entry,
-            indexOf: () => 0,
-            disposeTab,
-        });
-        await coord.closePane();
-        expect(confirmClose).toHaveBeenCalledWith([1]);
-        expect(disposeTab).toHaveBeenCalledWith(0);
-        expect(manager.closePaneById).not.toHaveBeenCalled();
+  it("routes last pane to closeTab", async () => {
+    const disposeTab = vi.fn(async () => undefined);
+    const confirmClose = vi.fn(async () => true);
+    const manager = mockManager({
+      paneCount: () => 1,
+      activePaneId: () => 1,
+      paneIds: () => [1],
+      closePaneById: vi.fn(),
+    });
+    const entry = { manager };
+    const coord = createCloseCoordinator({
+      confirmClose,
+      activeManager: () => manager,
+      activeIndex: () => 0,
+      tabAt: () => entry,
+      indexOf: () => 0,
+      disposeTab,
+    });
+    await coord.closePane();
+    expect(confirmClose).toHaveBeenCalledWith([1]);
+    expect(disposeTab).toHaveBeenCalledWith(0);
+    expect(manager.closePaneById).not.toHaveBeenCalled();
+  });
+
+  it("closes the confirmed pane id, not a later active pane", async () => {
+    const closePaneById = vi.fn(async () => undefined);
+    let activeId = 7;
+    const manager = mockManager({
+      paneCount: () => 2,
+      activePaneId: () => activeId,
+      paneIds: () => [7, 8],
+      closePaneById,
+    });
+    const confirmClose = vi.fn(async () => {
+      activeId = 8; // focus moved during dialog
+      return true;
+    });
+    const coord = createCloseCoordinator({
+      confirmClose,
+      activeManager: () => manager,
+      activeIndex: () => 0,
+      tabAt: () => ({ manager }),
+      indexOf: () => 0,
+      disposeTab: vi.fn(),
+    });
+    await coord.closePane();
+    expect(closePaneById).toHaveBeenCalledWith(7);
+  });
+
+  it("closes a native pane without sending its id through the PTY busy guard", async () => {
+    const closePaneById = vi.fn(async () => undefined);
+    const confirmClose = vi.fn(async () => true);
+    const manager = mockManager({
+      paneCount: () => 2,
+      activePaneId: () => 0x8000_0000,
+      paneIds: () => [1, 0x8000_0000],
+      ptyPaneIds: () => [1],
+      closePaneById,
+    });
+    const coord = createCloseCoordinator({
+      confirmClose,
+      activeManager: () => manager,
+      activeIndex: () => 0,
+      tabAt: () => ({ manager }),
+      indexOf: () => 0,
+      disposeTab: vi.fn(),
     });
 
-    it("closes the confirmed pane id, not a later active pane", async () => {
-        const closePaneById = vi.fn(async () => undefined);
-        let activeId = 7;
-        const manager = mockManager({
-            paneCount: () => 2,
-            activePaneId: () => activeId,
-            paneIds: () => [7, 8],
-            closePaneById,
-        });
-        const confirmClose = vi.fn(async () => {
-            activeId = 8; // focus moved during dialog
-            return true;
-        });
-        const coord = createCloseCoordinator({
-            confirmClose,
-            activeManager: () => manager,
-            activeIndex: () => 0,
-            tabAt: () => ({ manager }),
-            indexOf: () => 0,
-            disposeTab: vi.fn(),
-        });
-        await coord.closePane();
-        expect(closePaneById).toHaveBeenCalledWith(7);
-    });
+    await coord.closePane();
 
-    it("aborts when Busy dialog declines", async () => {
-        const disposeTab = vi.fn();
-        const manager = mockManager({
-            paneCount: () => 1,
-            activePaneId: () => 1,
-            paneIds: () => [1],
-            closePaneById: vi.fn(),
-        });
-        const entry = { manager };
-        const coord = createCloseCoordinator({
-            confirmClose: async () => false,
-            activeManager: () => manager,
-            activeIndex: () => 0,
-            tabAt: () => entry,
-            indexOf: () => 0,
-            disposeTab,
-        });
-        await coord.closeTab(0);
-        expect(disposeTab).not.toHaveBeenCalled();
-    });
+    expect(confirmClose).not.toHaveBeenCalled();
+    expect(closePaneById).toHaveBeenCalledWith(0x8000_0000);
+  });
 
-    it("skips dispose when tab vanished during dialog", async () => {
-        const disposeTab = vi.fn();
-        const manager = mockManager({
-            paneCount: () => 1,
-            activePaneId: () => 1,
-            paneIds: () => [1],
-            closePaneById: vi.fn(),
-        });
-        const entry = { manager };
-        const coord = createCloseCoordinator({
-            confirmClose: async () => true,
-            activeManager: () => manager,
-            activeIndex: () => 0,
-            tabAt: () => entry,
-            indexOf: () => -1,
-            disposeTab,
-        });
-        await coord.closeTab(0);
-        expect(disposeTab).not.toHaveBeenCalled();
+  it("aborts when Busy dialog declines", async () => {
+    const disposeTab = vi.fn();
+    const manager = mockManager({
+      paneCount: () => 1,
+      activePaneId: () => 1,
+      paneIds: () => [1],
+      closePaneById: vi.fn(),
     });
+    const entry = { manager };
+    const coord = createCloseCoordinator({
+      confirmClose: async () => false,
+      activeManager: () => manager,
+      activeIndex: () => 0,
+      tabAt: () => entry,
+      indexOf: () => 0,
+      disposeTab,
+    });
+    await coord.closeTab(0);
+    expect(disposeTab).not.toHaveBeenCalled();
+  });
+
+  it("skips dispose when tab vanished during dialog", async () => {
+    const disposeTab = vi.fn();
+    const manager = mockManager({
+      paneCount: () => 1,
+      activePaneId: () => 1,
+      paneIds: () => [1],
+      closePaneById: vi.fn(),
+    });
+    const entry = { manager };
+    const coord = createCloseCoordinator({
+      confirmClose: async () => true,
+      activeManager: () => manager,
+      activeIndex: () => 0,
+      tabAt: () => entry,
+      indexOf: () => -1,
+      disposeTab,
+    });
+    await coord.closeTab(0);
+    expect(disposeTab).not.toHaveBeenCalled();
+  });
 });

--- a/src/terminal/close-coordinator.test.ts
+++ b/src/terminal/close-coordinator.test.ts
@@ -65,7 +65,33 @@ describe("createCloseCoordinator", () => {
     expect(closePaneById).toHaveBeenCalledWith(7);
   });
 
-  it("closes a native pane without sending its id through the PTY busy guard", async () => {
+  it("guards native and PTY panes together when closing a tab", async () => {
+    const confirmClose = vi.fn(async () => true);
+    const disposeTab = vi.fn(async () => undefined);
+    const manager = mockManager({
+      paneCount: () => 2,
+      activePaneId: () => 1,
+      paneIds: () => [1, 0x8000_0000],
+      ptyPaneIds: () => [1],
+      closePaneById: vi.fn(),
+    });
+    const entry = { manager };
+    const coord = createCloseCoordinator({
+      confirmClose,
+      activeManager: () => manager,
+      activeIndex: () => 0,
+      tabAt: () => entry,
+      indexOf: () => 0,
+      disposeTab,
+    });
+
+    await coord.closeTab(0);
+
+    expect(confirmClose).toHaveBeenCalledWith([1, 0x8000_0000]);
+    expect(disposeTab).toHaveBeenCalledWith(0);
+  });
+
+  it("requires confirmation before closing a native pane", async () => {
     const closePaneById = vi.fn(async () => undefined);
     const confirmClose = vi.fn(async () => true);
     const manager = mockManager({
@@ -86,8 +112,31 @@ describe("createCloseCoordinator", () => {
 
     await coord.closePane();
 
-    expect(confirmClose).not.toHaveBeenCalled();
+    expect(confirmClose).toHaveBeenCalledWith([0x8000_0000]);
     expect(closePaneById).toHaveBeenCalledWith(0x8000_0000);
+  });
+
+  it("does not close a native pane when confirmation is declined", async () => {
+    const closePaneById = vi.fn(async () => undefined);
+    const manager = mockManager({
+      paneCount: () => 2,
+      activePaneId: () => 0x8000_0000,
+      paneIds: () => [1, 0x8000_0000],
+      ptyPaneIds: () => [1],
+      closePaneById,
+    });
+    const coord = createCloseCoordinator({
+      confirmClose: vi.fn(async () => false),
+      activeManager: () => manager,
+      activeIndex: () => 0,
+      tabAt: () => ({ manager }),
+      indexOf: () => 0,
+      disposeTab: vi.fn(),
+    });
+
+    await coord.closePane();
+
+    expect(closePaneById).not.toHaveBeenCalled();
   });
 
   it("aborts when Busy dialog declines", async () => {

--- a/src/terminal/close-coordinator.ts
+++ b/src/terminal/close-coordinator.ts
@@ -38,7 +38,10 @@ export function createCloseCoordinator(
     if (!entry) {
       return;
     }
-    if (!(await deps.confirmClose(entry.manager.ptyPaneIds()))) {
+    // Native panes cannot be inspected through PTY IPC. Passing every pane id
+    // makes them explicit "unknown" processes in the close guard, which asks
+    // before terminating them instead of treating them as idle.
+    if (!(await deps.confirmClose(entry.manager.paneIds()))) {
       return;
     }
     const currentIndex = deps.indexOf(entry);
@@ -61,10 +64,7 @@ export function createCloseCoordinator(
     if (paneId === null) {
       return;
     }
-    if (
-      manager.ptyPaneIds().includes(paneId) &&
-      !(await deps.confirmClose([paneId]))
-    ) {
+    if (!(await deps.confirmClose([paneId]))) {
       return;
     }
     // Close the pane the user confirmed, not whichever is active now —

--- a/src/terminal/close-coordinator.ts
+++ b/src/terminal/close-coordinator.ts
@@ -5,67 +5,72 @@ import type { TerminalManager } from "./terminal-manager";
  * Keeps Busy confirmation and dispose/quit behind one interface.
  */
 export interface CloseCoordinatorDeps {
-    /** Fresh Busy check + native dialog; true → proceed. */
-    confirmClose(paneIds: readonly number[]): Promise<boolean>;
-    activeManager(): TerminalManager | null;
-    activeIndex(): number;
-    tabAt(index: number): { manager: TerminalManager } | undefined;
-    /** Index of a tab entry after the dialog may have shifted the list. */
-    indexOf(entry: { manager: TerminalManager }): number;
-    /** Dispose + Closed tab snapshot + last-tab quit. Already unguarded. */
-    disposeTab(index: number): Promise<void>;
+  /** Fresh Busy check + native dialog; true → proceed. */
+  confirmClose(paneIds: readonly number[]): Promise<boolean>;
+  activeManager(): TerminalManager | null;
+  activeIndex(): number;
+  tabAt(index: number): { manager: TerminalManager } | undefined;
+  /** Index of a tab entry after the dialog may have shifted the list. */
+  indexOf(entry: { manager: TerminalManager }): number;
+  /** Dispose + Closed tab snapshot + last-tab quit. Already unguarded. */
+  disposeTab(index: number): Promise<void>;
 }
 
 export interface CloseCoordinator {
-    /**
-     * Cmd+W (iTerm2): last pane in the Tab → close the Tab;
-     * otherwise close the Focused pane. One Busy dialog on the final target.
-     */
-    closePane(): Promise<void>;
-    /** Close a Tab after Busy guard on every Pane. */
-    closeTab(index: number): Promise<void>;
+  /**
+   * Cmd+W (iTerm2): last pane in the Tab → close the Tab;
+   * otherwise close the Focused pane. One Busy dialog on the final target.
+   */
+  closePane(): Promise<void>;
+  /** Close a Tab after Busy guard on every Pane. */
+  closeTab(index: number): Promise<void>;
 }
 
 /**
  * Deep Close lifecycle: routing, post-dialog ID pin, Busy guard.
  * Auto-exit in TerminalManager stays outside — it is not a user Close.
  */
-export function createCloseCoordinator(deps: CloseCoordinatorDeps): CloseCoordinator {
-    async function closeTab(index: number): Promise<void> {
-        const entry = deps.tabAt(index);
-        if (!entry) {
-            return;
-        }
-        if (!(await deps.confirmClose(entry.manager.paneIds()))) {
-            return;
-        }
-        const currentIndex = deps.indexOf(entry);
-        if (currentIndex === -1) {
-            return;
-        }
-        await deps.disposeTab(currentIndex);
+export function createCloseCoordinator(
+  deps: CloseCoordinatorDeps,
+): CloseCoordinator {
+  async function closeTab(index: number): Promise<void> {
+    const entry = deps.tabAt(index);
+    if (!entry) {
+      return;
     }
-
-    async function closePane(): Promise<void> {
-        const manager = deps.activeManager();
-        if (!manager) {
-            return;
-        }
-        if (manager.paneCount() <= 1) {
-            await closeTab(deps.activeIndex());
-            return;
-        }
-        const paneId = manager.activePaneId();
-        if (paneId === null) {
-            return;
-        }
-        if (!(await deps.confirmClose([paneId]))) {
-            return;
-        }
-        // Close the pane the user confirmed, not whichever is active now —
-        // a pty:exit during the dialog can move focus to a different pane.
-        await manager.closePaneById(paneId);
+    if (!(await deps.confirmClose(entry.manager.ptyPaneIds()))) {
+      return;
     }
+    const currentIndex = deps.indexOf(entry);
+    if (currentIndex === -1) {
+      return;
+    }
+    await deps.disposeTab(currentIndex);
+  }
 
-    return { closePane, closeTab };
+  async function closePane(): Promise<void> {
+    const manager = deps.activeManager();
+    if (!manager) {
+      return;
+    }
+    if (manager.paneCount() <= 1) {
+      await closeTab(deps.activeIndex());
+      return;
+    }
+    const paneId = manager.activePaneId();
+    if (paneId === null) {
+      return;
+    }
+    if (
+      manager.ptyPaneIds().includes(paneId) &&
+      !(await deps.confirmClose([paneId]))
+    ) {
+      return;
+    }
+    // Close the pane the user confirmed, not whichever is active now —
+    // a pty:exit during the dialog can move focus to a different pane.
+    await manager.closePaneById(paneId);
+  }
+
+  return { closePane, closeTab };
 }

--- a/src/terminal/native-appearance.ts
+++ b/src/terminal/native-appearance.ts
@@ -1,0 +1,38 @@
+import type { Settings } from "../settings/settings-schema";
+import { resolveTheme } from "../settings/themes";
+import { paneUsesBackgroundImage } from "./pane-background";
+
+export interface NativeTerminalAppearance {
+  readonly fontFamily: string;
+  readonly fontSize: number;
+  readonly background: string;
+  readonly foreground: string;
+  readonly cursor: string;
+  readonly selectionBackground: string;
+  readonly normal: readonly string[];
+  readonly bright: readonly string[];
+  readonly opacity: number;
+  readonly scrollback: number;
+}
+const NORMAL_KEYS = ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"] as const;
+const BRIGHT_KEYS = ["brightBlack", "brightRed", "brightGreen", "brightYellow", "brightBlue", "brightMagenta", "brightCyan", "brightWhite"] as const;
+
+export function nativeTerminalAppearance(settings: Settings): NativeTerminalAppearance {
+  const theme = resolveTheme(settings);
+  const presetFallback = "#c0caf5";
+  return {
+    fontFamily: settings.fontFamily.split(",")[0].trim().replace(/^['"]|['"]$/g, ""),
+    // xterm uses CSS pixels; Alacritty uses points. Both are logical units at 96 DPI.
+    fontSize: Number((settings.fontSize * 0.75).toFixed(2)),
+    background: theme.background ?? "#16161e",
+    foreground: theme.foreground ?? presetFallback,
+    cursor: theme.cursor ?? theme.foreground ?? presetFallback,
+    selectionBackground: theme.selectionBackground ?? "#33467c",
+    normal: NORMAL_KEYS.map((key) => theme[key] ?? presetFallback),
+    bright: BRIGHT_KEYS.map((key) => theme[key] ?? presetFallback),
+    opacity: paneUsesBackgroundImage(settings, "alacritty")
+      ? settings.terminalBackground.nativeOpacity
+      : 1,
+    scrollback: settings.scrollback,
+  };
+}

--- a/src/terminal/native-pane-client.ts
+++ b/src/terminal/native-pane-client.ts
@@ -9,6 +9,11 @@ export interface NativePaneBounds {
   readonly height: number;
 }
 export interface NativePaneClient {
+  /**
+   * Native windows paint above the WebView. This is the single global gate
+   * that prevents them from being revealed while a board/modal covers panes.
+   */
+  setOccluded(occluded: boolean): Promise<void>;
   spawnAlacritty(
     cwd: string | null,
     appearance: NativeTerminalAppearance,
@@ -41,15 +46,30 @@ export type NativeTerminalAction =
   | "scroll-bottom";
 
 export function createTauriNativePaneClient(): NativePaneClient {
+  let epoch = 0;
+  let desiredOccluded = true;
+  let occlusionRequest: Promise<void> = Promise.resolve();
   return {
+    setOccluded(occluded) {
+      if (occluded === desiredOccluded) {
+        return occlusionRequest;
+      }
+      desiredOccluded = occluded;
+      epoch += 1;
+      occlusionRequest = invoke("set_alacritty_occluded", {
+        epoch,
+        occluded,
+      });
+      return occlusionRequest;
+    },
     spawnAlacritty(cwd, appearance) {
       return invoke<number>("spawn_alacritty", { cwd, appearance });
     },
     updateAlacritty(id, bounds, visible) {
-      return invoke("update_alacritty", { id, bounds, visible });
+      return invoke("update_alacritty", { id, bounds, visible, epoch });
     },
     focusAlacritty(id) {
-      return invoke("focus_alacritty", { id });
+      return invoke("focus_alacritty", { id, epoch });
     },
     killAlacritty(id) {
       return invoke("kill_alacritty", { id });
@@ -83,6 +103,8 @@ export function createMemoryNativePaneClient(
     bounds: NativePaneBounds;
     visible: boolean;
   }>;
+  readonly occlusionUpdates: boolean[];
+  readonly occluded: boolean;
   emitFocus(id: number): void;
 } {
   const sessions = new Set<number>();
@@ -93,10 +115,22 @@ export function createMemoryNativePaneClient(
     visible: boolean;
   }> = [];
   const focusHandlers = new Set<(id: number) => void>();
+  const occlusionUpdates: boolean[] = [];
+  let occluded = true;
   return {
     sessions,
     spawnedCwds,
     updates,
+    occlusionUpdates,
+    get occluded() {
+      return occluded;
+    },
+    async setOccluded(next) {
+      if (next !== occluded) {
+        occluded = next;
+        occlusionUpdates.push(next);
+      }
+    },
     async spawnAlacritty(cwd) {
       const id = nextId;
       nextId += 1;

--- a/src/terminal/native-pane-client.ts
+++ b/src/terminal/native-pane-client.ts
@@ -78,7 +78,7 @@ export function createTauriNativePaneClient(): NativePaneClient {
       return invoke("apply_alacritty_appearance", { id, appearance });
     },
     performAlacrittyAction(id, action) {
-      return invoke("perform_alacritty_action", { id, action });
+      return invoke("perform_alacritty_action", { id, action, epoch });
     },
     listenFocus(handler) {
       if (!("__TAURI_INTERNALS__" in globalThis)) {

--- a/src/terminal/native-pane-client.ts
+++ b/src/terminal/native-pane-client.ts
@@ -1,0 +1,128 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import type { NativeTerminalAppearance } from "./native-appearance";
+
+export interface NativePaneBounds {
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+  readonly height: number;
+}
+export interface NativePaneClient {
+  spawnAlacritty(
+    cwd: string | null,
+    appearance: NativeTerminalAppearance,
+  ): Promise<number>;
+  updateAlacritty(
+    id: number,
+    bounds: NativePaneBounds,
+    visible: boolean,
+  ): Promise<void>;
+  focusAlacritty(id: number): Promise<void>;
+  killAlacritty(id: number): Promise<void>;
+  applyAlacrittyAppearance(
+    id: number,
+    appearance: NativeTerminalAppearance,
+  ): Promise<void>;
+  performAlacrittyAction(id: number, action: NativeTerminalAction): Promise<void>;
+  listenFocus(handler: (id: number) => void): Promise<UnlistenFn>;
+}
+
+export type NativeTerminalAction =
+  | "copy"
+  | "paste"
+  | "search"
+  | "search-next"
+  | "search-previous"
+  | "clear"
+  | "page-up"
+  | "page-down"
+  | "scroll-top"
+  | "scroll-bottom";
+
+export function createTauriNativePaneClient(): NativePaneClient {
+  return {
+    spawnAlacritty(cwd, appearance) {
+      return invoke<number>("spawn_alacritty", { cwd, appearance });
+    },
+    updateAlacritty(id, bounds, visible) {
+      return invoke("update_alacritty", { id, bounds, visible });
+    },
+    focusAlacritty(id) {
+      return invoke("focus_alacritty", { id });
+    },
+    killAlacritty(id) {
+      return invoke("kill_alacritty", { id });
+    },
+    applyAlacrittyAppearance(id, appearance) {
+      return invoke("apply_alacritty_appearance", { id, appearance });
+    },
+    performAlacrittyAction(id, action) {
+      return invoke("perform_alacritty_action", { id, action });
+    },
+    listenFocus(handler) {
+      if (!("__TAURI_INTERNALS__" in globalThis)) {
+        return Promise.resolve(() => {});
+      }
+      return listen<{ id: number }>("native-terminal:focus", (event) => {
+        handler(event.payload.id);
+      });
+    },
+  };
+}
+
+export const defaultNativePaneClient = createTauriNativePaneClient();
+
+export function createMemoryNativePaneClient(
+  nextId = 0x8000_0000,
+): NativePaneClient & {
+  readonly sessions: Set<number>;
+  readonly spawnedCwds: Array<string | null>;
+  readonly updates: Array<{
+    id: number;
+    bounds: NativePaneBounds;
+    visible: boolean;
+  }>;
+  emitFocus(id: number): void;
+} {
+  const sessions = new Set<number>();
+  const spawnedCwds: Array<string | null> = [];
+  const updates: Array<{
+    id: number;
+    bounds: NativePaneBounds;
+    visible: boolean;
+  }> = [];
+  const focusHandlers = new Set<(id: number) => void>();
+  return {
+    sessions,
+    spawnedCwds,
+    updates,
+    async spawnAlacritty(cwd) {
+      const id = nextId;
+      nextId += 1;
+      sessions.add(id);
+      spawnedCwds.push(cwd);
+      return id;
+    },
+    async updateAlacritty(id, bounds, visible) {
+      updates.push({ id, bounds, visible });
+    },
+    async focusAlacritty() {},
+    async killAlacritty(id) {
+      sessions.delete(id);
+    },
+    async applyAlacrittyAppearance() {},
+    async performAlacrittyAction() {},
+    async listenFocus(handler) {
+      focusHandlers.add(handler);
+      return () => {
+        focusHandlers.delete(handler);
+      };
+    },
+    emitFocus(id) {
+      for (const handler of focusHandlers) {
+        handler(id);
+      }
+    },
+  };
+}

--- a/src/terminal/native-pane.test.ts
+++ b/src/terminal/native-pane.test.ts
@@ -14,12 +14,27 @@ beforeAll(() => {
       unobserve() {}
     },
   );
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) =>
+    window.setTimeout(() => callback(performance.now()), 0),
+  );
+  vi.stubGlobal("cancelAnimationFrame", (id: number) =>
+    window.clearTimeout(id),
+  );
 });
 
 afterAll(() => vi.unstubAllGlobals());
 
 describe("createNativePane accessibility", () => {
   it("announces asynchronous failures and names the retry action", async () => {
+    const nativeClient = createMemoryNativePaneClient();
+    const updateError = new Error("native resize failed");
+    const client = {
+      ...nativeClient,
+      updateAlacritty: vi.fn(async () => {
+        throw updateError;
+      }),
+    };
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const pane = createNativePane(
       0x8000_0000,
       DEFAULT_SETTINGS,
@@ -29,10 +44,19 @@ describe("createNativePane accessibility", () => {
         onFocus: vi.fn(),
         onAttentionSignal: vi.fn(),
       },
-      createMemoryNativePaneClient(),
+      client,
     );
 
-    expect(pane.element.querySelector('[role="alert"]')).not.toBeNull();
+    document.body.appendChild(pane.element);
+    pane.mount();
+    pane.setVisible?.(true);
+
+    const alert = pane.element.querySelector<HTMLElement>('[role="alert"]');
+    expect(alert).not.toBeNull();
+    await vi.waitFor(() => {
+      expect(alert?.hidden).toBe(false);
+      expect(alert?.textContent).toContain("native resize failed");
+    });
     expect(
       pane.element.querySelector(
         'button[aria-label="Retry embedded Alacritty pane"]',
@@ -41,5 +65,6 @@ describe("createNativePane accessibility", () => {
     await expect(pane.pasteText("do not submit")).resolves.toBe(false);
 
     pane.dispose();
+    warn.mockRestore();
   });
 });

--- a/src/terminal/native-pane.test.ts
+++ b/src/terminal/native-pane.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { DEFAULT_SETTINGS } from "../settings/settings-schema";
+import { createMemoryNativePaneClient } from "./native-pane-client";
+import { createNativePane } from "./native-pane";
+
+beforeAll(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    },
+  );
+});
+
+afterAll(() => vi.unstubAllGlobals());
+
+describe("createNativePane accessibility", () => {
+  it("announces asynchronous failures and names the retry action", () => {
+    const pane = createNativePane(
+      0x8000_0000,
+      DEFAULT_SETTINGS,
+      {
+        onData: vi.fn(),
+        onResize: vi.fn(),
+        onFocus: vi.fn(),
+        onAttentionSignal: vi.fn(),
+      },
+      createMemoryNativePaneClient(),
+    );
+
+    expect(pane.element.querySelector('[role="alert"]')).not.toBeNull();
+    expect(
+      pane.element.querySelector(
+        'button[aria-label="Retry embedded Alacritty pane"]',
+      ),
+    ).not.toBeNull();
+
+    pane.dispose();
+  });
+});

--- a/src/terminal/native-pane.test.ts
+++ b/src/terminal/native-pane.test.ts
@@ -19,7 +19,7 @@ beforeAll(() => {
 afterAll(() => vi.unstubAllGlobals());
 
 describe("createNativePane accessibility", () => {
-  it("announces asynchronous failures and names the retry action", () => {
+  it("announces asynchronous failures and names the retry action", async () => {
     const pane = createNativePane(
       0x8000_0000,
       DEFAULT_SETTINGS,
@@ -38,6 +38,7 @@ describe("createNativePane accessibility", () => {
         'button[aria-label="Retry embedded Alacritty pane"]',
       ),
     ).not.toBeNull();
+    await expect(pane.pasteText("do not submit")).resolves.toBe(false);
 
     pane.dispose();
   });

--- a/src/terminal/native-pane.ts
+++ b/src/terminal/native-pane.ts
@@ -1,0 +1,229 @@
+import { SearchAddon } from "@xterm/addon-search";
+import type { Settings } from "../settings/settings-schema";
+import type { PaneHeaderInfo } from "../lib/process-info";
+import type { Pane, PaneEvents } from "./pane";
+import type { NativePaneClient } from "./native-pane-client";
+import { applyPaneBackground } from "./pane-background";
+import { nativeTerminalAppearance } from "./native-appearance";
+
+export function createNativePane(
+  id: number,
+  _initial: Settings,
+  events: PaneEvents,
+  client: NativePaneClient,
+): Pane {
+  const element = document.createElement("div");
+  element.className = "pane pane--native";
+  applyPaneBackground(element, _initial, "alacritty");
+
+  const bar = document.createElement("div");
+  bar.className = "pane__bar";
+  const dot = document.createElement("span");
+  dot.className = "pane__dot";
+  const cwdEl = document.createElement("span");
+  cwdEl.className = "pane__cwd";
+  const badge = document.createElement("span");
+  badge.className = "pane__badge pane__badge--agent";
+  badge.textContent = "alacritty";
+  bar.append(dot, cwdEl, badge);
+
+  const anchor = document.createElement("div");
+  anchor.className = "pane__anchor";
+  const anchorGrip = document.createElement("span");
+  anchorGrip.className = "pane__anchor-grip";
+  anchorGrip.textContent = "⋮⋮";
+  const anchorCwd = document.createElement("span");
+  anchorCwd.className = "pane__anchor-cwd";
+  anchor.append(anchorGrip, anchorCwd);
+
+  const host = document.createElement("div");
+  host.className = "pane__term pane__term--native";
+  host.tabIndex = 0;
+  host.setAttribute("aria-label", "Embedded Alacritty terminal");
+  const errorBanner = document.createElement("div");
+  errorBanner.className = "pane__native-error";
+  errorBanner.hidden = true;
+  const errorText = document.createElement("span");
+  const retry = document.createElement("button");
+  retry.type = "button";
+  retry.textContent = "retry";
+  errorBanner.append(errorText, retry);
+  element.append(bar, anchor, host, errorBanner);
+
+  let mounted = false;
+  let disposed = false;
+  let visible = false;
+  let warned = false;
+  let active = false;
+  let animationFrame: number | null = null;
+  let lastUpdate = "";
+  let lastSettings = _initial;
+
+  function showError(error: unknown): void {
+    errorText.textContent =
+      typeof error === "string"
+        ? error
+        : error instanceof Error
+          ? error.message
+          : "Alacritty is unavailable";
+    errorBanner.hidden = false;
+  }
+
+  function clearError(): void {
+    errorBanner.hidden = true;
+    errorText.textContent = "";
+  }
+
+  function bounds() {
+    const rect = host.getBoundingClientRect();
+    const inset = active ? 1 : 0;
+    const dragInset = element.closest(".pane-bar-hidden") ? 26 : 0;
+    return {
+      left: rect.left + inset,
+      top: rect.top + inset + dragInset,
+      width: Math.max(0, rect.width - inset * 2),
+      height: Math.max(0, rect.height - inset * 2 - dragInset),
+    };
+  }
+
+  function syncNow(): void {
+    animationFrame = null;
+    if (disposed || !mounted) {
+      return;
+    }
+    const rect = bounds();
+    const shown =
+      visible && element.isConnected && rect.width >= 1 && rect.height >= 1;
+    const signature = JSON.stringify([rect, shown]);
+    if (signature === lastUpdate) return;
+    lastUpdate = signature;
+    void client.updateAlacritty(id, rect, shown).catch((error: unknown) => {
+      showError(error);
+      if (!warned) {
+        warned = true;
+        console.warn("Embedded Alacritty update failed:", error);
+      }
+    });
+  }
+
+  function sync(): void {
+    if (disposed || animationFrame !== null) return;
+    animationFrame = requestAnimationFrame(syncNow);
+  }
+
+  const observer = new ResizeObserver(sync);
+  element.addEventListener("focusin", () => events.onFocus(id));
+  element.addEventListener("mousedown", () => events.onFocus(id));
+
+  const ANCHOR_ZONE_PX = 26;
+  element.addEventListener("mousemove", (event) => {
+    const top = element.getBoundingClientRect().top;
+    element.classList.toggle(
+      "is-anchor-zone",
+      event.clientY - top < ANCHOR_ZONE_PX,
+    );
+  });
+  element.addEventListener("mouseleave", () => {
+    element.classList.remove("is-anchor-zone");
+  });
+
+  const pane: Pane = {
+    id,
+    kind: "alacritty",
+    element,
+    // Native Alacritty owns its own scrollback and search UI. TerminalManager
+    // checks `kind` before invoking the xterm search helpers.
+    search: new SearchAddon(),
+    mount() {
+      if (!mounted) {
+        observer.observe(host);
+        mounted = true;
+      }
+      sync();
+    },
+    write() {},
+    writeln() {},
+    fit: sync,
+    clear() {
+      void client.performAlacrittyAction(id, "clear");
+    },
+    copySelection() {
+      void client.performAlacrittyAction(id, "copy");
+    },
+    paste() {
+      void client.performAlacrittyAction(id, "paste");
+    },
+    scrollPage(dir) {
+      void client.performAlacrittyAction(id, dir < 0 ? "page-up" : "page-down");
+    },
+    scrollToEdge(edge) {
+      void client.performAlacrittyAction(
+        id,
+        edge === "top" ? "scroll-top" : "scroll-bottom",
+      );
+    },
+    openSearch() {
+      void client.performAlacrittyAction(id, "search");
+    },
+    findNext() {
+      void client.performAlacrittyAction(id, "search-next");
+    },
+    findPrevious() {
+      void client.performAlacrittyAction(id, "search-previous");
+    },
+    focus() {
+      events.onFocus(id);
+      void client.focusAlacritty(id).catch((error: unknown) => {
+        console.warn("Embedded Alacritty focus failed:", error);
+      });
+    },
+    setVisible(next) {
+      visible = next;
+      if (!next) lastUpdate = "";
+      sync();
+    },
+    setActive(next) {
+      active = next;
+      lastUpdate = "";
+      sync();
+    },
+    applySettings(next) {
+      lastSettings = next;
+      applyPaneBackground(element, next, "alacritty");
+      void client
+        .applyAlacrittyAppearance(id, nativeTerminalAppearance(next))
+        .then(clearError)
+        .catch((error: unknown) => {
+          showError(error);
+          console.warn("Embedded Alacritty appearance update failed:", error);
+        });
+      sync();
+    },
+    setHeaderInfo(info: PaneHeaderInfo) {
+      dot.style.background = info.dotColor;
+      cwdEl.textContent = info.cwd;
+      anchorCwd.textContent = info.cwd;
+    },
+    captureSelection() {
+      return null;
+    },
+    restoreSelection() {},
+    dispose() {
+      disposed = true;
+      if (animationFrame !== null) cancelAnimationFrame(animationFrame);
+      observer.disconnect();
+      element.remove();
+    },
+  };
+
+  retry.addEventListener("click", () => {
+    clearError();
+    lastUpdate = "";
+    void client
+      .applyAlacrittyAppearance(id, nativeTerminalAppearance(lastSettings))
+      .then(sync)
+      .catch(showError);
+  });
+
+  return pane;
+}

--- a/src/terminal/native-pane.ts
+++ b/src/terminal/native-pane.ts
@@ -9,13 +9,13 @@ import { nativeTerminalAppearance } from "./native-appearance";
 
 export function createNativePane(
   id: number,
-  _initial: Settings,
+  initial: Settings,
   events: PaneEvents,
   client: NativePaneClient,
 ): Pane {
   const element = document.createElement("div");
   element.className = "pane pane--native";
-  applyPaneBackground(element, _initial, "alacritty");
+  applyPaneBackground(element, initial, "alacritty");
 
   const bar = document.createElement("div");
   bar.className = "pane__bar";
@@ -43,11 +43,13 @@ export function createNativePane(
   host.setAttribute("aria-label", "Embedded Alacritty terminal");
   const errorBanner = document.createElement("div");
   errorBanner.className = "pane__native-error";
+  errorBanner.setAttribute("role", "alert");
   errorBanner.hidden = true;
   const errorText = document.createElement("span");
   const retry = document.createElement("button");
   retry.type = "button";
   retry.textContent = "retry";
+  retry.setAttribute("aria-label", "Retry embedded Alacritty pane");
   errorBanner.append(errorText, retry);
   element.append(bar, anchor, host, errorBanner);
 
@@ -58,7 +60,7 @@ export function createNativePane(
   let active = false;
   let animationFrame: number | null = null;
   let lastUpdate = "";
-  let lastSettings = _initial;
+  let lastSettings = initial;
 
   function showError(error: unknown): void {
     errorText.textContent =

--- a/src/terminal/native-pane.ts
+++ b/src/terminal/native-pane.ts
@@ -181,6 +181,12 @@ export function createNativePane(
     paste() {
       void client.performAlacrittyAction(id, "paste");
     },
+    pasteText() {
+      // Native Alacritty has no PTY write channel or bracketed-paste API.
+      // Fail closed so Prompt Board never auto-submits text that was not
+      // delivered; ordinary clipboard paste remains available above.
+      return Promise.resolve(false);
+    },
     scrollPage(dir) {
       void client.performAlacrittyAction(id, dir < 0 ? "page-up" : "page-down");
     },

--- a/src/terminal/native-pane.ts
+++ b/src/terminal/native-pane.ts
@@ -1,4 +1,5 @@
 import { SearchAddon } from "@xterm/addon-search";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { Settings } from "../settings/settings-schema";
 import type { PaneHeaderInfo } from "../lib/process-info";
 import type { Pane, PaneEvents } from "./pane";
@@ -111,6 +112,31 @@ export function createNativePane(
     animationFrame = requestAnimationFrame(syncNow);
   }
 
+  function forceSync(): void {
+    lastUpdate = "";
+    sync();
+  }
+
+  const windowUnlisteners: Array<() => void> = [];
+  if ("__TAURI_INTERNALS__" in globalThis) {
+    const appWindow = getCurrentWindow();
+    void Promise.all([
+      appWindow.onMoved(forceSync),
+      appWindow.onResized(forceSync),
+      appWindow.onScaleChanged(forceSync),
+    ])
+      .then((unlisteners) => {
+        if (disposed) {
+          unlisteners.forEach((unlisten) => unlisten());
+        } else {
+          windowUnlisteners.push(...unlisteners);
+        }
+      })
+      .catch((error: unknown) => {
+        console.warn("Native terminal window tracking is unavailable:", error);
+      });
+  }
+
   const observer = new ResizeObserver(sync);
   element.addEventListener("focusin", () => events.onFocus(id));
   element.addEventListener("mousedown", () => events.onFocus(id));
@@ -211,6 +237,7 @@ export function createNativePane(
     dispose() {
       disposed = true;
       if (animationFrame !== null) cancelAnimationFrame(animationFrame);
+      windowUnlisteners.forEach((unlisten) => unlisten());
       observer.disconnect();
       element.remove();
     },

--- a/src/terminal/pane-background.ts
+++ b/src/terminal/pane-background.ts
@@ -1,0 +1,38 @@
+import type { Settings } from "../settings/settings-schema";
+
+export type TerminalPaneKind = "xterm" | "alacritty";
+
+export function paneUsesBackgroundImage(
+  settings: Settings,
+  kind: TerminalPaneKind,
+): boolean {
+  const background = settings.terminalBackground;
+  return (
+    background.imageDataUrl !== "" &&
+    (background.target === "all" || background.target === kind)
+  );
+}
+export function applyPaneBackground(
+  element: HTMLElement,
+  settings: Settings,
+  kind: TerminalPaneKind,
+): void {
+  const background = settings.terminalBackground;
+  const enabled = paneUsesBackgroundImage(settings, kind);
+  element.classList.toggle("pane--has-background", enabled);
+  if (!enabled) {
+    element.style.removeProperty("--pane-background-image");
+    element.style.removeProperty("--pane-background-size");
+    element.style.removeProperty("--pane-background-dim");
+    return;
+  }
+  element.style.setProperty(
+    "--pane-background-image",
+    `url(${JSON.stringify(background.imageDataUrl)})`,
+  );
+  element.style.setProperty(
+    "--pane-background-size",
+    background.fit === "stretch" ? "100% 100%" : background.fit,
+  );
+  element.style.setProperty("--pane-background-dim", String(background.dim));
+}

--- a/src/terminal/pane-lifecycle.ts
+++ b/src/terminal/pane-lifecycle.ts
@@ -9,6 +9,12 @@ import {
 } from "./pane";
 import { clearPaneCwd, setPaneCwd } from "./pane-cwd";
 import type { PtyClient } from "./pty-client";
+import { createNativePane } from "./native-pane";
+import {
+  defaultNativePaneClient,
+  type NativePaneClient,
+} from "./native-pane-client";
+import { nativeTerminalAppearance } from "./native-appearance";
 
 // Placeholder size at spawn — fit() after mount resizes to the real dimensions
 const INITIAL_COLS = 80;
@@ -21,10 +27,18 @@ export type CreatePaneFn = (
   events: PaneEvents,
 ) => Pane;
 
+export type PaneKind = "xterm" | "alacritty";
+export type CreateNativePaneFn = (
+  id: number,
+  initial: Settings,
+  events: PaneEvents,
+  client: NativePaneClient,
+) => Pane;
+
 export interface PaneLifecycle {
   readonly panes: Map<number, Pane>;
   readonly exited: Set<number>;
-  spawnPane(cwd?: string | null): Promise<Pane>;
+  spawnPane(cwd?: string | null, kind?: PaneKind): Promise<Pane>;
   discardPane(pane: Pane): void;
   killPane(id: number): void;
   killAll(): void;
@@ -46,6 +60,8 @@ export interface PaneLifecycle {
    * this exact write reaches the PTY.
    */
   enqueueWrite(id: number, data: string): Promise<boolean>;
+  paneKind(id: number): PaneKind | null;
+  ptyPaneIds(): number[];
 }
 
 /**
@@ -60,11 +76,15 @@ export function createPaneLifecycle(deps: {
   onAttentionSignal?: (id: number, signal: PaneAttentionSignal) => void;
   /** Test seam — defaults to real createPane (xterm). */
   createPane?: CreatePaneFn;
+  createNativePane?: CreateNativePaneFn;
+  nativeClient?: NativePaneClient;
 }): PaneLifecycle {
   const panes = new Map<number, Pane>();
   const exited = new Set<number>();
   const respawning = new Set<number>();
   const makePane = deps.createPane ?? createPane;
+  const makeNativePane = deps.createNativePane ?? createNativePane;
+  const nativeClient = deps.nativeClient ?? defaultNativePaneClient;
 
   /**
    * Per-pane write chain. `pty.writePty` is fire-and-forget over IPC, so two
@@ -132,7 +152,41 @@ export function createPaneLifecycle(deps: {
     },
   };
 
-  async function spawnPane(cwd: string | null = null): Promise<Pane> {
+  async function spawnPane(
+    cwd: string | null = null,
+    kind: PaneKind = "xterm",
+  ): Promise<Pane> {
+    if (kind === "alacritty") {
+      const current = deps.getSettings();
+      let nativeId: number | null = null;
+      try {
+        nativeId = await nativeClient.spawnAlacritty(
+          cwd,
+          nativeTerminalAppearance(current),
+        );
+        const pane = makeNativePane(
+          nativeId,
+          current,
+          paneEvents,
+          nativeClient,
+        );
+        panes.set(nativeId, pane);
+        setPaneCwd(nativeId, cwd);
+        return pane;
+      } catch (error) {
+        // Shift-split is an enhancement, never a dead end. Alacritty can be
+        // removed after discovery or fail before its window appears; clean up
+        // any partially-created native session and preserve the requested
+        // split as an ordinary shell pane.
+        if (nativeId !== null) {
+          await nativeClient.killAlacritty(nativeId).catch(() => undefined);
+        }
+        console.warn(
+          "Alacritty is unavailable; opening a normal terminal pane instead:",
+          error,
+        );
+      }
+    }
     const id = await deps.pty.spawnShell({
       cols: INITIAL_COLS,
       rows: INITIAL_ROWS,
@@ -147,7 +201,11 @@ export function createPaneLifecycle(deps: {
   }
 
   function discardPane(pane: Pane): void {
-    deps.pty.killPty(pane.id).catch(() => {
+    const kill =
+      pane.kind === "alacritty"
+        ? nativeClient.killAlacritty(pane.id)
+        : deps.pty.killPty(pane.id);
+    kill.catch(() => {
       // Session already gone — ignore
     });
     panes.delete(pane.id);
@@ -156,14 +214,23 @@ export function createPaneLifecycle(deps: {
   }
 
   function killPane(id: number): void {
-    deps.pty.killPty(id).catch(() => {
+    const pane = panes.get(id);
+    const kill =
+      pane?.kind === "alacritty"
+        ? nativeClient.killAlacritty(id)
+        : deps.pty.killPty(id);
+    kill.catch(() => {
       // Session already ended on its own — ignore
     });
   }
 
   function killAll(): void {
     for (const pane of panes.values()) {
-      deps.pty.killPty(pane.id).catch(() => {
+      const kill =
+        pane.kind === "alacritty"
+          ? nativeClient.killAlacritty(pane.id)
+          : deps.pty.killPty(pane.id);
+      kill.catch(() => {
         // Session already gone — ignore
       });
     }
@@ -187,7 +254,10 @@ export function createPaneLifecycle(deps: {
     }
     respawning.add(oldId);
     try {
-      const fresh = await spawnPane();
+      const fresh = await spawnPane(
+        null,
+        old.kind === "alacritty" ? "alacritty" : "xterm",
+      );
       if (!isInTree(tree, oldId)) {
         discardPane(fresh);
         return null;
@@ -237,5 +307,18 @@ export function createPaneLifecycle(deps: {
     openInitial,
     paneEvents,
     enqueueWrite,
+    paneKind(id) {
+      const kind = panes.get(id)?.kind;
+      return kind === "alacritty"
+        ? "alacritty"
+        : kind === undefined && !panes.has(id)
+          ? null
+          : "xterm";
+    },
+    ptyPaneIds() {
+      return [...panes.values()]
+        .filter((pane) => pane.kind !== "alacritty")
+        .map((pane) => pane.id);
+    },
   };
 }

--- a/src/terminal/pane.ts
+++ b/src/terminal/pane.ts
@@ -15,6 +15,7 @@ import { classifyOscNotification } from "../lib/osc-notification";
 import { copyTerminalSelection, pasteIntoTerminal } from "./terminal-clipboard";
 import { getDesktopEnvironment } from "../lib/platform";
 import { createCodexWheelHandler } from "./codex-wheel";
+import { applyPaneBackground, paneUsesBackgroundImage } from "./pane-background";
 
 /** Structured attention signal a pane can emit — never a native notification. */
 export interface PaneAttentionSignal {
@@ -40,6 +41,8 @@ export interface SelectionSnapshot {
 /** A terminal cell (xterm instance) bound to one PTY session by id. */
 export interface Pane {
   readonly id: number;
+  /** Omitted by legacy test fakes; production xterm panes set this explicitly. */
+  readonly kind?: "xterm" | "alacritty";
   readonly element: HTMLElement;
   /** Per-pane search addon (Cmd+F); disposed with the terminal. */
   readonly search: SearchAddon;
@@ -65,7 +68,14 @@ export interface Pane {
   scrollPage(dir: 1 | -1): void;
   /** Jump to the very top (oldest) or bottom (latest output) of scrollback. */
   scrollToEdge(edge: "top" | "bottom"): void;
+  openSearch?(): void;
+  findNext?(): void;
+  findPrevious?(): void;
   focus(): void;
+  /** Native panes use this to hide their HWND when covered or backgrounded. */
+  setVisible?(visible: boolean): void;
+  /** Keep native geometry and SpaceVibe's focus treatment in sync. */
+  setActive?(active: boolean): void;
   applySettings(next: Settings): void;
   /** Update the header bar (dot color, cwd, process badge). */
   setHeaderInfo(info: PaneHeaderInfo): void;
@@ -93,6 +103,7 @@ export function createPane(
 ): Pane {
   const element = document.createElement("div");
   element.className = "pane";
+  applyPaneBackground(element, initial, "xterm");
 
   const bar = document.createElement("div");
   bar.className = "pane__bar";
@@ -141,7 +152,12 @@ export function createPane(
     // Option must stay a character key on macOS so IMEs (Vietnamese Telex,
     // dead-key accents) can compose — `true` swallows it as Meta.
     macOptionIsMeta: false,
-    theme: resolveTheme(initial),
+    theme: {
+      ...resolveTheme(initial),
+      ...(paneUsesBackgroundImage(initial, "xterm")
+        ? { background: "#00000000" }
+        : {}),
+    },
     // OSC 8 hyperlinks otherwise fall back to window.confirm/open, which
     // WKWebView blocks — route through Tauri like the custom link provider.
     linkHandler: createOscLinkHandler(),
@@ -291,7 +307,13 @@ export function createPane(
   function applySettings(next: Settings): void {
     term.options.fontFamily = toFontStack(next.fontFamily);
     term.options.fontSize = next.fontSize;
-    term.options.theme = resolveTheme(next);
+    applyPaneBackground(element, next, "xterm");
+    term.options.theme = {
+      ...resolveTheme(next),
+      ...(paneUsesBackgroundImage(next, "xterm")
+        ? { background: "#00000000" }
+        : {}),
+    };
     term.options.scrollback = next.scrollback;
     fit();
   }
@@ -352,6 +374,7 @@ export function createPane(
 
   return {
     id,
+    kind: "xterm",
     element,
     search: searchAddon,
     mount,

--- a/src/terminal/pane.ts
+++ b/src/terminal/pane.ts
@@ -17,6 +17,15 @@ import { getDesktopEnvironment } from "../lib/platform";
 import { createCodexWheelHandler } from "./codex-wheel";
 import { applyPaneBackground, paneUsesBackgroundImage } from "./pane-background";
 
+function paneTheme(settings: Settings) {
+  return {
+    ...resolveTheme(settings),
+    ...(paneUsesBackgroundImage(settings, "xterm")
+      ? { background: "#00000000" }
+      : {}),
+  };
+}
+
 /** Structured attention signal a pane can emit — never a native notification. */
 export interface PaneAttentionSignal {
   kind: "requested";
@@ -152,12 +161,7 @@ export function createPane(
     // Option must stay a character key on macOS so IMEs (Vietnamese Telex,
     // dead-key accents) can compose — `true` swallows it as Meta.
     macOptionIsMeta: false,
-    theme: {
-      ...resolveTheme(initial),
-      ...(paneUsesBackgroundImage(initial, "xterm")
-        ? { background: "#00000000" }
-        : {}),
-    },
+    theme: paneTheme(initial),
     // OSC 8 hyperlinks otherwise fall back to window.confirm/open, which
     // WKWebView blocks — route through Tauri like the custom link provider.
     linkHandler: createOscLinkHandler(),
@@ -308,12 +312,7 @@ export function createPane(
     term.options.fontFamily = toFontStack(next.fontFamily);
     term.options.fontSize = next.fontSize;
     applyPaneBackground(element, next, "xterm");
-    term.options.theme = {
-      ...resolveTheme(next),
-      ...(paneUsesBackgroundImage(next, "xterm")
-        ? { background: "#00000000" }
-        : {}),
-    };
+    term.options.theme = paneTheme(next);
     term.options.scrollback = next.scrollback;
     fit();
   }

--- a/src/terminal/tab-manager.test.ts
+++ b/src/terminal/tab-manager.test.ts
@@ -2,7 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PaneProcessInfo } from "../lib/process-info";
 import type { Pane, PaneEvents, PaneAttentionSignal } from "./pane";
-import type { CreatePaneFn } from "./pane-lifecycle";
+import type { CreateNativePaneFn, CreatePaneFn } from "./pane-lifecycle";
+import { createMemoryNativePaneClient } from "./native-pane-client";
 import { createMemoryPtyClient, type PtyClient } from "./pty-client";
 import { MACOS_KEYMAP, type ShortcutAction } from "./keymap";
 import { ACTION_REGISTRY } from "./action-registry";
@@ -261,6 +262,76 @@ function setupControllable(
 function flush(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
+
+describe("createTabManager native presentation ordering", () => {
+  it("waits for native occlusion before opening the workspace board", async () => {
+    let resolveHide!: () => void;
+    const base = createMemoryNativePaneClient();
+    const nativeClient = {
+      ...base,
+      setOccluded: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveHide = resolve;
+          }),
+      ),
+    };
+    const { tm } = setup({ deps: { nativeClient } });
+    boardOpen.value = false;
+
+    const opening = tm.newTab();
+    expect(boardOpen.value).toBe(false);
+    expect(nativeClient.setOccluded).toHaveBeenCalledWith(true);
+
+    resolveHide();
+    await opening;
+    expect(boardOpen.value).toBe(true);
+    boardOpen.value = false;
+    tm.dispose();
+  });
+
+  it("ignores a stale hide acknowledgement after a newer reveal", async () => {
+    const base = createMemoryNativePaneClient();
+    const pending: Array<{
+      occluded: boolean;
+      resolve(): void;
+    }> = [];
+    const nativeClient = {
+      ...base,
+      setOccluded(occluded: boolean) {
+        return new Promise<void>((resolve) => {
+          pending.push({ occluded, resolve });
+        });
+      },
+    };
+    const visibility: boolean[] = [];
+    const createNativePane: CreateNativePaneFn = (id, _settings, events) => ({
+      ...fakePane(id, events),
+      kind: "alacritty",
+      setVisible(visible) {
+        visibility.push(visible);
+      },
+    });
+    const { tm } = setup({ deps: { nativeClient, createNativePane } });
+    await tm.openFromPreset({ type: "leaf" }, ["C:\\repo"], {
+      workspacePath: "C:\\repo",
+      agent: "alacritty",
+    });
+    visibility.length = 0;
+
+    const hide = tm.setNativePanesVisible(false);
+    const reveal = tm.setNativePanesVisible(true);
+    expect(pending.map((request) => request.occluded)).toEqual([true, false]);
+
+    pending[1].resolve();
+    await reveal;
+    pending[0].resolve();
+    await hide;
+
+    expect(visibility).toEqual([true]);
+    tm.dispose();
+  });
+});
 
 /**
  * Fake `AgentNotifier` — records every `maybeNotify` call verbatim instead
@@ -2655,6 +2726,7 @@ describe("createTabManager new-preset / save-preset — unified into the action:
     await flush();
 
     tm.runAction("new-preset");
+    await flush();
 
     expect(editorRequest.value).toEqual({ source: "live" });
 
@@ -2676,6 +2748,7 @@ describe("createTabManager new-preset / save-preset — unified into the action:
 
     settingsOpen.value = true;
     tm.runAction("new-preset");
+    await flush();
 
     expect(editorRequest.value).toEqual({ source: "live" });
 
@@ -2689,6 +2762,7 @@ describe("createTabManager new-preset / save-preset — unified into the action:
 
     boardOpen.value = true;
     tm.runAction("new-preset");
+    await flush();
 
     expect(editorRequest.value).toEqual({ source: "live" });
 
@@ -2714,11 +2788,13 @@ describe("createTabManager new-preset / save-preset — unified into the action:
     await flush();
 
     window.dispatchEvent(metaShiftKeydown("n"));
+    await flush();
     expect(editorRequest.value).toEqual({ source: "live" });
     editorRequest.value = null;
 
     settingsOpen.value = true;
     window.dispatchEvent(metaShiftKeydown("n"));
+    await flush();
     expect(editorRequest.value).toEqual({ source: "live" });
 
     tm.dispose();

--- a/src/terminal/tab-manager.ts
+++ b/src/terminal/tab-manager.ts
@@ -359,7 +359,7 @@ export interface TabManager {
   closePane(): Promise<void>;
   applySettings(next: Settings): void;
   focusActive(): void;
-  setNativePanesVisible(visible: boolean): void;
+  setNativePanesVisible(visible: boolean): Promise<void>;
   dispose(): void;
 }
 
@@ -434,8 +434,26 @@ export function createTabManager(
   // `unlisteners` array that's already been drained, which would leak it.
   let disposed = false;
   let nativePanesVisible = true;
+  let nativeVisibilityRequest = 0;
   const nativeClient: NativePaneClient =
     deps.nativeClient ?? defaultNativePaneClient;
+
+  async function setNativeVisibility(visible: boolean): Promise<void> {
+    const request = ++nativeVisibilityRequest;
+    // Fail closed immediately. Tabs created while the hide acknowledgement is
+    // in flight must inherit the covered state.
+    if (!visible) {
+      nativePanesVisible = false;
+    }
+    await nativeClient.setOccluded(!visible);
+    if (request !== nativeVisibilityRequest || disposed) {
+      return;
+    }
+    nativePanesVisible = visible;
+    for (const tab of tabs) {
+      tab.manager.setNativePanesVisible(visible);
+    }
+  }
   // Types the chosen agent into each new pane's shell once its prompt is up.
   // Through paneIo so its synthetic keystrokes ("claude\r") count as input —
   // the echo suppression then keeps the launch echo out of the spinner.
@@ -743,7 +761,12 @@ export function createTabManager(
 
   async function newTab(): Promise<void> {
     // New tab goes through the Open board (workspace ∥ preset ∥ agent).
-    boardOpen.value = true;
+    try {
+      await setNativeVisibility(false);
+      boardOpen.value = true;
+    } catch (error) {
+      console.error("Couldn't safely open the workspace board:", error);
+    }
   }
 
   /**
@@ -1184,7 +1207,13 @@ export function createTabManager(
     // logic (nothing to save with zero tabs), not scope.
     "save-preset": () => {
       if (tabs.length > 0) {
-        saveDialogOpen.value = true;
+        void setNativeVisibility(false)
+          .then(() => {
+            saveDialogOpen.value = true;
+          })
+          .catch((error: unknown) => {
+            console.error("Couldn't safely open the preset dialog:", error);
+          });
       }
     },
     // Unified onto the same action:/runAction path as every other item
@@ -1192,7 +1221,13 @@ export function createTabManager(
     // `menu:new-preset` Tauri event instead. Sets the same request the live
     // window's "New Layout Preset…" board flow already used.
     "new-preset": () => {
-      editorRequest.value = { source: "live" };
+      void setNativeVisibility(false)
+        .then(() => {
+          editorRequest.value = { source: "live" };
+        })
+        .catch((error: unknown) => {
+          console.error("Couldn't safely open the preset editor:", error);
+        });
     },
   } satisfies Record<(typeof COMMAND_ACTIONS)[number], () => void>;
 
@@ -1628,12 +1663,7 @@ export function createTabManager(
     focusActive() {
       activeManager()?.focusActive();
     },
-    setNativePanesVisible(visible) {
-      nativePanesVisible = visible;
-      for (const tab of tabs) {
-        tab.manager.setNativePanesVisible(visible);
-      }
-    },
+    setNativePanesVisible: setNativeVisibility,
     dispose() {
       disposed = true;
       launcher.dispose();

--- a/src/terminal/tab-manager.ts
+++ b/src/terminal/tab-manager.ts
@@ -33,6 +33,7 @@ import {
 import { installFileDrop } from "./file-drop";
 import {
   createTerminalManager,
+  type SplitPaneOptions,
   type TerminalManager,
   type TerminalManagerDeps,
 } from "./terminal-manager";
@@ -57,6 +58,10 @@ import { freshCwd, freshPaneInfo } from "./pane-info";
 import { defaultPtyClient, type PtyClient } from "./pty-client";
 import { submitAllowed, type InjectOutcome } from "../prompts/inject";
 import { createAgentLauncher } from "./agent-launch";
+import {
+  defaultNativePaneClient,
+  type NativePaneClient,
+} from "./native-pane-client";
 import {
   buildClosedTabSnapshot,
   capturePresetLayout,
@@ -346,13 +351,16 @@ export interface TabManager {
    * item and its shortcut can never drift apart.
    */
   runAction(action: ShortcutAction): void;
-  splitActive(dir: Direction): Promise<void>;
+  splitActive(dir: Direction, options?: SplitPaneOptions): Promise<void>;
   /** Every pane id across every tab (quit-path busy guard). */
   allPaneIds(): number[];
+  /** Real PTYs only, for quit/Busy checks. */
+  allPtyPaneIds(): number[];
   /** Close the focused pane (busy-guarded); last pane in tab closes the tab. */
   closePane(): Promise<void>;
   applySettings(next: Settings): void;
   focusActive(): void;
+  setNativePanesVisible(visible: boolean): void;
   dispose(): void;
 }
 
@@ -426,6 +434,9 @@ export function createTabManager(
   // (e.g. a remount mid-init) — guards against pushing a listener into an
   // `unlisteners` array that's already been drained, which would leak it.
   let disposed = false;
+  let nativePanesVisible = true;
+  const nativeClient: NativePaneClient =
+    deps.nativeClient ?? defaultNativePaneClient;
   // Types the chosen agent into each new pane's shell once its prompt is up.
   // Through paneIo so its synthetic keystrokes ("claude\r") count as input —
   // the echo suppression then keeps the launch echo out of the spinner.
@@ -605,17 +616,22 @@ export function createTabManager(
     layout: SerializedNode | null,
     cwds: readonly (string | null)[] = [],
     workspacePath: string | null = null,
+    paneKind: "xterm" | "alacritty" = "xterm",
   ): Promise<boolean> {
     const container = document.createElement("div");
     container.className = "tab-stage";
     container.style.display = "none";
     host.appendChild(container);
-    const manager = createTerminalManager(container, callbacks, paneIo, deps);
+    const manager = createTerminalManager(container, callbacks, paneIo, {
+      ...deps,
+      nativeClient,
+    });
+    manager.setNativePanesVisible(nativePanesVisible);
     try {
       if (layout === null) {
-        await manager.initFresh(cwds[0] ?? null);
+        await manager.initFresh(cwds[0] ?? null, paneKind);
       } else {
-        await manager.initFromLayout(layout, cwds);
+        await manager.initFromLayout(layout, cwds, paneKind);
       }
     } catch (err) {
       console.error("Failed to open tab:", err);
@@ -741,7 +757,12 @@ export function createTabManager(
     // run several agent sessions side by side. `workspacePath` is a label the
     // tab carries (sidebar, logo, reopen), never an identity that dedupes.
     if (
-      !(await addTab(intent.layout, intent.cwds, intent.workspacePath ?? null))
+      !(await addTab(
+        intent.layout,
+        intent.cwds,
+        intent.workspacePath ?? null,
+        intent.agent === "alacritty" ? "alacritty" : "xterm",
+      ))
     ) {
       return false;
     }
@@ -767,10 +788,12 @@ export function createTabManager(
     // pane that types a stale command.
     const agentId = intent.agent ?? null;
     launcher.arm(
-      entry.manager.paneIds(),
+      entry.manager.ptyPaneIds(),
       agentId === null
         ? null
-        : resolveAgentCommand(agentId, settings.value.customAgents),
+        : agentId === "alacritty"
+          ? null
+          : resolveAgentCommand(agentId, settings.value.customAgents),
     );
     return true;
   }
@@ -1011,7 +1034,7 @@ export function createTabManager(
    * no longer enough. One `pty_info` IPC takes the whole id list.
    */
   function pollTargets(): number[] {
-    return allPaneIds();
+    return tabs.flatMap((tab) => tab.manager.ptyPaneIds());
   }
 
   const poller = createPaneInfoPoller({
@@ -1349,8 +1372,11 @@ export function createTabManager(
     dispatchAction(action);
   }
 
-  function splitActive(dir: Direction): Promise<void> {
-    return activeManager()?.splitActive(dir) ?? Promise.resolve();
+  function splitActive(
+    dir: Direction,
+    options: SplitPaneOptions = {},
+  ): Promise<void> {
+    return activeManager()?.splitActive(dir, options) ?? Promise.resolve();
   }
 
   // `dispose()` can run while this await is still in flight (a remount mid-
@@ -1369,6 +1395,21 @@ export function createTabManager(
   }
 
   async function init(): Promise<void> {
+    try {
+      await registerUnlisten(
+        nativeClient.listenFocus((id) => {
+          for (const tab of tabs) {
+            if (tab.manager.noteNativeFocus(id)) {
+              syncViews();
+              return;
+            }
+          }
+        }),
+      );
+    } catch (error) {
+      // A failed optional native listener must not stop PTY/event setup.
+      console.warn("native-terminal focus listener unavailable:", error);
+    }
     try {
       windowFocused = await getCurrentWindow().isFocused();
     } catch (err) {
@@ -1570,6 +1611,9 @@ export function createTabManager(
     runAction,
     splitActive,
     allPaneIds,
+    allPtyPaneIds() {
+      return tabs.flatMap((tab) => tab.manager.ptyPaneIds());
+    },
     closePane: () => close.closePane(),
     applySettings(next) {
       for (const tab of tabs) {
@@ -1578,6 +1622,12 @@ export function createTabManager(
     },
     focusActive() {
       activeManager()?.focusActive();
+    },
+    setNativePanesVisible(visible) {
+      nativePanesVisible = visible;
+      for (const tab of tabs) {
+        tab.manager.setNativePanesVisible(visible);
+      }
     },
     dispose() {
       disposed = true;

--- a/src/terminal/tab-manager.ts
+++ b/src/terminal/tab-manager.ts
@@ -54,7 +54,7 @@ import {
 import { confirmClose } from "./close-guard";
 import { createCloseCoordinator } from "./close-coordinator";
 import { activeAfterClose } from "./tab-close";
-import { freshCwd, freshPaneInfo } from "./pane-info";
+import { freshPaneInfo } from "./pane-info";
 import { defaultPtyClient, type PtyClient } from "./pty-client";
 import { submitAllowed, type InjectOutcome } from "../prompts/inject";
 import { createAgentLauncher } from "./agent-launch";
@@ -66,7 +66,6 @@ import {
   buildClosedTabSnapshot,
   capturePresetLayout,
   materializeChromeFrom,
-  resolvePaneCwds,
   type MaterializeIntent,
 } from "./tab-materialize";
 import {
@@ -824,11 +823,17 @@ export function createTabManager(
     if (!manager || layout === null) {
       return null;
     }
-    return capturePresetLayout(manager.paneIds(), layout, pty);
+    return capturePresetLayout(
+      manager.paneIds(),
+      layout,
+      pty,
+      manager.freshPaneCwd,
+    );
   }
 
   function activePaneCwd(): Promise<string | null> {
-    return freshCwd(activeManager()?.activePaneId() ?? null, pty);
+    const manager = activeManager();
+    return manager?.freshPaneCwd(manager.activePaneId()) ?? Promise.resolve(null);
   }
 
   function ownerOf(paneId: number): TabEntry | undefined {
@@ -967,9 +972,9 @@ export function createTabManager(
     const layout = entry.manager.serializeLayout();
     if (layout !== null) {
       const override = overrides.get(entry.key);
-      const cwds = await resolvePaneCwds(entry.manager.paneIds(), "fresh", {
-        pty,
-      });
+      const cwds = await Promise.all(
+        entry.manager.paneIds().map((id) => entry.manager.freshPaneCwd(id)),
+      );
       closedTabs = pushClosedTab(
         closedTabs,
         buildClosedTabSnapshot({

--- a/src/terminal/tab-materialize.test.ts
+++ b/src/terminal/tab-materialize.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildClosedTabSnapshot,
   capturePresetLayout,
@@ -138,6 +138,28 @@ describe("capturePresetLayout", () => {
     await expect(
       capturePresetLayout([1], { type: "leaf" }, pty),
     ).resolves.toEqual({ layout: { type: "leaf" }, cwds: ["/a"] });
+  });
+
+  it("uses a pane-aware CWD resolver for mixed native layouts", async () => {
+    const pty = createMemoryPtyClient();
+    const ptyInfo = vi.spyOn(pty, "ptyInfo");
+    const layout = {
+      type: "split" as const,
+      direction: "row" as const,
+      ratio: 0.5,
+      first: { type: "leaf" as const, paneType: "xterm" as const },
+      second: { type: "leaf" as const, paneType: "alacritty" as const },
+    };
+
+    await expect(
+      capturePresetLayout([1, 0x8000_0000], layout, pty, async (id) =>
+        id === 1 ? "C:\\shell" : "C:\\native",
+      ),
+    ).resolves.toEqual({
+      layout,
+      cwds: ["C:\\shell", "C:\\native"],
+    });
+    expect(ptyInfo).not.toHaveBeenCalled();
   });
 });
 

--- a/src/terminal/tab-materialize.ts
+++ b/src/terminal/tab-materialize.ts
@@ -101,8 +101,11 @@ export async function capturePresetLayout(
   paneIds: readonly number[],
   layout: SerializedNode,
   pty: PtyClient = defaultPtyClient,
+  cwdForPane?: (id: number) => Promise<string | null>,
 ): Promise<{ layout: SerializedNode; cwds: readonly (string | null)[] }> {
-  const cwds = await resolvePaneCwds(paneIds, "fresh", { pty });
+  const cwds = cwdForPane
+    ? await Promise.all(paneIds.map((id) => cwdForPane(id)))
+    : await resolvePaneCwds(paneIds, "fresh", { pty });
   return { layout, cwds };
 }
 

--- a/src/terminal/terminal-manager.test.ts
+++ b/src/terminal/terminal-manager.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Pane, PaneAttentionSignal, PaneEvents } from "./pane";
-import type { CreatePaneFn } from "./pane-lifecycle";
+import type { CreateNativePaneFn, CreatePaneFn } from "./pane-lifecycle";
+import { createMemoryNativePaneClient } from "./native-pane-client";
 import { createMemoryPtyClient } from "./pty-client";
 import {
   createTerminalManager,
@@ -154,6 +155,130 @@ describe("createTerminalManager attention signal routing", () => {
 
     expect(a.onAttentionSignal).toHaveBeenCalledTimes(1);
     expect(b.onAttentionSignal).not.toHaveBeenCalled();
+  });
+});
+
+describe("createTerminalManager native Alacritty panes", () => {
+  it("falls back to a normal shell when Alacritty cannot launch", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const pty = createMemoryPtyClient({ nextId: 1 });
+    const memoryNative = createMemoryNativePaneClient();
+    const native = {
+      ...memoryNative,
+      spawnAlacritty: vi.fn(async () => {
+        throw new Error("Alacritty is not installed");
+      }),
+    };
+    const tm = createTerminalManager(container, { onLayoutChange() {} }, pty, {
+      createPane: (id, _settings, events) => fakePane(id, events),
+      nativeClient: native,
+    });
+
+    await tm.initFresh("C:\\repo");
+    await tm.splitActive("column", { kind: "alacritty" });
+
+    expect(native.spawnAlacritty).toHaveBeenCalledOnce();
+    expect(pty.sessions.size).toBe(2);
+    expect(tm.paneIds()).toEqual([1, 2]);
+    expect(tm.ptyPaneIds()).toEqual([1, 2]);
+  });
+
+  it("creates only the new split as Alacritty and keeps PTY ids separate", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const pty = createMemoryPtyClient({ nextId: 1 });
+    const native = createMemoryNativePaneClient();
+    const visibility: boolean[] = [];
+    const createPane: CreatePaneFn = (id, _settings, events) =>
+      fakePane(id, events);
+    const createNativePane: CreateNativePaneFn = (id, _settings, events) => ({
+      ...fakePane(id, events),
+      kind: "alacritty",
+      setVisible(value) {
+        visibility.push(value);
+      },
+    });
+    const tm = createTerminalManager(container, { onLayoutChange() {} }, pty, {
+      createPane,
+      createNativePane,
+      nativeClient: native,
+    });
+
+    await tm.initFresh("C:\\repo");
+    await tm.splitActive("row", { kind: "alacritty" });
+
+    expect(pty.sessions.size).toBe(1);
+    expect(native.sessions.size).toBe(1);
+    expect(native.spawnedCwds).toEqual(["C:\\repo"]);
+    expect(tm.paneIds()).toEqual([1, 0x8000_0000]);
+    expect(tm.ptyPaneIds()).toEqual([1]);
+
+    tm.hide();
+    tm.show({ focus: false });
+    expect(visibility).toContain(false);
+    expect(visibility[visibility.length - 1]).toBe(true);
+  });
+
+  it("materializes every leaf as Alacritty when requested", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const pty = createMemoryPtyClient();
+    const native = createMemoryNativePaneClient();
+    const createNativePane: CreateNativePaneFn = (id, _settings, events) => ({
+      ...fakePane(id, events),
+      kind: "alacritty",
+    });
+    const tm = createTerminalManager(container, { onLayoutChange() {} }, pty, {
+      createNativePane,
+      nativeClient: native,
+    });
+
+    await tm.initFromLayout(
+      {
+        type: "split",
+        direction: "row",
+        ratio: 0.5,
+        first: { type: "leaf" },
+        second: { type: "leaf" },
+      },
+      ["C:\\one", "C:\\two"],
+      "alacritty",
+    );
+
+    expect(pty.sessions.size).toBe(0);
+    expect(native.sessions.size).toBe(2);
+    expect(tm.ptyPaneIds()).toEqual([]);
+  });
+
+  it("restores mixed pane renderer types from serialized leaves", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const pty = createMemoryPtyClient({ nextId: 1 });
+    const native = createMemoryNativePaneClient();
+    const tm = createTerminalManager(container, { onLayoutChange() {} }, pty, {
+      createPane: (id, _settings, events) => fakePane(id, events),
+      createNativePane: (id, _settings, events) => ({
+        ...fakePane(id, events),
+        kind: "alacritty",
+      }),
+      nativeClient: native,
+    });
+
+    await tm.initFromLayout({
+      type: "split",
+      direction: "row",
+      ratio: 0.5,
+      first: { type: "leaf", paneType: "xterm" },
+      second: { type: "leaf", paneType: "alacritty" },
+    });
+
+    expect(pty.sessions.size).toBe(1);
+    expect(native.sessions.size).toBe(1);
+    expect(tm.serializeLayout()).toMatchObject({
+      first: { paneType: "xterm" },
+      second: { paneType: "alacritty" },
+    });
   });
 });
 

--- a/src/terminal/terminal-manager.test.ts
+++ b/src/terminal/terminal-manager.test.ts
@@ -214,6 +214,10 @@ describe("createTerminalManager native Alacritty panes", () => {
     expect(tm.paneIds()).toEqual([1, 0x8000_0000]);
     expect(tm.ptyPaneIds()).toEqual([1]);
 
+    const ptyInfo = vi.spyOn(pty, "ptyInfo");
+    await expect(tm.freshPaneCwd(0x8000_0000)).resolves.toBe("C:\\repo");
+    expect(ptyInfo).not.toHaveBeenCalled();
+
     tm.hide();
     tm.show({ focus: false });
     expect(visibility).toContain(false);

--- a/src/terminal/terminal-manager.test.ts
+++ b/src/terminal/terminal-manager.test.ts
@@ -224,6 +224,41 @@ describe("createTerminalManager native Alacritty panes", () => {
     expect(visibility[visibility.length - 1]).toBe(true);
   });
 
+  it("does not focus a native pane materialized behind the workspace board", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const native = createMemoryNativePaneClient();
+    const focus = vi.fn();
+    const visibility: boolean[] = [];
+    const tm = createTerminalManager(
+      container,
+      { onLayoutChange() {} },
+      createMemoryPtyClient(),
+      {
+        nativeClient: native,
+        createNativePane: (id, _settings, events) => ({
+          ...fakePane(id, events),
+          kind: "alacritty",
+          focus,
+          setVisible(value) {
+            visibility.push(value);
+          },
+        }),
+      },
+    );
+
+    tm.setNativePanesVisible(false);
+    await tm.initFromLayout(
+      { type: "leaf", paneType: "alacritty" },
+      ["C:\\repo"],
+      "alacritty",
+    );
+    tm.show();
+
+    expect(visibility[visibility.length - 1]).toBe(false);
+    expect(focus).not.toHaveBeenCalled();
+  });
+
   it("materializes every leaf as Alacritty when requested", async () => {
     const container = document.createElement("div");
     document.body.appendChild(container);

--- a/src/terminal/terminal-manager.ts
+++ b/src/terminal/terminal-manager.ts
@@ -153,6 +153,8 @@ export interface TerminalManager {
   paneIds(): number[];
   /** Real PTY ids only; native pane ids must never cross PTY IPC boundaries. */
   ptyPaneIds(): number[];
+  /** Fresh PTY CWD, or the last safe launch CWD for a native pane. */
+  freshPaneCwd(id: number | null): Promise<string | null>;
   activePaneId(): number | null;
   paneCount(): number;
   /** Root element of a pane (overlay anchor for the agent picker). */
@@ -379,10 +381,7 @@ export function createTerminalManager(
     const targetId = activeId;
     try {
       // Fresh lookup, not the 2s poll cache — the user may have just cd'd
-      const cwd =
-        life.paneKind(targetId) === "alacritty"
-          ? paneCwd(targetId)
-          : ((await freshCwd(targetId, pty)) ?? paneCwd(targetId));
+      const cwd = await freshPaneCwd(targetId);
       const pane = await life.spawnPane(cwd, options.kind ?? "xterm");
       if (!life.isInTree(tree, targetId)) {
         // Target pane closed while spawning — drop the new session
@@ -401,6 +400,15 @@ export function createTerminalManager(
         .get(targetId)
         ?.writeln(`\r\n\x1b[31mFailed to open new pane: ${err}\x1b[0m`);
     }
+  }
+
+  async function freshPaneCwd(id: number | null): Promise<string | null> {
+    if (id === null) {
+      return null;
+    }
+    return life.paneKind(id) === "alacritty"
+      ? paneCwd(id)
+      : ((await freshCwd(id, pty)) ?? paneCwd(id));
   }
 
   function cycleFocus(step: 1 | -1): void {
@@ -742,6 +750,7 @@ export function createTerminalManager(
       const live = new Set(leafIds(tree));
       return life.ptyPaneIds().filter((id) => live.has(id));
     },
+    freshPaneCwd,
     activePaneId() {
       return activeId;
     },

--- a/src/terminal/terminal-manager.ts
+++ b/src/terminal/terminal-manager.ts
@@ -29,7 +29,7 @@ import {
   type CreatePaneFn,
   type PaneKind,
 } from "./pane-lifecycle";
-import type { PaneAttentionSignal } from "./pane";
+import type { Pane, PaneAttentionSignal } from "./pane";
 import { clearPaneCwd, paneCwd, setPaneCwd } from "./pane-cwd";
 import { freshCwd } from "./pane-info";
 import { defaultPtyClient, type PtyClient } from "./pty-client";
@@ -193,6 +193,12 @@ export function createTerminalManager(
   let inProgrammaticFocus = false;
   let tabVisible = container.style.display !== "none";
   let nativePanesVisible = true;
+
+  function focusPaneWhenVisible(pane: Pane | undefined): void {
+    if (pane && tabVisible && nativePanesVisible) {
+      pane.focus();
+    }
+  }
 
   // Pane bar visibility is CSS-only: pane.ts always builds and populates the
   // bar (the drag ghost and anchor still read its cwd) — this class hides it.
@@ -393,7 +399,7 @@ export function createTerminalManager(
       // DOM, which does not match the just-split tree until render() runs.
       activeId = pane.id;
       render();
-      pane.focus();
+      focusPaneWhenVisible(pane);
       callbacks.onLayoutChange();
     } catch (err) {
       life.panes
@@ -466,7 +472,7 @@ export function createTerminalManager(
     tree = leaf(pane.id);
     activeId = pane.id;
     render();
-    pane.focus();
+    focusPaneWhenVisible(pane);
   }
 
   async function initFromLayout(
@@ -498,7 +504,7 @@ export function createTerminalManager(
     );
     activeId = spawned[0]?.id ?? null;
     render();
-    spawned[0]?.focus();
+    focusPaneWhenVisible(spawned[0]);
   }
 
   function fileDragOver(x: number, y: number): void {
@@ -599,7 +605,7 @@ export function createTerminalManager(
         pane.fit();
       }
       if ((options?.focus ?? true) && activeId !== null) {
-        life.panes.get(activeId)?.focus();
+        focusPaneWhenVisible(life.panes.get(activeId));
       }
     },
     hide() {

--- a/src/terminal/terminal-manager.ts
+++ b/src/terminal/terminal-manager.ts
@@ -7,6 +7,7 @@ import {
   movePane,
   removeLeaf,
   serializeTree,
+  serializedPaneTypes,
   setRatio,
   splitLeaf,
   swapLeaves,
@@ -22,12 +23,18 @@ import { shellEscapePaths } from "../lib/shell-escape";
 import { getDesktopEnvironment } from "../lib/platform";
 import { reportPersistError } from "../chrome/events";
 import { createLayoutEngine } from "./layout-engine";
-import { createPaneLifecycle, type CreatePaneFn } from "./pane-lifecycle";
+import {
+  createPaneLifecycle,
+  type CreateNativePaneFn,
+  type CreatePaneFn,
+  type PaneKind,
+} from "./pane-lifecycle";
 import type { PaneAttentionSignal } from "./pane";
-import { clearPaneCwd, setPaneCwd } from "./pane-cwd";
+import { clearPaneCwd, paneCwd, setPaneCwd } from "./pane-cwd";
 import { freshCwd } from "./pane-info";
 import { defaultPtyClient, type PtyClient } from "./pty-client";
 import { createPaneDragController, type PaneDragController } from "./pane-drag";
+import type { NativePaneClient } from "./native-pane-client";
 import {
   advanceSearch,
   closeSearchBarForPane,
@@ -53,12 +60,20 @@ export interface ManagerCallbacks {
 export interface TerminalManagerDeps {
   /** Test seam — defaults to real createPane (xterm). */
   createPane?: CreatePaneFn;
+  /** Test seam for the DOM wrapper around a native Alacritty child window. */
+  createNativePane?: CreateNativePaneFn;
+  /** Test seam for Tauri's native Alacritty commands. */
+  nativeClient?: NativePaneClient;
+}
+
+export interface SplitPaneOptions {
+  readonly kind?: PaneKind;
 }
 
 /** One tab's worth of terminals: a split tree of panes sharing a container. */
 export interface TerminalManager {
   /** Spawn a single fresh shell (at `cwd` when given). Throws when the spawn fails. */
-  initFresh(cwd?: string | null): Promise<void>;
+  initFresh(cwd?: string | null, kind?: PaneKind): Promise<void>;
   /**
    * Spawn one shell per leaf and rebuild the split structure. `cwds` maps to
    * leaves in left-to-right order (missing/null entries → $HOME). Throws when
@@ -67,6 +82,7 @@ export interface TerminalManager {
   initFromLayout(
     layout: SerializedNode,
     cwds?: readonly (string | null)[],
+    kind?: PaneKind,
   ): Promise<void>;
   /**
    * Displays the container and fits every pane. `focus` defaults to `true`
@@ -76,7 +92,7 @@ export interface TerminalManager {
    */
   show(options?: { focus?: boolean }): void;
   hide(): void;
-  splitActive(dir: Direction): Promise<void>;
+  splitActive(dir: Direction, options?: SplitPaneOptions): Promise<void>;
   closeActive(): Promise<void>;
   /** Close a specific pane; unknown id → no-op (it may have exited meanwhile). */
   closePaneById(id: number): Promise<void>;
@@ -99,6 +115,8 @@ export interface TerminalManager {
    * classes via `setActive`). Unknown/dead id → no-op, returns `false`.
    */
   focusPane(id: number): boolean;
+  /** Native focus event from Rust; updates active state without refocusing. */
+  noteNativeFocus(id: number): boolean;
   /** Clear the active pane's buffer, keeping the prompt line (Cmd+K). */
   clearActive(): void;
   copyActiveSelection(): void;
@@ -133,6 +151,8 @@ export interface TerminalManager {
   applySettings(next: Settings): void;
   serializeLayout(): SerializedNode | null;
   paneIds(): number[];
+  /** Real PTY ids only; native pane ids must never cross PTY IPC boundaries. */
+  ptyPaneIds(): number[];
   activePaneId(): number | null;
   paneCount(): number;
   /** Root element of a pane (overlay anchor for the agent picker). */
@@ -150,6 +170,8 @@ export interface TerminalManager {
   fileDragLeave(): void;
   /** Write the (shell-escaped) paths into the PTY of the pane under the cursor. */
   fileDrop(x: number, y: number, paths: string[]): void;
+  /** Hide native child HWNDs while WebView overlays cover the terminal stage. */
+  setNativePanesVisible(visible: boolean): void;
   /** Kills all PTYs, disposes xterm instances and removes the container. */
   dispose(): void;
 }
@@ -167,6 +189,8 @@ export function createTerminalManager(
   // an element that already holds DOM focus never fires one), so the
   // lifecycle handler must not double- or zero-emit around it.
   let inProgrammaticFocus = false;
+  let tabVisible = container.style.display !== "none";
+  let nativePanesVisible = true;
 
   // Pane bar visibility is CSS-only: pane.ts always builds and populates the
   // bar (the drag ghost and anchor still read its cwd) — this class hides it.
@@ -176,6 +200,8 @@ export function createTerminalManager(
     pty,
     getSettings: () => settings.value,
     createPane: deps.createPane,
+    createNativePane: deps.createNativePane,
+    nativeClient: deps.nativeClient,
     onWriteWhileExited(id, data) {
       if (data === "\r") {
         void respawn(id);
@@ -197,7 +223,9 @@ export function createTerminalManager(
   const layout = createLayoutEngine(container, {
     getPaneElement: (id) => life.panes.get(id)?.element,
     mountPane: (id) => {
-      life.panes.get(id)?.mount();
+      const pane = life.panes.get(id);
+      pane?.mount();
+      pane?.setVisible?.(tabVisible && nativePanesVisible);
     },
     fitPane: (id) => {
       life.panes.get(id)?.fit();
@@ -240,6 +268,9 @@ export function createTerminalManager(
         callbacks.onLayoutChange();
       },
     });
+    for (const pane of life.panes.values()) {
+      pane.setActive?.(life.panes.size > 1 && pane.id === activeId);
+    }
   }
 
   function setActive(id: number): void {
@@ -251,6 +282,9 @@ export function createTerminalManager(
       layout.unzoom();
     }
     activeId = id;
+    for (const pane of life.panes.values()) {
+      pane.setActive?.(life.panes.size > 1 && pane.id === activeId);
+    }
     const overlay = overlayInput();
     if (overlay) {
       layout.refreshOverlay(overlay);
@@ -335,15 +369,21 @@ export function createTerminalManager(
     );
   }
 
-  async function splitActive(dir: Direction): Promise<void> {
+  async function splitActive(
+    dir: Direction,
+    options: SplitPaneOptions = {},
+  ): Promise<void> {
     if (!tree || activeId === null) {
       return;
     }
     const targetId = activeId;
     try {
       // Fresh lookup, not the 2s poll cache — the user may have just cd'd
-      const cwd = await freshCwd(targetId, pty);
-      const pane = await life.spawnPane(cwd);
+      const cwd =
+        life.paneKind(targetId) === "alacritty"
+          ? paneCwd(targetId)
+          : ((await freshCwd(targetId, pty)) ?? paneCwd(targetId));
+      const pane = await life.spawnPane(cwd, options.kind ?? "xterm");
       if (!life.isInTree(tree, targetId)) {
         // Target pane closed while spawning — drop the new session
         life.discardPane(pane);
@@ -410,8 +450,11 @@ export function createTerminalManager(
     callbacks.onLayoutChange();
   }
 
-  async function initFresh(cwd: string | null = null): Promise<void> {
-    const pane = await life.spawnPane(cwd);
+  async function initFresh(
+    cwd: string | null = null,
+    kind: PaneKind = "xterm",
+  ): Promise<void> {
+    const pane = await life.spawnPane(cwd, kind);
     tree = leaf(pane.id);
     activeId = pane.id;
     render();
@@ -421,12 +464,19 @@ export function createTerminalManager(
   async function initFromLayout(
     layoutNode: SerializedNode,
     cwds: readonly (string | null)[] = [],
+    kind: PaneKind = "xterm",
   ): Promise<void> {
     const total = countLeaves(layoutNode);
+    const storedKinds = serializedPaneTypes(layoutNode);
     const spawned: Awaited<ReturnType<typeof life.spawnPane>>[] = [];
     try {
       for (let i = 0; i < total; i += 1) {
-        spawned.push(await life.spawnPane(cwds[i] ?? null));
+        spawned.push(
+          await life.spawnPane(
+            cwds[i] ?? null,
+            kind === "alacritty" ? "alacritty" : storedKinds[i] ?? "xterm",
+          ),
+        );
       }
     } catch (err) {
       for (const pane of spawned) {
@@ -463,7 +513,11 @@ export function createTerminalManager(
     if (id === null) {
       return; // dropped outside every pane (tab bar / status bar) — ignore
     }
-    if (!life.panes.has(id) || life.exited.has(id)) {
+    if (
+      !life.panes.has(id) ||
+      life.exited.has(id) ||
+      life.paneKind(id) === "alacritty"
+    ) {
       return; // pane already exited — never write into a dead PTY
     }
     const data = shellEscapePaths(paths, getDesktopEnvironment().platform);
@@ -530,8 +584,10 @@ export function createTerminalManager(
     initFresh,
     initFromLayout,
     show(options) {
+      tabVisible = true;
       container.style.display = "";
       for (const pane of life.panes.values()) {
+        pane.setVisible?.(nativePanesVisible);
         pane.fit();
       }
       if ((options?.focus ?? true) && activeId !== null) {
@@ -539,6 +595,10 @@ export function createTerminalManager(
       }
     },
     hide() {
+      tabVisible = false;
+      for (const pane of life.panes.values()) {
+        pane.setVisible?.(false);
+      }
       container.style.display = "none";
     },
     splitActive,
@@ -575,6 +635,15 @@ export function createTerminalManager(
       } finally {
         inProgrammaticFocus = false;
       }
+      callbacks.onPaneFocus?.(id);
+      return true;
+    },
+    noteNativeFocus(id) {
+      const pane = life.panes.get(id);
+      if (pane?.kind !== "alacritty") {
+        return false;
+      }
+      setActive(id);
       callbacks.onPaneFocus?.(id);
       return true;
     },
@@ -619,7 +688,9 @@ export function createTerminalManager(
     openSearch() {
       if (activeId !== null) {
         const pane = life.panes.get(activeId);
-        if (pane) {
+        if (pane?.kind === "alacritty") {
+          pane.openSearch?.();
+        } else if (pane) {
           openSearchBar(pane);
         }
       }
@@ -627,7 +698,9 @@ export function createTerminalManager(
     findNext() {
       if (activeId !== null) {
         const pane = life.panes.get(activeId);
-        if (pane) {
+        if (pane?.kind === "alacritty") {
+          pane.findNext?.();
+        } else if (pane) {
           advanceSearch(pane, "next");
         }
       }
@@ -635,7 +708,9 @@ export function createTerminalManager(
     findPrevious() {
       if (activeId !== null) {
         const pane = life.panes.get(activeId);
-        if (pane) {
+        if (pane?.kind === "alacritty") {
+          pane.findPrevious?.();
+        } else if (pane) {
           advanceSearch(pane, "previous");
         }
       }
@@ -653,10 +728,19 @@ export function createTerminalManager(
       }
     },
     serializeLayout() {
-      return tree === null ? null : serializeTree(tree);
+      return tree === null
+        ? null
+        : serializeTree(tree, (id) => life.paneKind(id) ?? "xterm");
     },
     paneIds() {
       return tree === null ? [] : leafIds(tree);
+    },
+    ptyPaneIds() {
+      if (tree === null) {
+        return [];
+      }
+      const live = new Set(leafIds(tree));
+      return life.ptyPaneIds().filter((id) => live.has(id));
     },
     activePaneId() {
       return activeId;
@@ -693,6 +777,12 @@ export function createTerminalManager(
     fileDragOver,
     fileDragLeave,
     fileDrop,
+    setNativePanesVisible(visible) {
+      nativePanesVisible = visible;
+      for (const pane of life.panes.values()) {
+        pane.setVisible?.(tabVisible && nativePanesVisible);
+      }
+    },
     dispose() {
       paneDrag.dispose();
       layout.unzoom();

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -294,7 +294,20 @@ export function App() {
    * open/close decision.
    */
   const toggleSettings = (): void => {
-    toggleSettingsPanel(restoreFocusAfterSettings);
+    if (settingsOpen.value) {
+      toggleSettingsPanel(restoreFocusAfterSettings);
+      return;
+    }
+    if (editorRequest.value !== null || saveDialogOpen.value) {
+      return;
+    }
+    const hidden =
+      tabsRef.current?.setNativePanesVisible(false) ?? Promise.resolve();
+    void hidden.then(() => {
+      toggleSettingsPanel(restoreFocusAfterSettings);
+    }).catch((error: unknown) => {
+      reportPersistError(`Couldn't safely hide native terminals: ${error}`);
+    });
   };
 
   const nativePanesObstructed = (): boolean =>
@@ -708,7 +721,11 @@ export function App() {
       }
       stage={
         <main class="stage">
-          <div class="stage__tabs" ref={stagesRef} />
+          <div
+            class={`stage__tabs ${overlayCoversPane() ? "is-covered" : ""}`}
+            aria-hidden={overlayCoversPane()}
+            ref={stagesRef}
+          />
           {boardOpen.value ? (
             <OpenBoard
               canCancel={tabViews.value.length > 0}

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -348,7 +348,7 @@ export function App() {
       confirmQuit: () => {
         const manager = tabsRef.current;
         return manager
-          ? confirmClose(manager.allPtyPaneIds(), defaultPtyClient, QUIT_COPY)
+          ? confirmClose(manager.allPaneIds(), defaultPtyClient, QUIT_COPY)
           : Promise.resolve(true);
       },
       flush: flushSettingsSave,

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -297,11 +297,19 @@ export function App() {
     toggleSettingsPanel(restoreFocusAfterSettings);
   };
 
+  const nativePanesObstructed = (): boolean =>
+    boardOpen.value ||
+    settingsOpen.value ||
+    editorRequest.value !== null ||
+    saveDialogOpen.value;
+
   useEffect(() => {
     const host = stagesRef.current;
     if (!host) {
       return;
     }
+    // Session restore is gone: the app always opens on the board (Intent §Constraint).
+    boardOpen.value = true;
     const manager = createTabManager(host, undefined, {
       onRequestAttentionFocus: (tabIndex) => requestAttentionFocus(tabIndex),
       onToggleSettings: () => toggleSettings(),
@@ -322,6 +330,7 @@ export function App() {
     }
     // Session restore is gone: the app always opens on the board (Intent §Constraint).
     boardOpen.value = true;
+    manager.setNativePanesVisible(!nativePanesObstructed());
     manager.init().catch((err: unknown) => {
       console.error("Failed to initialize terminals:", err);
       boardOpen.value = true;
@@ -339,7 +348,7 @@ export function App() {
       confirmQuit: () => {
         const manager = tabsRef.current;
         return manager
-          ? confirmClose(manager.allPaneIds(), defaultPtyClient, QUIT_COPY)
+          ? confirmClose(manager.allPtyPaneIds(), defaultPtyClient, QUIT_COPY)
           : Promise.resolve(true);
       },
       flush: flushSettingsSave,
@@ -409,6 +418,12 @@ export function App() {
     rootStyle.setProperty("--text-primary", chrome.textPrimary);
     rootStyle.setProperty("--text-muted", chrome.textMuted);
     rootStyle.setProperty("--text-faint", chrome.textFaint);
+  });
+
+  // A native child HWND always paints above WebView content. Hide it while a
+  // board/panel/modal covers the terminal stage, then restore it afterwards.
+  useSignalEffect(() => {
+    tabsRef.current?.setNativePanesVisible(!nativePanesObstructed());
   });
 
   /** Open board confirm: materialize + record recents + preselect memory. */
@@ -610,8 +625,16 @@ export function App() {
     <ChromeActions
       settingsOpen={settingsOpen.value}
       expandActive={settings.value.focusExpand}
-      onSplitRow={() => void tabsRef.current?.splitActive("row")}
-      onSplitColumn={() => void tabsRef.current?.splitActive("column")}
+      onSplitRow={(alacritty) =>
+        void tabsRef.current?.splitActive("row", {
+          kind: alacritty ? "alacritty" : "xterm",
+        })
+      }
+      onSplitColumn={(alacritty) =>
+        void tabsRef.current?.splitActive("column", {
+          kind: alacritty ? "alacritty" : "xterm",
+        })
+      }
       onClosePane={() => void tabsRef.current?.closePane()}
       onToggleExpand={() =>
         updateSettings({ focusExpand: !settings.value.focusExpand })
@@ -655,8 +678,16 @@ export function App() {
           onSelectTab={selectTab}
           onCloseTab={(index) => void tabsRef.current?.closeTab(index)}
           onNewTab={() => void tabsRef.current?.newTab()}
-          onSplitRow={() => void tabsRef.current?.splitActive("row")}
-          onSplitColumn={() => void tabsRef.current?.splitActive("column")}
+          onSplitRow={(alacritty) =>
+            void tabsRef.current?.splitActive("row", {
+              kind: alacritty ? "alacritty" : "xterm",
+            })
+          }
+          onSplitColumn={(alacritty) =>
+            void tabsRef.current?.splitActive("column", {
+              kind: alacritty ? "alacritty" : "xterm",
+            })
+          }
           onClosePane={() => void tabsRef.current?.closePane()}
           onRenameTab={(index, name) => tabsRef.current?.renameTab(index, name)}
           onSetTabColor={(index, color) =>

--- a/src/ui/chrome-actions.tsx
+++ b/src/ui/chrome-actions.tsx
@@ -11,8 +11,8 @@ interface ChromeActionsProps {
   /** Rendered inside the trigger's anchor while open — see `.prompts-anchor`. */
   promptPopover?: ComponentChildren;
   updateAction?: ComponentChildren;
-  onSplitRow(): void;
-  onSplitColumn(): void;
+  onSplitRow(alacritty: boolean): void;
+  onSplitColumn(alacritty: boolean): void;
   onClosePane(): void;
   onToggleExpand(): void;
   onTogglePrompts(): void;
@@ -145,18 +145,18 @@ export function ChromeActions(props: ChromeActionsProps) {
       <button
         type="button"
         class="iconbtn"
-        title={`Split vertically (${splitRow})`}
+        title={`Split vertically (${splitRow}); hold Shift for Alacritty`}
         aria-label="Split pane vertically"
-        onClick={props.onSplitRow}
+        onClick={(event) => props.onSplitRow(event.shiftKey)}
       >
         <SplitRowIcon />
       </button>
       <button
         type="button"
         class="iconbtn"
-        title={`Split horizontally (${splitColumn})`}
+        title={`Split horizontally (${splitColumn}); hold Shift for Alacritty`}
         aria-label="Split pane horizontally"
-        onClick={props.onSplitColumn}
+        onClick={(event) => props.onSplitColumn(event.shiftKey)}
       >
         <SplitColumnIcon />
       </button>

--- a/src/ui/controls/terminal-background-row.tsx
+++ b/src/ui/controls/terminal-background-row.tsx
@@ -91,6 +91,7 @@ export function TerminalBackgroundRows() {
         <button
           type="button"
           class="cfg-btn"
+          aria-label="Cycle terminal background target"
           onClick={() => patchBackground({ target: nextValue(TARGETS, current.target) })}
         >
           {current.target}
@@ -101,6 +102,7 @@ export function TerminalBackgroundRows() {
         <button
           type="button"
           class="cfg-btn"
+          aria-label="Cycle terminal background image fit"
           onClick={() => patchBackground({ fit: nextValue(FITS, current.fit) })}
         >
           {current.fit}

--- a/src/ui/controls/terminal-background-row.tsx
+++ b/src/ui/controls/terminal-background-row.tsx
@@ -1,0 +1,145 @@
+import { invoke } from "@tauri-apps/api/core";
+import { open } from "@tauri-apps/plugin-dialog";
+import { useSignal } from "@preact/signals";
+import { reportPersistError } from "../../chrome/events";
+import { settings, updateSettings } from "../../settings/settings-store";
+import type {
+  TerminalBackgroundFit,
+  TerminalBackgroundSettings,
+  TerminalBackgroundTarget,
+} from "../../settings/settings-schema";
+import { ConfigRow } from "./config-row";
+
+const TARGETS: readonly TerminalBackgroundTarget[] = [
+  "all",
+  "xterm",
+  "alacritty",
+];
+const FITS: readonly TerminalBackgroundFit[] = ["cover", "contain", "stretch"];
+
+function patchBackground(patch: Partial<TerminalBackgroundSettings>): void {
+  updateSettings({
+    terminalBackground: { ...settings.value.terminalBackground, ...patch },
+  });
+}
+
+function nextValue<T>(values: readonly T[], current: T): T {
+  return values[(Math.max(0, values.indexOf(current)) + 1) % values.length];
+}
+
+export function TerminalBackgroundRows() {
+  const current = settings.value.terminalBackground;
+  const picking = useSignal(false);
+
+  const chooseImage = async (): Promise<void> => {
+    if (picking.value) return;
+    picking.value = true;
+    try {
+      const selected = await open({
+        multiple: false,
+        directory: false,
+        filters: [
+          { name: "Images", extensions: ["png", "jpg", "jpeg", "webp", "svg"] },
+        ],
+      });
+      if (typeof selected !== "string") return;
+      const imageDataUrl = await invoke<string>("read_image_as_data_url", {
+        path: selected,
+      });
+      patchBackground({ imageDataUrl });
+    } catch (error) {
+      reportPersistError(
+        typeof error === "string" ? error : "Couldn't load the background image.",
+      );
+    } finally {
+      picking.value = false;
+    }
+  };
+
+  return (
+    <>
+      <ConfigRow label="Terminal background" desc="image behind terminal panes">
+        <span class="cfg-background-actions">
+          {current.imageDataUrl !== "" && (
+            <span
+              class="cfg-background-preview"
+              style={{ backgroundImage: `url(${current.imageDataUrl})` }}
+              aria-hidden="true"
+            />
+          )}
+          <button
+            type="button"
+            class="cfg-btn"
+            disabled={picking.value}
+            onClick={() => void chooseImage()}
+          >
+            {current.imageDataUrl === "" ? "choose…" : "change…"}
+          </button>
+          {current.imageDataUrl !== "" && (
+            <button
+              type="button"
+              class="cfg-btn cfg-btn--compact"
+              aria-label="Remove terminal background image"
+              onClick={() => patchBackground({ imageDataUrl: "" })}
+            >
+              remove
+            </button>
+          )}
+        </span>
+      </ConfigRow>
+      <ConfigRow label="Background target">
+        <button
+          type="button"
+          class="cfg-btn"
+          onClick={() => patchBackground({ target: nextValue(TARGETS, current.target) })}
+        >
+          {current.target}
+          <span class="cfg-btn__hint">↹</span>
+        </button>
+      </ConfigRow>
+      <ConfigRow label="Image fit">
+        <button
+          type="button"
+          class="cfg-btn"
+          onClick={() => patchBackground({ fit: nextValue(FITS, current.fit) })}
+        >
+          {current.fit}
+          <span class="cfg-btn__hint">↹</span>
+        </button>
+      </ConfigRow>
+      <ConfigRow label="Image dim" desc={`${Math.round(current.dim * 100)}%`}>
+        <input
+          class="cfg-range"
+          type="range"
+          min="0"
+          max="90"
+          step="5"
+          value={Math.round(current.dim * 100)}
+          aria-label="Background image dimming"
+          onInput={(event) =>
+            patchBackground({ dim: Number(event.currentTarget.value) / 100 })
+          }
+        />
+      </ConfigRow>
+      <ConfigRow
+        label="Alacritty opacity"
+        desc={`${Math.round(current.nativeOpacity * 100)}%`}
+      >
+        <input
+          class="cfg-range"
+          type="range"
+          min="40"
+          max="100"
+          step="5"
+          value={Math.round(current.nativeOpacity * 100)}
+          aria-label="Alacritty background opacity"
+          onInput={(event) =>
+            patchBackground({
+              nativeOpacity: Number(event.currentTarget.value) / 100,
+            })
+          }
+        />
+      </ConfigRow>
+    </>
+  );
+}

--- a/src/ui/settings/sections/terminal-section.tsx
+++ b/src/ui/settings/sections/terminal-section.tsx
@@ -4,6 +4,7 @@ import {
 } from "../../../settings/settings-schema";
 import { settings, updateSettings } from "../../../settings/settings-store";
 import { ConfigRow } from "../../controls/config-row";
+import { TerminalBackgroundRows } from "../../controls/terminal-background-row";
 
 function scrollbackLabel(n: number): string {
   if (n >= 1000) {
@@ -29,17 +30,20 @@ export function TerminalSection() {
   };
 
   return (
-    <ConfigRow label="Scrollback" desc="lines kept per pane">
-      <button
-        type="button"
-        class="cfg-btn"
-        title="Next scrollback size"
-        aria-label={`Scrollback: ${scrollbackLabel(current.scrollback)}. Switch to next size`}
-        onClick={cycleScrollback}
-      >
-        {scrollbackLabel(current.scrollback)}
-        <span class="cfg-btn__hint">↹</span>
-      </button>
-    </ConfigRow>
+    <>
+      <ConfigRow label="Scrollback" desc="lines kept per pane">
+        <button
+          type="button"
+          class="cfg-btn"
+          title="Next scrollback size"
+          aria-label={`Scrollback: ${scrollbackLabel(current.scrollback)}. Switch to next size`}
+          onClick={cycleScrollback}
+        >
+          {scrollbackLabel(current.scrollback)}
+          <span class="cfg-btn__hint">↹</span>
+        </button>
+      </ConfigRow>
+      <TerminalBackgroundRows />
+    </>
   );
 }

--- a/src/ui/settings/settings-screen.test.tsx
+++ b/src/ui/settings/settings-screen.test.tsx
@@ -130,12 +130,18 @@ const EXPECTED_ROWS = [
   "Selection",
   // terminal
   "Scrollback",
+  "Terminal background",
+  "Background target",
+  "Image fit",
+  "Image dim",
+  "Alacritty opacity",
   // agents (built-ins are locked rows; declared ones are added by the user)
   "Claude Code",
   "Codex",
   "Gemini CLI",
   "OpenCode",
   "Antigravity",
+  "Alacritty",
   "Add agent",
   // links & editor
   "Editor",
@@ -164,7 +170,7 @@ describe("SettingsScreen — every setting survived the move", () => {
     });
   });
 
-  it("reaches all 22 rows by walking the rail", () => {
+  it("reaches all 28 rows by walking the rail", () => {
     act(() => {
       render(<SettingsScreen open onClose={vi.fn()} />, host);
     });

--- a/src/ui/tab-bar.test.tsx
+++ b/src/ui/tab-bar.test.tsx
@@ -99,6 +99,26 @@ describe("TabBar", () => {
     expect(add.getAttribute("aria-label")).toBe("New tab");
   });
 
+  it("passes Shift state through both split buttons", () => {
+    const props = baseProps();
+    mount(props);
+    const buttons = host.querySelectorAll<HTMLButtonElement>(
+      '.tabbar__actions button[aria-label^="Split pane"]',
+    );
+
+    act(() => {
+      buttons[0].dispatchEvent(
+        new MouseEvent("click", { bubbles: true, shiftKey: false }),
+      );
+      buttons[1].dispatchEvent(
+        new MouseEvent("click", { bubbles: true, shiftKey: true }),
+      );
+    });
+
+    expect(props.onSplitRow).toHaveBeenCalledWith(false);
+    expect(props.onSplitColumn).toHaveBeenCalledWith(true);
+  });
+
   it("clicking the status mark calls onFocusAttention(index) and does not select or toggle the popover", () => {
     tabViews.value = [
       tab({

--- a/src/ui/tab-bar.tsx
+++ b/src/ui/tab-bar.tsx
@@ -19,8 +19,8 @@ interface TabBarProps {
   onSelectTab(index: number): void;
   onCloseTab(index: number): void;
   onNewTab(): void;
-  onSplitRow(): void;
-  onSplitColumn(): void;
+  onSplitRow(alacritty: boolean): void;
+  onSplitColumn(alacritty: boolean): void;
   onClosePane(): void;
   onRenameTab(index: number, name: string | null): void;
   onSetTabColor(index: number, color: TabDotColor | null): void;


### PR DESCRIPTION
## Summary

- add Alacritty as a first-class Windows pane renderer without replacing the default PowerShell/xterm terminal
- Shift-click either split control to create only the new pane as Alacritty; ordinary clicks still create normal shell panes
- fall back to a normal shell pane when Alacritty is missing or fails to launch
- launch one isolated Alacritty process/config per native pane, attach it to the SpaceVibe window, and synchronize focus, visibility, DPI-aware geometry, zoom, dividers, tabs, and overlays
- preserve mixed xterm/Alacritty pane types in serialized layouts and presets
- apply SpaceVibe font, theme colors, scrollback, opacity, and terminal background settings to running native panes
- retain the blue active-pane outline and route native copy/paste/search/clear/scroll actions
- clean up native processes and generated runtime config on pane close, tab close, and app shutdown

## Compatibility

- Windows implementation only; existing macOS behavior is unchanged
- existing layouts without `paneType` continue to restore as xterm
- PowerShell/xterm remains the default and normal split behavior is unchanged

## Verification

- frontend: 90 test files / 1,049 tests passed
- TypeScript + Vite production build passed
- Rust: 142 tests passed
- `cargo fmt --check` passed
- Windows Tauri release build passed
- runtime dependency audit: 0 vulnerabilities
- native desktop smoke test:
  - opened Alacritty inside a SpaceVibe-owned pane
  - typed and executed a command
  - Shift-click vertical split created a second native Alacritty pane
  - normal horizontal split created an xterm pane
  - active native pane retained the blue inset focus ring
  - clean shutdown left no test Alacritty process or generated config behind

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native Alacritty terminal panes on Windows with appearance, focus, resizing, and lifecycle support.
  * Hold **Shift** while splitting rows or columns to create an Alacritty pane.
  * Added terminal background image settings with target, fit, dimming, and opacity controls.
  * Layouts now preserve pane types across sessions.
* **Bug Fixes**
  * Improved Alacritty discovery and fallback to standard shell panes when unavailable.
  * Improved close confirmation behavior for tabs containing native panes.
  * Improved native pane visibility when opening overlays and dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->