### PR TITLE
feat(terminal): performable keybindings — Ctrl+C copies or interrupts on Windows

### DIFF
--- a/src/terminal/action-performable.test.ts
+++ b/src/terminal/action-performable.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { isActionPerformable, type PerformableContext } from "./action-performable";
+
+const context = (overrides: Partial<PerformableContext> = {}): PerformableContext => ({
+  stageOwner: "terminal",
+  hasSelection: false,
+  ...overrides,
+});
+
+describe("isActionPerformable", () => {
+  it("answers true for an action with no predicate", () => {
+    expect(isActionPerformable("split-row", context())).toBe(true);
+    expect(isActionPerformable("split-row", context({ stageOwner: "surface" }))).toBe(true);
+  });
+
+  it("lets copy-selection consume inside a terminal with no selection", () => {
+    expect(isActionPerformable("copy-selection", context())).toBe(true);
+  });
+
+  it.each(["surface", "overlay"] as const)(
+    "refuses copy-selection while %s owns the stage",
+    (stageOwner) => {
+      expect(
+        isActionPerformable("copy-selection", context({ stageOwner, hasSelection: true })),
+      ).toBe(false);
+    },
+  );
+
+  it("refuses copy-or-interrupt with no selection so the PTY gets the key", () => {
+    expect(isActionPerformable("copy-or-interrupt", context())).toBe(false);
+  });
+
+  it("performs copy-or-interrupt with a selection in a terminal", () => {
+    expect(isActionPerformable("copy-or-interrupt", context({ hasSelection: true }))).toBe(true);
+  });
+
+  it("refuses copy-or-interrupt over a surface even with a selection", () => {
+    expect(
+      isActionPerformable(
+        "copy-or-interrupt",
+        context({ stageOwner: "surface", hasSelection: true }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/terminal/action-performable.ts
+++ b/src/terminal/action-performable.ts
@@ -1,0 +1,47 @@
+/**
+ * Whether a matched binding may CONSUME its keystroke.
+ *
+ * `handleShortcut` (tab-manager.ts) asks this before `preventDefault()`. A
+ * false answer means the binding behaves as if it did not exist and the key
+ * continues to whatever holds focus — Ghostty's `performable:` principle,
+ * carried on the action rather than on the binding because Deck stores user
+ * overrides per action and replaces an action's whole chord set
+ * (`resolveKeymap`, src/lib/keybindings.ts), so two chords of one action
+ * cannot differ in conditionality. See
+ * docs/specs/2026-08-20-performable-keybindings-design.md D1.
+ *
+ * Deliberately pure: it reads a context value, never a signal, so the rules
+ * are testable without mounting a tab manager.
+ */
+import type { ShortcutAction } from "./keymap";
+
+/** Which kind of thing currently owns the stage. */
+export type StageOwner = "terminal" | "surface" | "overlay";
+
+export interface PerformableContext {
+  readonly stageOwner: StageOwner;
+  /** Whether the ACTIVE TERMINAL PANE holds a selection. */
+  readonly hasSelection: boolean;
+}
+
+type Predicate = (context: PerformableContext) => boolean;
+
+/**
+ * Only the clipboard actions so far. Every other action answers true, so this
+ * table can take the remaining pane-scoped actions later as a data change
+ * rather than a rework (spec, Non-goals).
+ */
+const PREDICATES: ReadonlyMap<ShortcutAction, Predicate> = new Map<ShortcutAction, Predicate>([
+  // Stage-conditional only: inside a terminal it keeps consuming even with no
+  // selection, because nothing else wants Ctrl+Shift+C and leaking it into an
+  // agent TUI has unspecified behaviour (spec D2).
+  ["copy-selection", (context) => context.stageOwner === "terminal"],
+  // Stage AND selection conditional: with no selection the key must reach the
+  // PTY as the interrupt (spec D5).
+  ["copy-or-interrupt", (context) => context.stageOwner === "terminal" && context.hasSelection],
+]);
+
+export function isActionPerformable(action: ShortcutAction, context: PerformableContext): boolean {
+  const predicate = PREDICATES.get(action);
+  return predicate === undefined ? true : predicate(context);
+}

--- a/src/terminal/action-registry.test.ts
+++ b/src/terminal/action-registry.test.ts
@@ -88,10 +88,21 @@ describe("ACTION_REGISTRY", () => {
     expect(mac[0]).not.toHaveProperty("code");
   });
 
+  it("ships copy-or-interrupt unbound on macOS and on Ctrl+C on Windows", () => {
+    const mac = MACOS_KEYMAP.filter((binding) => binding.action === "copy-or-interrupt");
+    const win = WINDOWS_KEYMAP.filter((binding) => binding.action === "copy-or-interrupt");
+    // macOS has no conflict to solve: Cmd+C copies and Ctrl+C interrupts are
+    // already two different keys, so binding here would invent a problem.
+    expect(mac).toEqual([]);
+    expect(win).toEqual([{ key: "c", ctrl: true, action: "copy-or-interrupt" }]);
+  });
+
   // 51 = the 48 rows verified passing after Task 6's "save-file", plus the
   // Edit menu's "select-all"/"undo"/"redo" (2026-08-19) — routed through the
   // renderer because their native Cocoa roles cannot reach Monaco.
-  it("has exactly the 52 action ids including updater menu actions", () => {
+  // 53 = 52 + copy-or-interrupt (2026-08-20), the conditional Ctrl+C twin of
+  // copy-selection — docs/plans/2026-08-20-performable-keybindings.md.
+  it("has exactly the 53 action ids including updater menu actions", () => {
     const ids = new Set(ACTION_REGISTRY.map((a) => a.id));
     expect(ids).toEqual(
       new Set([
@@ -115,6 +126,7 @@ describe("ACTION_REGISTRY", () => {
         "clear-buffer",
         "copy-cwd",
         "copy-selection",
+        "copy-or-interrupt",
         "paste",
         "split-row",
         "split-column",

--- a/src/terminal/action-registry.ts
+++ b/src/terminal/action-registry.ts
@@ -301,6 +301,14 @@ export const ACTION_REGISTRY = [
     scope: "pane",
   },
   {
+    id: "copy-or-interrupt",
+    label: "Copy Selection or Interrupt",
+    scope: "pane",
+    // No `menu` field on purpose. A Cocoa menu accelerator is consumed before
+    // the webview and would force the action regardless of whether it can be
+    // performed — the reason Ghostty excludes performable binds from menus.
+  },
+  {
     id: "paste",
     label: "Paste",
     scope: "pane",

--- a/src/terminal/default-keymaps.ts
+++ b/src/terminal/default-keymaps.ts
@@ -290,9 +290,16 @@ const WINDOWS_SELECT_LAST_TAB_BINDING: KeyBinding = {
 
 /**
  * Windows Terminal-style chords keep conventional bare Ctrl sequences
- * available to the PTY, except Ctrl+V: Deck owns standard text paste through
- * Ctrl+V, Ctrl+Shift+V, and physical Shift+Insert. Alt+V remains unbound so
- * the active agent can handle it if that CLI supports the chord.
+ * available to the PTY, with two exceptions. Ctrl+V: Deck owns standard text
+ * paste through Ctrl+V, Ctrl+Shift+V, and physical Shift+Insert; Alt+V remains
+ * unbound so the active agent can handle it if that CLI supports the chord.
+ * Ctrl+C: bound to `copy-or-interrupt`, which is PERFORMABLE — it consumes the
+ * key only while a terminal pane owns the stage AND holds a selection, so with
+ * nothing selected the key is never preventDefault()ed and xterm encodes the
+ * interrupt itself. Deck writes no interrupt byte of its own; hardcoding
+ * `\x03` would pin one encoding a different keyboard protocol does not use.
+ * See action-performable.ts and
+ * docs/specs/2026-08-20-performable-keybindings-design.md.
  *
  * Clipboard actions dispatch through the shared path every other chord uses —
  * this keymap, then the `commands` table in tab-manager.ts, then
@@ -304,6 +311,7 @@ const WINDOWS_SELECT_LAST_TAB_BINDING: KeyBinding = {
  */
 export const WINDOWS_KEYMAP: readonly KeyBinding[] = [
   { key: "c", ctrl: true, shift: true, action: "copy-selection" },
+  { key: "c", ctrl: true, action: "copy-or-interrupt" },
   { key: "v", ctrl: true, action: "paste" },
   { key: "v", ctrl: true, shift: true, action: "paste" },
   { code: "Insert", shift: true, action: "paste" },

--- a/src/terminal/keymap.test.ts
+++ b/src/terminal/keymap.test.ts
@@ -283,15 +283,11 @@ describe("matchBinding", () => {
   // The dock's other two chords, added 2026-08-19 so every control in its
   // header can print one (DL-23.1). Same shape as the ⌘⇧U pair above.
   it("matches Cmd+Shift+Y as toggle-sessions", () => {
-    expect(matchBinding(keyEvent("y", { metaKey: true, shiftKey: true }))).toBe(
-      "toggle-sessions",
-    );
+    expect(matchBinding(keyEvent("y", { metaKey: true, shiftKey: true }))).toBe("toggle-sessions");
   });
 
   it("matches Cmd+Shift+J as toggle-dock", () => {
-    expect(matchBinding(keyEvent("j", { metaKey: true, shiftKey: true }))).toBe(
-      "toggle-dock",
-    );
+    expect(matchBinding(keyEvent("j", { metaKey: true, shiftKey: true }))).toBe("toggle-dock");
   });
 
   it("does not match Y or J without both modifiers", () => {
@@ -323,6 +319,7 @@ describe("matchBinding", () => {
   // to the keymap layer, so it has to be asserted here instead.
   it("leaves Windows clipboard chords unbound on macOS", () => {
     expect(matchBinding(keyEvent("c", { ctrlKey: true, shiftKey: true }))).toBeNull();
+    expect(matchBinding(keyEvent("c", { ctrlKey: true }))).toBeNull();
     expect(matchBinding(keyEvent("v", { ctrlKey: true, shiftKey: true }))).toBeNull();
     expect(matchBinding(keyEvent("v", { ctrlKey: true }))).toBeNull();
     expect(matchBinding(codeEvent("Insert", "Unidentified", { shiftKey: true }))).toBeNull();
@@ -332,6 +329,7 @@ describe("matchBinding", () => {
 describe("WINDOWS_KEYMAP", () => {
   it.each([
     ["c", { ctrlKey: true, shiftKey: true }, "copy-selection"],
+    ["c", { ctrlKey: true }, "copy-or-interrupt"],
     ["v", { ctrlKey: true }, "paste"],
     ["v", { ctrlKey: true, shiftKey: true }, "paste"],
     ["c", { ctrlKey: true, altKey: true, shiftKey: true }, "copy-cwd"],
@@ -427,7 +425,14 @@ describe("WINDOWS_KEYMAP", () => {
     ).toBe(action);
   });
 
-  it.each(["c", "d", "w", "k", "f", "o"])("leaves protected bare Ctrl+%s unbound", (key) => {
+  // "c" left this list on 2026-08-20. It is bound to `copy-or-interrupt` now,
+  // which is PERFORMABLE: the binding consumes the key only while a terminal
+  // pane owns the stage AND holds a selection, so with nothing selected
+  // `handleShortcut` never calls preventDefault() and xterm still encodes the
+  // interrupt. The protection this row asserted therefore moved from the
+  // keymap to `action-performable.ts` — matched here, not consumed there.
+  // See docs/specs/2026-08-20-performable-keybindings-design.md.
+  it.each(["d", "w", "k", "f", "o"])("leaves protected bare Ctrl+%s unbound", (key) => {
     expect(matchBinding(keyEvent(key, { ctrlKey: true }), WINDOWS_KEYMAP)).toBeNull();
   });
 });

--- a/src/terminal/pane-lifecycle.test.ts
+++ b/src/terminal/pane-lifecycle.test.ts
@@ -28,6 +28,10 @@ function fakePane(id: number, events: PaneEvents): Pane & { focusCalls: number }
     fit() {},
     clear() {},
     copySelection() {},
+    hasSelection() {
+      return false;
+    },
+    clearSelection() {},
     paste() {},
     pasteText(text) {
       return events.onData(id, text);

--- a/src/terminal/pane.ts
+++ b/src/terminal/pane.ts
@@ -74,6 +74,14 @@ export interface Pane {
   clear(): void;
   /** Copy the current selection to the system clipboard (Ctrl+Shift+C). */
   copySelection(): void;
+  /** Whether the terminal currently holds a selection. */
+  hasSelection(): boolean;
+  /**
+   * Drop the selection. Separate from `copySelection` because only
+   * `copy-or-interrupt` clears — a plain copy keeps the highlight
+   * (docs/specs/2026-08-20-performable-keybindings-design.md D3).
+   */
+  clearSelection(): void;
   /** Paste the clipboard through xterm's bracketed-paste path (Ctrl+Shift+V). */
   paste(): void;
   /**
@@ -272,9 +280,7 @@ export function createPane(
     // its own lower half sits OUTSIDE that zone: aiming for the grip used to
     // remove the class and hide the pill from under the pointer. Standing on
     // the anchor holds it open — this is the hysteresis the zone alone lacks.
-    const inZone =
-      event.clientY - top < ANCHOR_ZONE_PX ||
-      anchor.contains(event.target as Node);
+    const inZone = event.clientY - top < ANCHOR_ZONE_PX || anchor.contains(event.target as Node);
     element.classList.toggle("is-anchor-zone", inZone);
   });
   element.addEventListener("mouseleave", () => {
@@ -317,17 +323,12 @@ export function createPane(
         if (!retireWebglAddon(pending)) {
           return;
         }
-        console.warn(
-          "WebGL terminal renderer context lost; falling back to DOM.",
-        );
+        console.warn("WebGL terminal renderer context lost; falling back to DOM.");
       });
       term.loadAddon(pending);
     } catch (error) {
       if (addon === undefined || retireWebglAddon(addon)) {
-        console.warn(
-          "WebGL terminal renderer initialization failed; falling back to DOM:",
-          error,
-        );
+        console.warn("WebGL terminal renderer initialization failed; falling back to DOM:", error);
       }
     }
   }
@@ -392,9 +393,7 @@ export function createPane(
     dot.style.background = info.dotColor;
     cwdEl.textContent = info.cwd;
     badge.textContent = info.badge;
-    badge.className = `pane__badge ${
-      info.agent ? "pane__badge--agent" : "pane__badge--shell"
-    }`;
+    badge.className = `pane__badge ${info.agent ? "pane__badge--agent" : "pane__badge--shell"}`;
   }
 
   function captureSelection(): SelectionSnapshot | null {
@@ -468,6 +467,8 @@ export function createPane(
     copySelection() {
       copyTerminalSelection(term);
     },
+    hasSelection: () => term.hasSelection(),
+    clearSelection: () => term.clearSelection(),
     paste() {
       pasteIntoTerminal(term);
     },
@@ -486,8 +487,7 @@ export function createPane(
       return capturedWrite ?? Promise.resolve(false);
     },
     scrollPage: (dir) => term.scrollPages(dir),
-    scrollToEdge: (edge) =>
-      edge === "top" ? term.scrollToTop() : term.scrollToBottom(),
+    scrollToEdge: (edge) => (edge === "top" ? term.scrollToTop() : term.scrollToBottom()),
     focus: () => term.focus(),
     applySettings,
     setHeaderInfo,

--- a/src/terminal/tab-action-scope.ts
+++ b/src/terminal/tab-action-scope.ts
@@ -41,6 +41,7 @@ export const COMMAND_ACTIONS = [
   "close-pane",
   "close-tab",
   "copy-cwd",
+  "copy-or-interrupt",
   "copy-selection",
   "find",
   "find-next",

--- a/src/terminal/tab-manager.file-surfaces.test.ts
+++ b/src/terminal/tab-manager.file-surfaces.test.ts
@@ -760,3 +760,135 @@ describe("file surfaces in the tab strip — the real FileSurfaceController (Tas
     tm.dispose();
   });
 });
+
+/**
+ * Performable keybindings — `handleShortcut` asks `isActionPerformable`
+ * BEFORE `preventDefault()`, so a binding that cannot do anything behaves as
+ * if it did not exist and the key continues to whatever holds focus.
+ * See docs/specs/2026-08-20-performable-keybindings-design.md.
+ *
+ * Driving `window` through the pane's own textarea is the real path: the
+ * listener is capture-phase on `window`, so a chord that IS consumed never
+ * reaches the downstream listener, and one that is not consumed does — which
+ * is precisely what "xterm encodes the interrupt itself" means here.
+ */
+describe("performable chords (Ctrl+C copies or falls through)", () => {
+  /** The Windows keymap is where the conditional Ctrl+C lives; macOS is untouched. */
+  function useWindows(): void {
+    resetDesktopEnvironmentForTests();
+    initializeDesktopEnvironment({
+      platform: "windows",
+      homeDir: String.raw`C:\Users\dev`,
+    });
+  }
+
+  function terminalInput(): HTMLTextAreaElement {
+    const input = document.querySelector<HTMLTextAreaElement>(
+      '[data-testid="fake-terminal-input"]',
+    );
+    if (input === null) {
+      throw new Error("Expected the fake terminal input to be mounted");
+    }
+    return input;
+  }
+
+  function press(target: HTMLElement, init: KeyboardEventInit): KeyboardEvent {
+    const event = new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init });
+    target.dispatchEvent(event);
+    return event;
+  }
+
+  it("does not consume Ctrl+C when the terminal has no selection", async () => {
+    useWindows();
+    const copySelection = vi.fn();
+    const { tm } = setup({ paneOverrides: { copySelection }, infos: IDLE_SHELLS });
+    await tm.materialize({ layout: null, cwds: [String.raw`C:\work`] });
+    // handleShortcut is only attached as a window listener once init() runs.
+    await tm.init();
+    const input = terminalInput();
+    const downstream = vi.fn();
+    input.addEventListener("keydown", downstream);
+
+    const event = press(input, { key: "c", ctrlKey: true });
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(copySelection).not.toHaveBeenCalled();
+    // The key reached the pane, which is where xterm would encode the
+    // interrupt. Deck writes no `\x03` of its own.
+    expect(downstream).toHaveBeenCalledTimes(1);
+    expect(downstream).toHaveBeenLastCalledWith(event);
+    tm.dispose();
+  });
+
+  it("consumes Ctrl+C and clears the selection when there is one", async () => {
+    useWindows();
+    const copySelection = vi.fn();
+    const { tm } = setup({
+      paneOverrides: { copySelection, selection: true },
+      infos: IDLE_SHELLS,
+    });
+    await tm.materialize({ layout: null, cwds: [String.raw`C:\work`] });
+    await tm.init();
+    const input = terminalInput();
+    const downstream = vi.fn();
+    input.addEventListener("keydown", downstream);
+
+    const first = press(input, { key: "c", ctrlKey: true });
+
+    expect(first.defaultPrevented).toBe(true);
+    expect(copySelection).toHaveBeenCalledTimes(1);
+    expect(downstream).not.toHaveBeenCalled();
+
+    // The clear is what makes the SECOND press an interrupt instead of a
+    // second copy — spec D3, the two-press cancel.
+    const second = press(input, { key: "c", ctrlKey: true });
+
+    expect(second.defaultPrevented).toBe(false);
+    expect(copySelection).toHaveBeenCalledTimes(1);
+    expect(downstream).toHaveBeenCalledTimes(1);
+    tm.dispose();
+  });
+
+  it("does not consume Ctrl+Shift+C while a file surface owns the stage", async () => {
+    useWindows();
+    const copySelection = vi.fn();
+    const surfaces = fakeSurfaces({ count: 1, total: 1, activeIndex: 0 });
+    const { tm } = setup({
+      deps: { surfaces },
+      paneOverrides: { copySelection, selection: true },
+      infos: IDLE_SHELLS,
+    });
+    await tm.materialize({ layout: null, cwds: [String.raw`C:\work`] });
+    await tm.init();
+    // After materialize, exactly as every other surface test here does it —
+    // materializing a terminal tab deactivates the strip.
+    surfaces.activeIndexValue = 0;
+    const input = terminalInput();
+
+    // Upper-case `key` on purpose: Shift is held, and matchBinding lowercases.
+    const event = press(input, { key: "C", ctrlKey: true, shiftKey: true });
+
+    // Falling through is the point: Chromium's own copy must reach Monaco,
+    // which the old order swallowed and then blocked (spec, the latent defect).
+    expect(event.defaultPrevented).toBe(false);
+    expect(copySelection).not.toHaveBeenCalled();
+    tm.dispose();
+  });
+
+  it("still consumes Ctrl+Shift+C inside a terminal with nothing selected", async () => {
+    useWindows();
+    const copySelection = vi.fn();
+    const { tm } = setup({ paneOverrides: { copySelection }, infos: IDLE_SHELLS });
+    await tm.materialize({ layout: null, cwds: [String.raw`C:\work`] });
+    await tm.init();
+    const input = terminalInput();
+
+    const event = press(input, { key: "C", ctrlKey: true, shiftKey: true });
+
+    // Stage-conditional but NOT selection-conditional (spec D2): nothing else
+    // wants this chord, and leaking it into an agent TUI is unspecified.
+    expect(event.defaultPrevented).toBe(true);
+    expect(copySelection).toHaveBeenCalledTimes(1);
+    tm.dispose();
+  });
+});

--- a/src/terminal/tab-manager.fixtures.ts
+++ b/src/terminal/tab-manager.fixtures.ts
@@ -42,6 +42,14 @@ export function fakePane(
     copySelection?: Pane["copySelection"];
     paste?: Pane["paste"];
     pasteText?: Pane["pasteText"];
+    /**
+     * Whether the pane starts holding a terminal selection — Ctrl+C's
+     * precondition. A boolean rather than a spy pair because the two methods
+     * share state: `copy-or-interrupt` clears after copying, and a test has
+     * to observe the highlight actually go
+     * (docs/specs/2026-08-20-performable-keybindings-design.md D3).
+     */
+    selection?: boolean;
   } = {},
 ): Pane {
   const element = document.createElement("div");
@@ -56,6 +64,7 @@ export function fakePane(
   // so the fake must actually move `document.activeElement`, not just fire
   // the synthetic event below (which mirrors production's `focusin` listener).
   element.tabIndex = -1;
+  let selected = overrides.selection ?? false;
   return {
     id,
     element,
@@ -74,6 +83,10 @@ export function fakePane(
     fit() {},
     clear() {},
     copySelection: overrides.copySelection ?? (() => {}),
+    hasSelection: () => selected,
+    clearSelection: () => {
+      selected = false;
+    },
     paste: overrides.paste ?? (() => {}),
     pasteText: overrides.pasteText ?? ((text: string) => events.onData(id, text)),
     scrollPage() {},

--- a/src/terminal/tab-manager.ts
+++ b/src/terminal/tab-manager.ts
@@ -8,11 +8,7 @@ import {
   toggleDock,
   updateSettings,
 } from "../settings/settings-store";
-import {
-  type Direction,
-  type Edge,
-  type SerializedNode,
-} from "../lib/split-tree";
+import { type Direction, type Edge, type SerializedNode } from "../lib/split-tree";
 import { explicitAgent, processLabel } from "../lib/process-info";
 import type { SessionTab } from "../lib/session-schema";
 import type { DetachTarget } from "./pane-detach";
@@ -31,17 +27,16 @@ import {
   probeNames,
   resolveAgentCommand,
 } from "../lib/agent-catalog";
-import {
-  agentLaunchCommand,
-  resolveLaunchCommand,
-} from "../lib/launch-command";
+import { agentLaunchCommand, resolveLaunchCommand } from "../lib/launch-command";
 import { matchBinding, selectTabIndex, type ShortcutAction } from "./keymap";
 import { TIER_RANK } from "./action-registry";
-import { installFileDrop } from "./file-drop";
 import {
-  createTerminalManager,
-  type TerminalManager,
-} from "./terminal-manager";
+  isActionPerformable,
+  type PerformableContext,
+  type StageOwner,
+} from "./action-performable";
+import { installFileDrop } from "./file-drop";
+import { createTerminalManager, type TerminalManager } from "./terminal-manager";
 import { createPaneInfoPoller } from "./pane-info-poller";
 import { createAgentActivity } from "./agent-activity";
 import {
@@ -51,11 +46,7 @@ import {
 } from "./agent-attention";
 import { createAgentNotifier, type AgentNotifier } from "./agent-notifier";
 import type { PaneAttentionSignal } from "./pane";
-import {
-  popClosedTab,
-  pushClosedTab,
-  type ClosedTabSnapshot,
-} from "./closed-tabs";
+import { popClosedTab, pushClosedTab, type ClosedTabSnapshot } from "./closed-tabs";
 import { confirmClose } from "./close-guard";
 import { createCloseCoordinator } from "./close-coordinator";
 import { activeAfterClose } from "./tab-close";
@@ -105,11 +96,7 @@ import {
   type TabManagerDeps,
   type TabManager,
 } from "./tab-manager-types";
-import {
-  ACTION_SCOPE,
-  DESTRUCTIVE_ACTIONS,
-  COMMAND_ACTIONS,
-} from "./tab-action-scope";
+import { ACTION_SCOPE, DESTRUCTIVE_ACTIONS, COMMAND_ACTIONS } from "./tab-action-scope";
 
 // The module-scope header that used to live here (types + pure constants
 // above `createTabManager`) moved out 2026-08-16 for file size:
@@ -123,11 +110,7 @@ import {
 // from tab-action-scope.ts directly. `createTabManager` itself — the load-
 // bearing R4 seam — did not move.
 export type { SurfaceStrip, SurfaceEditCommand } from "./surface-strip";
-export type {
-  OpenFromPresetOptions,
-  TabManagerDeps,
-  TabManager,
-} from "./tab-manager-types";
+export type { OpenFromPresetOptions, TabManagerDeps, TabManager } from "./tab-manager-types";
 
 const WINDOWS_AGENT_TIMEOUT_MESSAGE =
   "PowerShell was not ready in time. Launch the agent manually.";
@@ -208,8 +191,7 @@ export function createTabManager(
   // Types the chosen agent into each new pane's shell once its prompt is up.
   // Through paneIo so its synthetic keystrokes ("claude\r") count as input —
   // the echo suppression then keeps the launch echo out of the spinner.
-  const reportAgentLaunchTimeout =
-    deps.onAgentLaunchTimeout ?? reportChromeMessage;
+  const reportAgentLaunchTimeout = deps.onAgentLaunchTimeout ?? reportChromeMessage;
   const launcher = createAgentLauncher(paneIo, {
     platform: environment.platform,
     onTimeout: () => {
@@ -242,9 +224,7 @@ export function createTabManager(
 
   /** Workspace of the active tab; null when it has none (or no tab). */
   function activeWorkspacePath(): string | null {
-    return active >= 0 && active < tabs.length
-      ? tabs[active].workspacePath
-      : null;
+    return active >= 0 && active < tabs.length ? tabs[active].workspacePath : null;
   }
 
   function syncViews(): void {
@@ -275,8 +255,7 @@ export function createTabManager(
         ),
       ];
       const agentBusy = paneIds.some(
-        (id) =>
-          explicitAgent(poller.infoFor(id)) !== null && activity.working(id),
+        (id) => explicitAgent(poller.infoFor(id)) !== null && activity.working(id),
       );
       // The per-pane projection the agent rail's chips and expanded rows both
       // need (agent-status-rail spec §5, tier 2). It reports every pane, agent
@@ -286,10 +265,7 @@ export function createTabManager(
       const panes: readonly PaneView[] = paneIds.map((id) => {
         const snap = tracker.snapshot(id);
         const agent = explicitAgent(poller.infoFor(id));
-        tab.manager.setPaneWorking(
-          id,
-          agent !== null && snap?.phase === "working",
-        );
+        tab.manager.setPaneWorking(id, agent !== null && snap?.phase === "working");
         return {
           paneId: id,
           agent,
@@ -328,8 +304,7 @@ export function createTabManager(
       agent: explicitAgent(info),
       // Null, not zero: a non-terminal surface owns no panes, and spec §7 asks
       // for the count to be ABSENT rather than reading "0 panes".
-      paneCount:
-        surfaces.activeIndex() >= 0 ? null : (manager?.paneCount() ?? 0),
+      paneCount: surfaces.activeIndex() >= 0 ? null : (manager?.paneCount() ?? 0),
       home,
     };
   }
@@ -383,9 +358,7 @@ export function createTabManager(
     const owner = tabs.find((t) => t.manager.paneIds().includes(id));
     const label =
       (owner ? overrides.get(owner.key)?.name : undefined) ??
-      (owner?.workspacePath == null
-        ? "Unknown"
-        : workspaceLabel(owner.workspacePath));
+      (owner?.workspacePath == null ? "Unknown" : workspaceLabel(owner.workspacePath));
     notifier.maybeNotify({
       paneId: id,
       revision: snap.revision,
@@ -472,12 +445,7 @@ export function createTabManager(
     container.className = "tab-stage";
     container.style.display = "none";
     host.appendChild(container);
-    const manager = createTerminalManager(
-      container,
-      callbacks,
-      paneIo,
-      managerDeps(nextKey),
-    );
+    const manager = createTerminalManager(container, callbacks, paneIo, managerDeps(nextKey));
     try {
       if (layout === null) {
         await manager.initFresh(cwds[0] ?? null);
@@ -496,8 +464,7 @@ export function createTabManager(
       openedAt: nextOpenSequence(),
       // The only place a tab's workspace is ever set — normalize here so every
       // entry point (Open, reopen, live preset) agrees on one spelling.
-      workspacePath:
-        workspacePath === null ? null : normalizeWorkspacePath(workspacePath),
+      workspacePath: workspacePath === null ? null : normalizeWorkspacePath(workspacePath),
     });
     nextKey += 1;
     return true;
@@ -576,9 +543,7 @@ export function createTabManager(
     tabIndex?: number,
   ): { owningIndex: number; paneId: number } | null {
     for (const cand of tracker.actionable()) {
-      const owningIndex = tabs.findIndex((t) =>
-        t.manager.paneIds().includes(cand.id),
-      );
+      const owningIndex = tabs.findIndex((t) => t.manager.paneIds().includes(cand.id));
       if (owningIndex === -1) continue; // pane gone
       if (tabIndex !== undefined && owningIndex !== tabIndex) continue; // scoped to one tab
       return { owningIndex, paneId: cand.id };
@@ -656,11 +621,7 @@ export function createTabManager(
     // change. Window-level, not tab-level: a second tab keeps the window
     // alive, so splitting this tab out is a real move. Offering the pane to an
     // EXISTING window stays allowed — that one merges and is meaningful.
-    if (
-      target.kind === "new-window" &&
-      tabs.length === 1 &&
-      entry.manager.paneIds().length === 1
-    ) {
+    if (target.kind === "new-window" && tabs.length === 1 && entry.manager.paneIds().length === 1) {
       reportChromeMessage("Nothing to move — this is the window's only pane.");
       return;
     }
@@ -726,12 +687,7 @@ export function createTabManager(
     container.className = "tab-stage";
     container.style.display = "none";
     host.appendChild(container);
-    const manager = createTerminalManager(
-      container,
-      callbacks,
-      paneIo,
-      managerDeps(nextKey),
-    );
+    const manager = createTerminalManager(container, callbacks, paneIo, managerDeps(nextKey));
     // Pushed BEFORE the adoption runs, not after. Rust flushes everything it
     // buffered during the transfer as part of `commit_transfer`, which happens
     // INSIDE `initFromAdoption`. Output is routed by scanning `tabs` for the
@@ -768,12 +724,8 @@ export function createTabManager(
     }
     if (result.payload.tabName !== null || result.payload.dotColor !== null) {
       overrides.set(nextKey, {
-        ...(result.payload.tabName !== null
-          ? { name: result.payload.tabName }
-          : {}),
-        ...(result.payload.dotColor !== null
-          ? { dotColor: result.payload.dotColor }
-          : {}),
+        ...(result.payload.tabName !== null ? { name: result.payload.tabName } : {}),
+        ...(result.payload.dotColor !== null ? { dotColor: result.payload.dotColor } : {}),
       });
     }
     nextKey += 1;
@@ -807,9 +759,7 @@ export function createTabManager(
     // tab spawns another rather than focusing the first, so the same repo can
     // run several agent sessions side by side. `workspacePath` is a label the
     // tab carries (sidebar, logo, reopen), never an identity that dedupes.
-    if (
-      !(await addTab(intent.layout, intent.cwds, intent.workspacePath ?? null))
-    ) {
+    if (!(await addTab(intent.layout, intent.cwds, intent.workspacePath ?? null))) {
       return false;
     }
     const entry = tabs[tabs.length - 1];
@@ -850,8 +800,7 @@ export function createTabManager(
     const fallback =
       agentId === null
         ? null
-        : (launchCommand ??
-          resolveAgentCommand(agentId, settings.value.customAgents));
+        : (launchCommand ?? resolveAgentCommand(agentId, settings.value.customAgents));
     const paneIds = entry.manager.paneIds();
     if (launchCommand !== null) {
       for (const id of paneIds) {
@@ -876,9 +825,7 @@ export function createTabManager(
     return materialize({
       layout,
       cwds,
-      ...(options.workspacePath !== undefined
-        ? { workspacePath: options.workspacePath }
-        : {}),
+      ...(options.workspacePath !== undefined ? { workspacePath: options.workspacePath } : {}),
       ...(options.agent !== undefined ? { agent: options.agent } : {}),
     });
   }
@@ -917,11 +864,7 @@ export function createTabManager(
       ...(profileId === undefined
         ? {}
         : {
-            launchCommand: resolveLaunchCommand(
-              agentId,
-              profileId,
-              settings.value.launchProfiles,
-            ),
+            launchCommand: resolveLaunchCommand(agentId, profileId, settings.value.launchProfiles),
           }),
       ...(workspacePath !== null ? { workspacePath } : {}),
     });
@@ -946,21 +889,16 @@ export function createTabManager(
    * spawn a Shell. A failed probe degrades to Shell rather than sinking the
    * drop.
    */
-  async function dropAgentPane(
-    targetPaneId: number,
-    edge: Edge,
-  ): Promise<boolean> {
+  async function dropAgentPane(targetPaneId: number, edge: Edge): Promise<boolean> {
     const manager = activeManager();
     if (manager === null) {
       return false;
     }
     const customAgents = settings.value.customAgents;
-    const detected = await pty
-      .detectAgents(probeNames(customAgents))
-      .catch((err: unknown) => {
-        console.warn("detect_agents failed:", err);
-        return [];
-      });
+    const detected = await pty.detectAgents(probeNames(customAgents)).catch((err: unknown) => {
+      console.warn("detect_agents failed:", err);
+      return [];
+    });
     const agentId = agentForWorkspace(
       workspacesData.value.recents,
       activeWorkspacePath(),
@@ -986,9 +924,7 @@ export function createTabManager(
       {
         id: paneId,
         command:
-          agentId === null
-            ? null
-            : (launchCommand ?? resolveAgentCommand(agentId, customAgents)),
+          agentId === null ? null : (launchCommand ?? resolveAgentCommand(agentId, customAgents)),
       },
     ]);
     // The docked pane has no process info until the next tick otherwise, so
@@ -1153,9 +1089,7 @@ export function createTabManager(
         return;
       }
       if (!(await workspaceIsLive(snapshot.workspacePath))) {
-        console.warn(
-          `Not reopening tab: workspace ${snapshot.workspacePath} no longer exists`,
-        );
+        console.warn(`Not reopening tab: workspace ${snapshot.workspacePath} no longer exists`);
         stack = rest; // drop the dead snapshot, try the one below it
         continue;
       }
@@ -1164,9 +1098,7 @@ export function createTabManager(
           layout: snapshot.layout,
           cwds: snapshot.cwds,
           chrome: materializeChromeFrom(snapshot.name, snapshot.dotColor),
-          ...(snapshot.workspacePath !== null
-            ? { workspacePath: snapshot.workspacePath }
-            : {}),
+          ...(snapshot.workspacePath !== null ? { workspacePath: snapshot.workspacePath } : {}),
         }))
       ) {
         closedTabs = stack; // spawn failed — keep the snapshot for another try
@@ -1287,11 +1219,7 @@ export function createTabManager(
       // opens: only a classified, named agent can do that.
       for (const info of infos) {
         const agent = explicitAgent(info);
-        const snap = tracker.noteProcess(
-          info.id,
-          agent ?? info.process,
-          agent !== null,
-        );
+        const snap = tracker.noteProcess(info.id, agent ?? info.process, agent !== null);
         if (snap !== null) {
           maybeNotify(info.id, snap);
         }
@@ -1411,25 +1339,31 @@ export function createTabManager(
     // to close, and closing the terminal tab behind it would be a silent
     // catastrophe.
     "close-pane": () =>
-      surfaces.activeIndex() >= 0
-        ? void surfaces.close()
-        : void close.closePane(),
+      surfaces.activeIndex() >= 0 ? void surfaces.close() : void close.closePane(),
     "focus-next": () => activeManager()?.cycleFocus(1),
     "focus-prev": () => activeManager()?.cycleFocus(-1),
-    "toggle-expand": () =>
-      updateSettings({ focusExpand: !settings.value.focusExpand }),
+    "toggle-expand": () => updateSettings({ focusExpand: !settings.value.focusExpand }),
     "new-tab": () => void newTab(),
     "close-tab": () => void close.closeTab(active),
     "next-tab": () => cycleTab(1),
     "prev-tab": () => cycleTab(-1),
-    "zoom-in": () =>
-      updateSettings({ fontSize: clampFontSize(settings.value.fontSize + 1) }),
-    "zoom-out": () =>
-      updateSettings({ fontSize: clampFontSize(settings.value.fontSize - 1) }),
+    "zoom-in": () => updateSettings({ fontSize: clampFontSize(settings.value.fontSize + 1) }),
+    "zoom-out": () => updateSettings({ fontSize: clampFontSize(settings.value.fontSize - 1) }),
     "zoom-reset": () => updateSettings({ fontSize: DEFAULT_SETTINGS.fontSize }),
     "toggle-zoom-pane": () => activeManager()?.toggleZoom(),
     "clear-buffer": () => activeManager()?.clearActive(),
     "copy-selection": () => activeManager()?.copyActiveSelection(),
+    // Only ever reached when the predicate said a selection exists, so this
+    // never has to decide between copying and interrupting — the interrupt
+    // branch is the KEY not being consumed, so xterm encodes it (spec).
+    // The clear is synchronous after the text is read: `copyTerminalSelection`
+    // writes the clipboard asynchronously, and clearing in its callback could
+    // erase a selection the user made in the meantime (spec D4).
+    "copy-or-interrupt": () => {
+      const manager = activeManager();
+      manager?.copyActiveSelection();
+      manager?.clearActiveSelection();
+    },
     paste: () => activeManager()?.pasteIntoActive(),
     "copy-cwd": () => {
       const paneId = activeManager()?.activePaneId() ?? null;
@@ -1620,14 +1554,38 @@ export function createTabManager(
     if (boardOpen.value) {
       ranks.push(TIER_RANK.board);
     }
-    if (
-      editorRequest.value !== null ||
-      saveDialogOpen.value ||
-      agentQuickPickerOpen.value
-    ) {
+    if (editorRequest.value !== null || saveDialogOpen.value || agentQuickPickerOpen.value) {
       ranks.push(TIER_RANK.modal);
     }
     return ranks;
+  }
+
+  /**
+   * Which kind of thing owns the stage, for `isActionPerformable`.
+   *
+   * `browserSurfaceActive` is read beside `surfaces.activeIndex()` rather than
+   * trusted to be folded into it: the browser tab is a `SurfaceStrip` member,
+   * but `openOverlayRanks` above does not mention it, and answering "terminal"
+   * while a web view covers the stage would consume a key the page wanted.
+   * Reading both fails toward not consuming, which is the safe direction.
+   */
+  function stageOwner(): StageOwner {
+    if (openOverlayRanks().length > 0) {
+      return "overlay";
+    }
+    if (surfaces.activeIndex() >= 0 || browserSurfaceActive.value) {
+      return "surface";
+    }
+    return "terminal";
+  }
+
+  function performableContext(): PerformableContext {
+    return {
+      stageOwner: stageOwner(),
+      // `?? false` is the fail-toward-the-PTY rule (spec D5): no manager means
+      // no selection means the key is not consumed.
+      hasSelection: activeManager()?.activeHasSelection() ?? false,
+    };
   }
 
   /**
@@ -1653,11 +1611,7 @@ export function createTabManager(
    */
   function overlayBlocksAction(action: ShortcutAction): boolean {
     const scope = ACTION_SCOPE.get(action);
-    if (
-      scope === undefined ||
-      scope === "always" ||
-      isTabSwitchAction(action)
-    ) {
+    if (scope === undefined || scope === "always" || isTabSwitchAction(action)) {
       return false;
     }
     // A file surface owns the stage the same way an overlay does, but it is
@@ -1760,8 +1714,7 @@ export function createTabManager(
    */
   function isChromeTextField(node: unknown): boolean {
     return (
-      (node instanceof HTMLInputElement ||
-        node instanceof HTMLTextAreaElement) &&
+      (node instanceof HTMLInputElement || node instanceof HTMLTextAreaElement) &&
       !node.closest(".pane__term")
     );
   }
@@ -1841,10 +1794,7 @@ export function createTabManager(
     // was never protecting anything and used to silently swallow a genuine
     // menu click (F-B2) or find-next/find-previous typed straight into the
     // search bar's own input (F-B1).
-    if (
-      DESTRUCTIVE_ACTIONS.has(action) &&
-      isChromeTextField(document.activeElement)
-    ) {
+    if (DESTRUCTIVE_ACTIONS.has(action) && isChromeTextField(document.activeElement)) {
       return;
     }
     dispatchAction(action);
@@ -1870,6 +1820,14 @@ export function createTabManager(
     }
     const action = matchBinding(event);
     if (action === null) {
+      return;
+    }
+    // BEFORE preventDefault, never after. `dispatchAction`'s own
+    // `overlayBlocksAction` runs too late to stop the key being swallowed, and
+    // that ordering is what made a matched-but-blocked chord a dead key over an
+    // open document. Returning here leaves the event alone so it reaches
+    // whatever holds focus — Monaco, a modal, or the pane's own xterm.
+    if (!isActionPerformable(action, performableContext())) {
       return;
     }
     event.preventDefault();
@@ -1900,18 +1858,13 @@ export function createTabManager(
     try {
       windowFocused = await getCurrentWindow().isFocused();
     } catch (err) {
-      console.warn(
-        "attention: window isFocused() failed; assuming focused",
-        err,
-      );
+      console.warn("attention: window isFocused() failed; assuming focused", err);
       windowFocused = true;
     }
     try {
-      const unlistenFocus = await getCurrentWindow().onFocusChanged(
-        ({ payload }) => {
-          windowFocused = payload;
-        },
-      );
+      const unlistenFocus = await getCurrentWindow().onFocusChanged(({ payload }) => {
+        windowFocused = payload;
+      });
       unlisteners.push(unlistenFocus);
     } catch (err) {
       console.warn(
@@ -1990,9 +1943,7 @@ export function createTabManager(
         // flips, or a tracker change) — every other chunk is a no-op, so this
         // stays off the hot per-chunk path.
         const unreadChanged =
-          owner !== undefined &&
-          owner !== tabs[active] &&
-          !unread.has(owner.key);
+          owner !== undefined && owner !== tabs[active] && !unread.has(owner.key);
         if (unreadChanged) {
           unread.add(owner.key);
         }
@@ -2013,10 +1964,7 @@ export function createTabManager(
           id,
           setTimeout(() => {
             activityResync.delete(id);
-            if (
-              !activity.working(id) &&
-              tracker.snapshot(id)?.phase === "working"
-            ) {
+            if (!activity.working(id) && tracker.snapshot(id)?.phase === "working") {
               const resyncSnap = tracker.noteActivity(id, {
                 phase: "idle",
                 source: "output-heuristic",

--- a/src/terminal/terminal-manager-types.ts
+++ b/src/terminal/terminal-manager-types.ts
@@ -135,6 +135,16 @@ export interface TerminalManager {
   /** Clear the active pane's buffer, keeping the prompt line (Cmd+K). */
   clearActive(): void;
   copyActiveSelection(): void;
+  /**
+   * Whether the active pane holds a terminal selection — read by
+   * `isActionPerformable` before a chord is consumed, so `copy-or-interrupt`
+   * can fall through to the PTY when there is nothing to copy. No active pane
+   * answers `false` (fail toward the PTY,
+   * docs/specs/2026-08-20-performable-keybindings-design.md D5).
+   */
+  activeHasSelection(): boolean;
+  /** Drop the active pane's selection. No active pane → no-op. */
+  clearActiveSelection(): void;
   pasteIntoActive(): void;
   /**
    * Paste text into ONE pane by id (the Prompt Board targets the pane the

--- a/src/terminal/terminal-manager.test.ts
+++ b/src/terminal/terminal-manager.test.ts
@@ -19,12 +19,19 @@ import {
  * `fitCounts`, when given, records one increment per `fit()` call for this
  * pane's id — lets a test assert every pane was fit without caring about
  * focus.
+ *
+ * `selections`, when given, is the shared set of pane ids that currently hold
+ * a terminal selection: a test adds an id to model the user having dragged
+ * over output, and `clearSelection()` removes it, so `activeHasSelection()`
+ * is observed through the same state the manager mutates rather than a spy
+ * that cannot answer differently after the clear.
  */
 function fakePane(
   id: number,
   events: PaneEvents,
   emitFocusEvent = true,
   fitCounts?: Map<number, number>,
+  selections?: Set<number>,
 ): Pane {
   const element = document.createElement("div");
   return {
@@ -47,6 +54,12 @@ function fakePane(
     },
     clear() {},
     copySelection() {},
+    hasSelection() {
+      return selections?.has(id) ?? false;
+    },
+    clearSelection() {
+      selections?.delete(id);
+    },
     paste() {},
     pasteText(text) {
       return events.onData(id, text);
@@ -83,6 +96,7 @@ function setup(emitFocusEvent = true): {
   eventsById: Map<number, PaneEvents>;
   fitCounts: Map<number, number>;
   panesById: Map<number, Pane>;
+  selections: Set<number>;
 } {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -90,9 +104,10 @@ function setup(emitFocusEvent = true): {
   const eventsById = new Map<number, PaneEvents>();
   const fitCounts = new Map<number, number>();
   const panesById = new Map<number, Pane>();
+  const selections = new Set<number>();
   const createPane: CreatePaneFn = (id, _settings, events) => {
     eventsById.set(id, events);
-    const pane = fakePane(id, events, emitFocusEvent, fitCounts);
+    const pane = fakePane(id, events, emitFocusEvent, fitCounts, selections);
     panesById.set(id, pane);
     return pane;
   };
@@ -112,6 +127,7 @@ function setup(emitFocusEvent = true): {
     eventsById,
     fitCounts,
     panesById,
+    selections,
   };
 }
 
@@ -411,6 +427,27 @@ describe("createTerminalManager scrollActivePage / scrollActiveToEdge", () => {
       tm.scrollActivePage(1);
       tm.scrollActiveToEdge("top");
     }).not.toThrow();
+  });
+});
+
+describe("createTerminalManager activeHasSelection / clearActiveSelection", () => {
+  it("reports and clears the active pane's selection", async () => {
+    const { tm, selections } = setup();
+    await tm.initFresh();
+    const id = tm.activePaneId();
+    expect(id).not.toBeNull();
+    selections.add(id!);
+
+    expect(tm.activeHasSelection()).toBe(true);
+    tm.clearActiveSelection();
+    expect(tm.activeHasSelection()).toBe(false);
+  });
+
+  it("answers false for a selection when there is no active pane", () => {
+    const { tm } = setup();
+
+    expect(tm.activeHasSelection()).toBe(false);
+    expect(() => tm.clearActiveSelection()).not.toThrow();
   });
 });
 

--- a/src/terminal/terminal-manager.ts
+++ b/src/terminal/terminal-manager.ts
@@ -687,6 +687,14 @@ export function createTerminalManager(
         life.panes.get(activeId)?.copySelection();
       }
     },
+    activeHasSelection() {
+      return activeId !== null && (life.panes.get(activeId)?.hasSelection() ?? false);
+    },
+    clearActiveSelection() {
+      if (activeId !== null) {
+        life.panes.get(activeId)?.clearSelection();
+      }
+    },
     pasteIntoActive() {
       if (activeId !== null) {
         life.panes.get(activeId)?.paste();

--- a/src/ui/settings/shortcut-groups.ts
+++ b/src/ui/settings/shortcut-groups.ts
@@ -75,6 +75,7 @@ const PLACEMENT: Readonly<Record<string, ShortcutGroupId>> = {
   "find-previous": "text",
   "clear-buffer": "text",
   "copy-selection": "text",
+  "copy-or-interrupt": "text",
   "copy-cwd": "text",
   paste: "text",
   // The Edit menu's own three (2026-08-19). They carry no `KeyBinding` — the


### PR DESCRIPTION
## What

On Windows, `Ctrl+C` copies the terminal selection when there is one and reaches the PTY as an interrupt when there is not — matching Windows Terminal's default. The mechanism that makes that safe is a general one, applied here to the clipboard actions only.

## Why

`handleShortcut` called `preventDefault()` and `stopPropagation()` the moment `matchBinding` returned an action, and only then called `dispatchAction`, where `overlayBlocksAction` decided whether the action could run at all. **The key was committed before anything decided whether the action could do anything.** Two consequences:

- **A latent defect.** Every `scope: "pane"` action — `find`, `clear-buffer`, `zoom-*`, `copy-selection`, `paste`, `scroll-*`, `focus-*`, `swap-*`, `next-tab`/`prev-tab` — was swallowed and then blocked while a file surface or an overlay owned the stage. Monaco escapes the `isChromeTextField` early return, because with `editContext` on it focuses a plain `<div>`, never an `<input>`/`<textarea>`. So `Ctrl+Shift+C` over an open document copied nothing **and** denied Chromium's own copy: a dead key, silently.
- **A blocked feature.** Bare `Ctrl+C` could not be bound on Windows at all, because a binding here always consumed.

## How

`src/terminal/action-performable.ts` answers "can this action do anything right now" from a pure context value, and `handleShortcut` asks it **before** `preventDefault()`. A false answer means the binding behaves as if it did not exist and the key continues to whatever holds focus. `dispatchAction` keeps `overlayBlocksAction` unchanged — it still guards the macOS menu path, which never passes through `handleShortcut`.

**The predicate is keyed on the ACTION, not the binding.** Ghostty expresses this as a `performable:` prefix on the bind, which cannot work here: user overrides are stored per action and replace an action's whole chord set (`resolveKeymap`), so two chords of one action cannot differ in conditionality — and a user who had rebound `copy-selection` would never receive the new `Ctrl+C`. kitty's compound-action shape is what fits.

| Action | Chord | Stage-conditional | Selection-conditional | Clears selection |
| --- | --- | --- | --- | --- |
| `copy-selection` | `Ctrl+Shift+C` (Windows) | yes | no | no |
| `copy-or-interrupt` | `Ctrl+C` (Windows only) | yes | yes | yes |

`copy-or-interrupt` carries **no `menu` field** on purpose: a Cocoa accelerator is consumed before the webview and would force the action regardless of whether it can be performed — the same reason Ghostty excludes performable binds from menus.

**Deck writes no interrupt byte.** When `copy-or-interrupt` is not performable, `handleShortcut` returns without consuming and xterm encodes the keystroke itself. A literal `\x03` through `pty.writePty` would pin one encoding that a terminal on a different keyboard protocol does not use.

**Only `copy-or-interrupt` clears the selection**, so a second press interrupts instead of copying again. The clear runs synchronously after the text is read, never in the clipboard write's callback, which could erase a selection made in the meantime.

## Deviations from the plan

Both forced, both explained in the commit body:

1. `copy-or-interrupt` joins `COMMAND_ACTIONS` (`tab-action-scope.ts`) — not in the plan, but `dispatch-coverage.test.ts` and two `shortcut-groups.test.ts` assertions both require a dispatch target.
2. `"c"` leaves the `leaves protected bare Ctrl+%s unbound` lock-in test. That assertion encodes exactly the rule this PR reverses; the protection moved from the keymap to the predicate.
3. The chord tests live in `tab-manager.file-surfaces.test.ts` rather than `tab-manager.chord-actions.test.ts` — `fakeSurfaces` and the Windows dispatch pattern already live there, and the plan forbids a second mounting helper.
4. The manager interface lives in `terminal-manager-types.ts`, not `terminal-manager.ts` as the plan assumed.

## Evidence

- `npm test` — **3375 passed / 10 failed**. All ten reproduced **byte-identically on a pristine `HEAD` worktree** with none of this branch's changes, so all ten are other in-flight work on `main`: agent launch-command strings (`claude` vs `claude --dangerously-skip-permissions`, 7), `agent-rail-model` remembered projects (2), and `toggle-sessions` missing from `shortcut-groups.ts`'s `PLACEMENT` (1). None is touched here.
- `npx tsc --noEmit` — clean.
- `npx tsc -p tsconfig.electron.json --noEmit` — clean.
- `npm run build` — clean.
- `npm run generate:menu:check` — clean.
- Owning suites on this branch: **216/216** across `action-performable`, `keymap`, `action-registry`, `dispatch-coverage`, `terminal-manager`, `tab-manager.file-surfaces`, `tab-manager.overlay-guard`, `pane-lifecycle`.
- 4 new chord tests drive the **real capture-phase `window` listener** through the pane's own textarea, so a consumed chord provably never reaches downstream and a non-consumed one provably does.

## Not verified

- **No Windows hardware (Gate C): the `Ctrl+C` keystroke has never actually been pressed.** This is renderer-verified, never Windows-verified.
- No `npm run electron:dev` or `npm run tauri dev` pass, and no owner eye review.
- Renderer-only, so the mechanism reaches **both** hosts; macOS is untouched (`⌘C` stays the native Cocoa Copy role, and `copy-or-interrupt` ships unbound there).

## Known gap, carried on purpose

macOS **menu**-bound actions (`find`, `find-next`, `find-previous`, `clear-buffer`, `zoom-*`, `split-*`, `toggle-*`) keep dying over a file surface, because Cocoa consumes their accelerators before the webview and no renderer-side reorder can reach them. Ghostty's answer is that performable binds get no menu shortcut at all; adopting that trades away the menu's role as the place chords are learned. Out of scope. The remaining ~18 pane-scoped actions are deliberately unregistered — the table takes them later as a data change.

## Notes for review

- The raw diff is inflated by a local `prettier --write` hook reflowing the touched files to the repo's `printWidth: 100`. Real semantic footprint is **~293 lines**, not ~456 — in `tab-manager.ts` it is 50 of 248. (`main` currently has 84 files that are not prettier-clean, so this is that normalization arriving early on these files.)
- **Docs are not in this PR.** `docs/CONTEXT.md` and `AGENTS.md` entries for this change are written and waiting for owner approval of the prose (D14); they can be pushed onto this branch as a separate `docs(...)` commit on request.

Spec: `docs/specs/2026-08-20-performable-keybindings-design.md`
Plan: `docs/plans/2026-08-20-performable-keybindings.md`

https://claude.ai/code/session_01E39AYRkagtxbvS1GQ2VGzx
