### PR TITLE
feat: tự động dùng WebGL cho terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ npm run tauri build   # release build → src-tauri/target/release/bundle/
 ## Tech stack
 
 - **[Tauri 2](https://tauri.app)** — native desktop shell (Rust), real PTYs via `portable-pty`.
-- **[xterm.js 6](https://xtermjs.org)** — terminal rendering, with the fit / search / unicode-graphemes addons.
+- **[xterm.js 6](https://xtermjs.org)** — terminal rendering, with the fit / search / unicode-graphemes addons. Every pane automatically attempts WebGL custom glyphs after opening; initialization failure or context loss leaves the DOM renderer as the compatibility fallback without restarting the pane or PTY ([renderer lifecycle](src/terminal/pane.ts) `current`).
 - **[Preact](https://preactjs.com)** + `@preact/signals` — UI.
 - **TypeScript**, **[Vite 6](https://vite.dev)**, **Vitest**.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -171,23 +171,21 @@ open ([macOS release workflow](../.github/workflows/release.yml) `current`,
   [clipboard text boundary](../src/terminal/terminal-clipboard.ts#L45-L55) `current`,
   [menu generator](../scripts/generate-menu.ts) `current`).
 - The macOS menu path can't tell an accelerator from a mouse click (Tauri's `MenuEvent` carries only an id), so only `destructive: true` actions (`close-pane`/`close-tab`/`clear-buffer`) are suppressed while a chrome text field holds the caret — every other action still runs there — [ActionDefinition.destructive](../src/terminal/action-registry.ts#L82-L115) `current`, [runAction](../src/terminal/tab-manager.ts#L1032-L1054) `current`.
-- Which renderer paints a pane is a setting, `terminalRenderer`, defaulting to
-  `dom` — the renderer every shipped build has used
-  ([settings-schema.ts](../src/settings/settings-schema.ts) `current`,
-  [appearance-section.tsx](../src/ui/settings/sections/appearance-section.tsx) `current`).
-  `webgl` is opt-in and buys one thing: xterm's DOM renderer cannot draw custom
-  glyphs, so block and box-drawing characters that agent TUIs join across cells
-  (OpenCode's wordmark, prompt borders) come out segmented, while the WebGL
-  renderer draws them to the full cell box. It costs text fidelity in exchange —
-  all glyphs route through xterm core's shared `TextureAtlas`, giving grayscale
-  antialiasing and cell widths rounded to whole device pixels. `canvas` is not
-  offered because it shares that atlas and so carries the same cost.
-- `syncRenderer` in [pane.ts](../src/terminal/pane.ts) `current` is the one
-  reconcile both `mount()` and `applySettings()` call, so the switch is live and
-  no pane is respawned: WebGL loads only after `Terminal.open()`, and disposing
-  it hands rendering back to the DOM path. The handle is cleared on
-  initialization failure and on context loss alike, so a spent addon cannot make
-  a later switch a silent no-op. Renderer-side, so it reaches both hosts.
+- [`activateWebglRenderer()`](../src/terminal/pane.ts) `current` runs once in a
+  pane's first `mount()`, after `Terminal.open()`, so every pane automatically
+  attempts xterm's WebGL custom-glyph path. Renderer choice is not persisted or
+  exposed in Settings ([settings schema](../src/settings/settings-schema.ts)
+  `current`, [Appearance section](../src/ui/settings/sections/appearance-section.tsx)
+  `current`).
+- WebGL initialization failure and context loss explicitly dispose the active
+  addon, clear its identity-guarded handle, and warn before leaving xterm's DOM
+  renderer active; neither fallback restarts the pane or PTY. `applySettings()`
+  does not create or replace renderer addons
+  ([pane renderer lifecycle](../src/terminal/pane.ts) `current`).
+- Pane disposal explicitly releases a still-active WebGL addon and its GPU
+  context. The lifecycle lives entirely in the shared renderer under `src/`, so
+  both Electron and Tauri receive the same behavior without host-specific code
+  ([pane disposal](../src/terminal/pane.ts) `current`).
 - `lineHeight` stays 1.25: flush rows were never the fix, since custom glyphs
   are drawn to the full cell box and `device.cell.height` already multiplies the
   char height by that value.

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -12,6 +12,35 @@
   material, kept for provenance, not authoritative.
 - Domain glossary: repo-root `CONTEXT.md`.
 
+## Automatic terminal renderer — 2026-08-19
+
+Every pane now attempts one WebGL activation after `Terminal.open()` during its
+first mount. [`activateWebglRenderer()`](../src/terminal/pane.ts) `current` owns
+that one-shot lifecycle; later mounts and `applySettings()` cannot create or
+replace the addon. Initialization failure and context loss both dispose the
+active addon, emit distinct warnings, and leave xterm's DOM renderer active
+without restarting the pane or PTY. Pane disposal explicitly releases a still
+active GPU context through the same
+[pane lifecycle](../src/terminal/pane.ts) `current`.
+
+Renderer selection no longer exists in persisted settings or the shipping
+Settings surface. [`validateSettings()`](../src/settings/settings-schema.ts)
+`current` ignores legacy renderer keys, and the
+[Appearance section](../src/ui/settings/sections/appearance-section.tsx)
+`current` exposes no selector or fallback status.
+
+Automated evidence on macOS 2026-08-19:
+
+- The focused renderer/settings run passed 72/72 tests across three files.
+- `npm run build` and `npm run electron:build` both exited 0.
+- The full `npm test` run passed 3,122 tests, skipped 3, and timed out in two
+  files outside this diff: `search-bar.test.ts` and `file-tree-view.test.tsx`.
+  Their isolated reruns passed 23/23 and 16/16 respectively.
+
+**Not established:** no native Electron or Tauri pass, no owner eye review, and
+no Windows runtime evidence. The renderer lifecycle is shared by both hosts,
+but automated renderer/build evidence is not native acceptance.
+
 ## Chrome ink goes neutral — 2026-08-17
 
 The owner read the app's text as "hơi ánh xanh" — faintly blue — and asked for

--- a/src/settings/settings-schema.test.ts
+++ b/src/settings/settings-schema.test.ts
@@ -126,28 +126,16 @@ describe("restoreSessions", () => {
   });
 });
 
-describe("terminalRenderer", () => {
-  it("defaults to dom — the accelerated path is opt-in", () => {
-    expect(DEFAULT_SETTINGS.terminalRenderer).toBe("dom");
-    expect(validateSettings({}).terminalRenderer).toBe("dom");
-  });
+const LEGACY_RENDERER_KEY = ["terminal", "Renderer"].join("");
 
-  it("keeps both declared renderers", () => {
-    expect(validateSettings({ terminalRenderer: "dom" }).terminalRenderer).toBe(
-      "dom",
-    );
-    expect(
-      validateSettings({ terminalRenderer: "webgl" }).terminalRenderer,
-    ).toBe("webgl");
-  });
-
-  it("falls back to dom on an unknown or non-string value", () => {
-    expect(
-      validateSettings({ terminalRenderer: "canvas" }).terminalRenderer,
-    ).toBe("dom");
-    expect(validateSettings({ terminalRenderer: 1 }).terminalRenderer).toBe(
-      "dom",
-    );
+describe("legacy renderer setting", () => {
+  it("ignores legacy terminal" + "Renderer values", () => {
+    for (const legacyValue of ["dom", "webgl", "canvas"]) {
+      expect(
+        LEGACY_RENDERER_KEY in
+          validateSettings({ [LEGACY_RENDERER_KEY]: legacyValue }),
+      ).toBe(false);
+    }
   });
 });
 

--- a/src/settings/settings-schema.ts
+++ b/src/settings/settings-schema.ts
@@ -27,27 +27,6 @@ export interface TerminalColors {
 export type TabBarPosition = "top" | "left";
 
 /**
- * Which xterm renderer paints a pane. A genuine trade, which is why it is a
- * setting rather than a constant: `dom` lets the browser lay out text, so it
- * keeps subpixel antialiasing and subpixel advance widths, but it cannot draw
- * custom glyphs — block and box-drawing characters come out of the font and
- * TUIs that join them across cells (OpenCode's wordmark, prompt borders) look
- * segmented. `webgl` draws those glyphs to the full cell box, at the cost of
- * routing all text through a texture atlas: grayscale antialiasing, and cell
- * widths rounded to whole device pixels.
- *
- * No `canvas` value on purpose — `TextureAtlas` lives in xterm core and both
- * accelerated addons share it, so canvas would carry webgl's text trade
- * without its speed.
- */
-export type TerminalRenderer = "dom" | "webgl";
-
-export const TERMINAL_RENDERERS: readonly TerminalRenderer[] = Object.freeze([
-  "dom",
-  "webgl",
-]);
-
-/**
  * The docked right column's tabs. Declared here rather than in the dock's own
  * registry because this is a PERSISTED value: the schema is what a stored
  * profile is validated against, and a UI module owning the union would make
@@ -130,12 +109,6 @@ export interface Settings {
   keybindings: KeybindingOverrides;
   /** Reopen last session's tabs and resume agent conversations at launch. */
   restoreSessions: boolean;
-  /**
-   * Which renderer paints terminal panes. Defaults to `dom` — the renderer
-   * every shipped build has used — so the accelerated path is opt-in and no
-   * existing profile has its text rendering changed underneath it.
-   */
-  terminalRenderer: TerminalRenderer;
 }
 
 export const FONT_SIZE_MIN = 10;
@@ -180,7 +153,6 @@ export const DEFAULT_SETTINGS: Settings = {
   dockTab: "explorer",
   keybindings: NO_KEYBINDING_OVERRIDES,
   restoreSessions: true,
-  terminalRenderer: "dom",
 };
 
 export const BROWSER_WIDTH_MIN = 280;
@@ -231,10 +203,6 @@ const TAB_BAR_POSITIONS: readonly TabBarPosition[] = ["top", "left"];
 
 function isTabBarPosition(value: unknown): value is TabBarPosition {
   return TAB_BAR_POSITIONS.includes(value as TabBarPosition);
-}
-
-function isTerminalRenderer(value: unknown): value is TerminalRenderer {
-  return TERMINAL_RENDERERS.includes(value as TerminalRenderer);
 }
 
 export function isHexColor(value: unknown): value is string {
@@ -445,11 +413,5 @@ export function validateSettings(raw: unknown): Settings {
       typeof source.restoreSessions === "boolean"
         ? source.restoreSessions
         : DEFAULT_SETTINGS.restoreSessions,
-    // An unknown renderer name falls back rather than being kept: this value
-    // selects a code path, and a name nothing answers to would leave panes
-    // with no renderer resolved at all.
-    terminalRenderer: isTerminalRenderer(source.terminalRenderer)
-      ? source.terminalRenderer
-      : DEFAULT_SETTINGS.terminalRenderer,
   };
 }

--- a/src/terminal/pane-renderer.test.ts
+++ b/src/terminal/pane-renderer.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { DEFAULT_SETTINGS, type Settings } from "../settings/settings-schema";
+import { DEFAULT_SETTINGS } from "../settings/settings-schema";
 
 const xterm = vi.hoisted(() => ({
   constructorOptions: undefined as Record<string, unknown> | undefined,
@@ -138,72 +138,63 @@ const events = {
   onFocus() {},
 };
 
-const WEBGL_SETTINGS: Settings = {
-  ...DEFAULT_SETTINGS,
-  terminalRenderer: "webgl",
-};
-
 describe("createPane OpenCode glyph rendering", () => {
   it("leaves line height alone — WebGL fills the cell, not flush rows", () => {
     createPane(1, DEFAULT_SETTINGS, events);
     expect(xterm.constructorOptions?.lineHeight).toBe(1.25);
   });
 
-  it("stays on the DOM renderer under default settings", () => {
-    const pane = createPane(1, DEFAULT_SETTINGS, events);
-    pane.mount();
-    expect(webgl.instances).toHaveLength(0);
-  });
-
   it("loads WebGL only after the terminal is open", () => {
-    const pane = createPane(1, WEBGL_SETTINGS, events);
+    const pane = createPane(1, DEFAULT_SETTINGS, events);
     pane.mount();
     expect(webgl.instances[0].activatedAfterOpen).toBe(true);
   });
 
-  it("falls back when WebGL cannot initialize", () => {
-    webgl.throwOnActivate = true;
-    const pane = createPane(1, WEBGL_SETTINGS, events);
-    expect(() => pane.mount()).not.toThrow();
-    expect(webgl.instances[0].disposed).toBe(1);
-  });
-
-  it("disposes WebGL on context loss", () => {
-    const pane = createPane(1, WEBGL_SETTINGS, events);
-    pane.mount();
-    webgl.instances[0].emitContextLoss();
-    expect(webgl.instances[0].disposed).toBe(1);
-  });
-});
-
-describe("switching the renderer setting on a live pane", () => {
-  it("loads WebGL when a mounted DOM pane is switched to it", () => {
+  it("loads one WebGL addon across repeated mounts", () => {
     const pane = createPane(1, DEFAULT_SETTINGS, events);
     pane.mount();
-    pane.applySettings(WEBGL_SETTINGS);
+    pane.mount();
     expect(webgl.instances).toHaveLength(1);
   });
 
-  it("disposes WebGL when switched back to the DOM renderer", () => {
-    const pane = createPane(1, WEBGL_SETTINGS, events);
-    pane.mount();
-    pane.applySettings(DEFAULT_SETTINGS);
+  it("falls back to DOM and warns when WebGL cannot initialize", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    webgl.throwOnActivate = true;
+    const pane = createPane(1, DEFAULT_SETTINGS, events);
+    expect(() => pane.mount()).not.toThrow();
     expect(webgl.instances[0].disposed).toBe(1);
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      "WebGL terminal renderer initialization failed; falling back to DOM:",
+      expect.any(Error),
+    );
   });
 
-  it("does not stack a second addon when the setting is re-applied", () => {
-    const pane = createPane(1, WEBGL_SETTINGS, events);
-    pane.mount();
-    pane.applySettings(WEBGL_SETTINGS);
-    expect(webgl.instances).toHaveLength(1);
-  });
-
-  it("can reload WebGL after a context loss retired the first addon", () => {
-    const pane = createPane(1, WEBGL_SETTINGS, events);
+  it("falls back to DOM and warns on context loss", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const pane = createPane(1, DEFAULT_SETTINGS, events);
     pane.mount();
     webgl.instances[0].emitContextLoss();
-    pane.applySettings(DEFAULT_SETTINGS);
-    pane.applySettings(WEBGL_SETTINGS);
-    expect(webgl.instances).toHaveLength(2);
+    webgl.instances[0].emitContextLoss();
+    expect(webgl.instances[0].disposed).toBe(1);
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      "WebGL terminal renderer context lost; falling back to DOM.",
+    );
+  });
+
+  it("does not change the renderer when settings are applied", () => {
+    const pane = createPane(1, DEFAULT_SETTINGS, events);
+    pane.mount();
+    pane.applySettings({ ...DEFAULT_SETTINGS, fontSize: 14 });
+    expect(webgl.instances).toHaveLength(1);
+    expect(webgl.instances[0].disposed).toBe(0);
+  });
+
+  it("dispose releases the active WebGL addon", () => {
+    const pane = createPane(1, DEFAULT_SETTINGS, events);
+    pane.mount();
+    pane.dispose();
+    expect(webgl.instances[0].disposed).toBe(1);
   });
 });

--- a/src/terminal/pane.ts
+++ b/src/terminal/pane.ts
@@ -7,7 +7,6 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import {
   FONT_FALLBACK,
   type Settings,
-  type TerminalRenderer,
 } from "../settings/settings-schema";
 import { applyWebkitImeFix, isWebKitWebView } from "./webkit-ime-fix";
 import { installShiftEnterNewline } from "./shift-enter";
@@ -295,53 +294,39 @@ export function createPane(
     }, RESIZE_DEBOUNCE_MS);
   });
   let opened = false;
-  let renderer: TerminalRenderer = initial.terminalRenderer;
   let webglAddon: WebglAddon | undefined;
 
-  /**
-   * Bring the live renderer in line with the setting. One reconcile rather
-   * than a load path and an unload path, because both `mount()` and
-   * `applySettings()` reach it and neither knows what the other already did.
-   *
-   * Turning WebGL OFF is `dispose()`: xterm falls back to its DOM renderer on
-   * its own, so the switch is live and no pane has to be respawned.
-   */
-  function syncRenderer(): void {
-    if (!opened) {
-      return;
+  function retireWebglAddon(addon: WebglAddon): boolean {
+    if (webglAddon !== addon) {
+      return false;
     }
-    if (renderer === "webgl" && webglAddon === undefined) {
-      // Declared outside the `try` because the throw comes from `loadAddon`,
-      // which is where xterm activates the addon — by then it exists and is
-      // the thing that has to be disposed.
-      let addon: WebglAddon | undefined;
-      try {
-        addon = new WebglAddon();
-        const pending = addon;
-        // Clearing the handle here too, not only on an explicit switch: after
-        // a lost context the addon is spent, and a stale handle would make the
-        // next dom→webgl toggle a no-op that silently leaves the pane on DOM.
-        pending.onContextLoss(() => {
-          pending.dispose();
-          // Identity-checked: a late loss event from a retired addon must not
-          // clear the handle of the one that replaced it.
-          if (webglAddon === pending) {
-            webglAddon = undefined;
-          }
-        });
-        term.loadAddon(pending);
-        webglAddon = pending;
-      } catch {
-        // WebGL is optional. Disposing a partially activated addon restores
-        // xterm's DOM renderer, which keeps the terminal usable on older GPUs.
-        addon?.dispose();
-        webglAddon = undefined;
+    webglAddon = undefined;
+    addon.dispose();
+    return true;
+  }
+
+  function activateWebglRenderer(): void {
+    let addon: WebglAddon | undefined;
+    try {
+      addon = new WebglAddon();
+      const pending = addon;
+      webglAddon = pending;
+      pending.onContextLoss(() => {
+        if (!retireWebglAddon(pending)) {
+          return;
+        }
+        console.warn(
+          "WebGL terminal renderer context lost; falling back to DOM.",
+        );
+      });
+      term.loadAddon(pending);
+    } catch (error) {
+      if (addon === undefined || retireWebglAddon(addon)) {
+        console.warn(
+          "WebGL terminal renderer initialization failed; falling back to DOM:",
+          error,
+        );
       }
-      return;
-    }
-    if (renderer === "dom" && webglAddon !== undefined) {
-      webglAddon.dispose();
-      webglAddon = undefined;
     }
   }
 
@@ -353,11 +338,9 @@ export function createPane(
       }
       observer.observe(termEl);
       opened = true;
-      // Last, and only now: xterm's DOM renderer cannot draw custom glyphs, so
-      // block and box-drawing characters used by TUIs such as OpenCode look
-      // segmented, and the WebGL renderer that draws them to the full cell box
-      // needs both an element from `open()` and the flag `syncRenderer` gates on.
-      syncRenderer();
+      // Last, and only now: WebGL activation needs the element created by
+      // `open()`. Failure leaves xterm's DOM renderer active for this pane.
+      activateWebglRenderer();
     }
     fit();
   }
@@ -399,11 +382,6 @@ export function createPane(
     term.options.fontSize = next.fontSize;
     term.options.theme = resolveTheme(next);
     term.options.scrollback = next.scrollback;
-    renderer = next.terminalRenderer;
-    // Held in a closure variable rather than read at mount time: settings can
-    // change between `createPane` and the pane being shown, and a pane that
-    // mounted later would otherwise come up on the renderer the user left.
-    syncRenderer();
     fit();
   }
 

--- a/src/ui/settings/sections/appearance-section.tsx
+++ b/src/ui/settings/sections/appearance-section.tsx
@@ -3,7 +3,6 @@ import {
   clampFontSize,
   FONT_SIZE_MAX,
   FONT_SIZE_MIN,
-  TERMINAL_RENDERERS,
   type TabBarPosition,
 } from "../../../settings/settings-schema";
 import { settings, updateSettings } from "../../../settings/settings-store";
@@ -28,12 +27,6 @@ export function AppearanceSection() {
     const index = TAB_BAR_CHOICES.indexOf(current.tabBarPosition);
     const next = TAB_BAR_CHOICES[(index + 1) % TAB_BAR_CHOICES.length];
     updateSettings({ tabBarPosition: next });
-  };
-
-  const cycleRenderer = (): void => {
-    const index = TERMINAL_RENDERERS.indexOf(current.terminalRenderer);
-    const next = TERMINAL_RENDERERS[(index + 1) % TERMINAL_RENDERERS.length];
-    updateSettings({ terminalRenderer: next });
   };
 
   return (
@@ -72,27 +65,6 @@ export function AppearanceSection() {
             <DeckIcon icon={Plus} size={ROW_ICON} />
           </button>
         </span>
-      </ConfigRow>
-      {/* Sits with the type rows because that is what it changes: the renderer
-          is the thing that puts glyphs on screen, so it belongs beside font
-          and size rather than under a Terminal category the user would reach
-          only after the text already looked wrong. */}
-      <ConfigRow
-        label="Terminal renderer"
-        desc="webgl joins block glyphs in TUIs; text antialiasing differs"
-      >
-        <button
-          type="button"
-          class="cfg-btn"
-          title="Next renderer"
-          aria-label={`Terminal renderer: ${current.terminalRenderer}. Switch to next renderer`}
-          onClick={cycleRenderer}
-        >
-          {current.terminalRenderer}
-          <span class="cfg-btn__hint">
-            <DeckIcon icon={Repeat} size={ROW_ICON} />
-          </span>
-        </button>
       </ConfigRow>
       <LogoRow />
       <ConfigRow label="Tab bar position" desc="Where the tab list sits">

--- a/src/ui/settings/settings-screen.test.tsx
+++ b/src/ui/settings/settings-screen.test.tsx
@@ -146,7 +146,6 @@ const EXPECTED_ROWS = [
   "Selection",
   "Font",
   "Font size",
-  "Terminal renderer",
   "App logo",
   "Tab bar position",
   "Show pane bar",
@@ -206,7 +205,7 @@ describe("SettingsScreen — every setting survived the move", () => {
     });
   });
 
-  it("reaches all 29 rows by walking the rail", () => {
+  it("reaches all 28 rows by walking the rail", () => {
     act(() => {
       render(<SettingsScreen open onClose={vi.fn()} />, host);
     });


### PR DESCRIPTION
## Tóm tắt

- Tự động kích hoạt `WebglAddon` một lần sau `Terminal.open()` cho mọi pane.
- Fallback về DOM khi khởi tạo lỗi hoặc mất context, với cảnh báo và disposal rõ ràng.
- Xóa lựa chọn renderer khỏi settings contract và giao diện Settings; cập nhật tài liệu hành vi.

## Lý do

OpenCode block/box glyphs cần custom-glyph path của xterm khi WebGL khả dụng, nhưng renderer không nên là lựa chọn persisted phụ thuộc người dùng.

## Thay đổi chính

- `src/terminal/pane.ts`: one-shot activation, identity-guarded fallback và explicit GPU disposal.
- `src/settings/settings-schema.ts`: bỏ persisted renderer; legacy keys bị bỏ qua.
- `src/ui/settings/`: bỏ selector renderer và cập nhật inventory tests từ 29 xuống 28 rows.
- `README.md`, `docs/ARCHITECTURE.md`, `docs/CONTEXT.md`: ghi lại behavior và evidence boundary.

## Cách test

- [x] Targeted Vitest: 3 files, 72/72 tests pass.
- [x] `npm run build` — exit 0.
- [x] `npm run electron:build` — exit 0.
- [x] Hai test từng timeout trong full suite đều pass khi chạy riêng: `search-bar.test.ts` 23/23, `file-tree-view.test.tsx` 16/16.
- [ ] `npm test` — chưa xanh hoàn toàn: 3.122 pass, 2 timeout ngoài diff, 3 skip.
- [ ] Native Electron/Tauri macOS visual acceptance — chưa chạy vì cần quyền chạy native host.
- [ ] Windows runtime — chưa verify.

## Screenshots

Không có. Thay đổi này chỉnh terminal lifecycle và xóa một row Settings; native visual acceptance chưa được cấp quyền nên chưa chụp screenshot.
