### PR TITLE
fix(terminal): join OpenCode glyphs with WebGL

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -102,6 +102,11 @@ open ([macOS release workflow](../.github/workflows/release.yml) `current`,
   [clipboard text boundary](../src/terminal/terminal-clipboard.ts#L45-L55) `current`,
   [menu generator](../scripts/generate-menu.ts) `current`).
 - The macOS menu path can't tell an accelerator from a mouse click (Tauri's `MenuEvent` carries only an id), so only `destructive: true` actions (`close-pane`/`close-tab`/`clear-buffer`) are suppressed while a chrome text field holds the caret — every other action still runs there — [ActionDefinition.destructive](../src/terminal/action-registry.ts#L82-L115) `current`, [runAction](../src/terminal/tab-manager.ts#L1032-L1054) `current`.
+- Terminal panes use xterm's official WebGL renderer so continuous block and
+  box-drawing glyphs used by agent TUIs render without DOM-renderer seams. It
+  is loaded only after `Terminal.open()` and disposes on initialization failure
+  or WebGL context loss, preserving xterm's DOM renderer as a compatibility
+  fallback ([pane.ts](../src/terminal/pane.ts) `current`).
 - Windows uses native decorated system chrome; Preact renders only Deck's
   internal toolbar and omits synthetic minimize/maximize/close controls
   ([tauri.windows.conf.json](../src-tauri/tauri.windows.conf.json) `current`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-serialize": "0.14.0",
         "@xterm/addon-unicode-graphemes": "^0.4.0",
+        "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "lucide-preact": "^1.30.0",
         "monaco-editor": "0.56.0",
@@ -2618,6 +2619,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-unicode-graphemes/-/addon-unicode-graphemes-0.4.0.tgz",
       "integrity": "sha512-9+/CqwbKcnlkJU4d3wIgO+wjsL8f6vyz+UwUWLu6nADQz8Gr8ONqGCJfdDjIdI+yYZLABQqQy47FzEM6AWELjw==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-webgl": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.19.0.tgz",
+      "integrity": "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==",
       "license": "MIT"
     },
     "node_modules/@xterm/xterm": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-serialize": "0.14.0",
     "@xterm/addon-unicode-graphemes": "^0.4.0",
+    "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "lucide-preact": "^1.30.0",
     "monaco-editor": "0.56.0",

--- a/src/terminal/pane-renderer.test.ts
+++ b/src/terminal/pane-renderer.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_SETTINGS } from "../settings/settings-schema";
+
+const xterm = vi.hoisted(() => ({
+  constructorOptions: undefined as Record<string, unknown> | undefined,
+  opened: false,
+}));
+
+const webgl = vi.hoisted(() => ({
+  instances: [] as Array<{
+    activatedAfterOpen: boolean;
+    disposed: number;
+    emitContextLoss(): void;
+  }>,
+  throwOnActivate: false,
+}));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class {
+    options: Record<string, unknown>;
+    unicode = { activeVersion: "" };
+    parser = { registerOscHandler: () => ({ dispose() {} }) };
+    buffer = { active: { type: "normal" } };
+    cols = 80;
+    rows = 24;
+
+    constructor(options: Record<string, unknown>) {
+      xterm.constructorOptions = options;
+      this.options = options;
+    }
+    open() {
+      xterm.opened = true;
+    }
+    loadAddon(addon: { activate?(terminal: unknown): void }) {
+      addon.activate?.(this);
+    }
+    attachCustomWheelEventHandler() {}
+    registerLinkProvider() {
+      return { dispose() {} };
+    }
+    onBell() {
+      return { dispose() {} };
+    }
+    onData() {}
+    onResize() {}
+    getSelectionPosition() {
+      return undefined;
+    }
+    paste() {}
+    write() {}
+    dispose() {}
+  },
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: class {
+    activatedAfterOpen = false;
+    disposed = 0;
+    private contextLossHandler: (() => void) | undefined;
+
+    constructor() {
+      webgl.instances.push(this);
+    }
+    activate() {
+      this.activatedAfterOpen = xterm.opened;
+      if (webgl.throwOnActivate) throw new Error("WebGL2 unavailable");
+    }
+    onContextLoss(handler: () => void) {
+      this.contextLossHandler = handler;
+      return { dispose() {} };
+    }
+    emitContextLoss() {
+      this.contextLossHandler?.();
+    }
+    dispose() {
+      this.disposed += 1;
+    }
+  },
+}));
+
+vi.mock("@xterm/addon-fit", () => ({ FitAddon: class { fit() {} } }));
+vi.mock("@xterm/addon-search", () => ({ SearchAddon: class {} }));
+vi.mock("@xterm/addon-serialize", () => ({
+  SerializeAddon: class {
+    serialize() { return ""; }
+    dispose() {}
+  },
+}));
+vi.mock("@xterm/addon-unicode-graphemes", () => ({ UnicodeGraphemesAddon: class {} }));
+vi.mock("./webkit-ime-fix", () => ({ applyWebkitImeFix: vi.fn(), isWebKitWebView: () => false }));
+vi.mock("./shift-enter", () => ({ installShiftEnterNewline: () => vi.fn() }));
+vi.mock("./ime-trace", () => ({ installImeTrace: vi.fn() }));
+vi.mock("../settings/themes", () => ({ resolveTheme: () => ({}) }));
+vi.mock("./link-provider", () => ({ createLinkProvider: () => ({}) }));
+vi.mock("./osc-link-handler", () => ({ createOscLinkHandler: () => ({}) }));
+vi.mock("./pane-cwd", () => ({ paneCwd: () => "" }));
+vi.mock("../lib/osc-notification", () => ({ classifyOscNotification: () => null }));
+vi.mock("./terminal-clipboard", () => ({ copyTerminalSelection: vi.fn(), pasteIntoTerminal: vi.fn() }));
+vi.mock("../lib/platform", () => ({ getDesktopEnvironment: () => ({ platform: "windows" }) }));
+vi.mock("./codex-wheel", () => ({ createCodexWheelHandler: () => vi.fn() }));
+
+import { createPane } from "./pane";
+
+class ResizeObserverStub {
+  observe() {}
+  disconnect() {}
+}
+
+beforeEach(() => {
+  xterm.constructorOptions = undefined;
+  xterm.opened = false;
+  webgl.instances = [];
+  webgl.throwOnActivate = false;
+  vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+});
+
+const events = {
+  onData: async () => true,
+  onResize() {},
+  onFocus() {},
+};
+
+describe("createPane OpenCode glyph rendering", () => {
+  it("keeps terminal rows flush", () => {
+    createPane(1, DEFAULT_SETTINGS, events);
+    expect(xterm.constructorOptions?.lineHeight).toBe(1);
+  });
+
+  it("loads WebGL only after the terminal is open", () => {
+    const pane = createPane(1, DEFAULT_SETTINGS, events);
+    pane.mount();
+    expect(webgl.instances[0].activatedAfterOpen).toBe(true);
+  });
+
+  it("falls back when WebGL cannot initialize", () => {
+    webgl.throwOnActivate = true;
+    const pane = createPane(1, DEFAULT_SETTINGS, events);
+    expect(() => pane.mount()).not.toThrow();
+    expect(webgl.instances[0].disposed).toBe(1);
+  });
+
+  it("disposes WebGL on context loss", () => {
+    const pane = createPane(1, DEFAULT_SETTINGS, events);
+    pane.mount();
+    webgl.instances[0].emitContextLoss();
+    expect(webgl.instances[0].disposed).toBe(1);
+  });
+});

--- a/src/terminal/pane.ts
+++ b/src/terminal/pane.ts
@@ -3,6 +3,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { SearchAddon } from "@xterm/addon-search";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { UnicodeGraphemesAddon } from "@xterm/addon-unicode-graphemes";
+import { WebglAddon } from "@xterm/addon-webgl";
 import { FONT_FALLBACK, type Settings } from "../settings/settings-schema";
 import { applyWebkitImeFix, isWebKitWebView } from "./webkit-ime-fix";
 import { installShiftEnterNewline } from "./shift-enter";
@@ -159,7 +160,9 @@ export function createPane(
     cursorWidth: 1,
     fontSize: initial.fontSize,
     fontFamily: toFontStack(initial.fontFamily),
-    lineHeight: 1.25,
+    // Keep cell rows flush: OpenCode joins block and box-drawing glyphs across
+    // rows, and extra leading slices its wordmark and prompt borders apart.
+    lineHeight: 1,
     scrollback: initial.scrollback,
     // Option must stay a character key on macOS so IMEs (Vietnamese Telex,
     // dead-key accents) can compose — `true` swallows it as Meta.
@@ -288,9 +291,27 @@ export function createPane(
   });
   let opened = false;
 
+  function loadWebglRenderer(): void {
+    let addon: WebglAddon | undefined;
+    try {
+      addon = new WebglAddon();
+      const renderer = addon;
+      renderer.onContextLoss(() => renderer.dispose());
+      term.loadAddon(renderer);
+    } catch {
+      // WebGL is optional. Disposing a partially activated addon restores
+      // xterm's DOM renderer, which keeps the terminal usable on older GPUs.
+      addon?.dispose();
+    }
+  }
+
   function mount(): void {
     if (!opened) {
       term.open(termEl);
+      // xterm's DOM renderer does not support custom glyphs, so block and
+      // box-drawing characters used by TUIs such as OpenCode look segmented.
+      // WebGL draws those glyphs continuously and must be loaded after open().
+      loadWebglRenderer();
       if (isWebKitWebView()) {
         applyWebkitImeFix(term);
       }


### PR DESCRIPTION
## Summary

- Load xterm's official WebGL renderer after `Terminal.open()` so OpenCode block and box-drawing glyphs render continuously.
- Set terminal `lineHeight` to `1` to keep adjacent glyph rows flush.
- Preserve xterm's DOM renderer as a fallback when WebGL initialization fails or its context is lost.
- Add renderer lifecycle regression tests and record the renderer decision in the architecture notes.

## Verification

- `npx vitest run src/terminal/pane-renderer.test.ts src/terminal/pane.test.ts` - 8 tests passed
- `npm run build` - passed
- `npm run generate:menu:check` - passed
- Rebuilt and installed the Windows 0.12.2 package and visually verified OpenCode renders without seams; this PR is cleanly based on upstream 0.12.3.
- `npm audit --omit=dev --audit-level=high` - passed the high-severity threshold (two existing lower-severity Monaco/DOMPurify advisories remain)

## Upstream Windows test baseline

A full `npm test` run still encounters existing Windows-only baseline failures outside this five-file patch: Electron Windows Gate C stubs, POSIX chmod/path assumptions, the vendored react-grab bundle hash check, and the release-notes script suite. The focused terminal tests above pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added WebGL rendering for terminal panes to improve visual performance.
  - Automatically falls back to the standard renderer if WebGL is unavailable or fails to initialize.
  - Handles WebGL context loss gracefully.

- **Improvements**
  - Adjusted terminal line spacing so glyph rows display flush and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->