### PR TITLE
docs: rebuild docs/ as internals, operations and user tiers for the Electron host (MXR-18)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,13 @@ is meant to replace it. The renderer is Preact + xterm.js and reaches whichever 
 under through the facades in `src/host/`. Everything in this repo — UI strings, comments, docs,
 and commits — is **English only**.
 
-Project state: [docs/CONTEXT.md](docs/CONTEXT.md) `current`; architecture:
-[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) `current`; visual rules:
-[docs/DESIGN-LANGUAGE.md](docs/DESIGN-LANGUAGE.md) `current`.
+Documentation index: [docs/README.md](docs/README.md) `current` — architecture and
+invariants in [docs/internals/](docs/internals/overview.md) `current`, build and release
+runbooks in [docs/operations/](docs/operations/development.md) `current`, user guides in
+[docs/user/](docs/user/getting-started.md) `current`; visual rules:
+[docs/DESIGN-LANGUAGE.md](docs/DESIGN-LANGUAGE.md) `current`. `docs/CONTEXT.md` and
+`docs/ARCHITECTURE.md` are the earlier decision journal and Tauri-era architecture note,
+superseded by `docs/internals/` wherever they disagree.
 
 ## Current direction
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,3 +1,8 @@
+> **Superseded.** The maintained vocabulary is
+> [`docs/internals/glossary.md`](docs/internals/glossary.md), which merges this file and
+> corrects the entries that drifted (Workspace, Theme gallery, Agent rail, Close tab, Quit).
+> Kept unedited below until the code comments that cite it are updated.
+
 # Deck
 
 A terminal for running many agent CLIs side by side. The UI hierarchy is Window → Tab → Pane.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ replace its launch command, or add another CLI command.
 | Open usage | `⌘⇧U` | `Ctrl+Shift+U` |
 | Open Settings | `⌘,` | `Ctrl+,` |
 
-The complete bindings live in [the platform keymaps](src/terminal/default-keymaps.ts) `current`.
+The complete bindings are listed in [keyboard shortcuts](docs/user/keyboard-shortcuts.md)
+`current` and defined in [the platform keymaps](src/terminal/default-keymaps.ts) `current`.
 
 ## Build from source
 
@@ -133,7 +134,10 @@ Create a local packaged macOS build with `npm run electron:package`. Release pac
 separate signed and notarized workflow.
 
 Deck uses Electron, Preact, TypeScript, xterm.js, Monaco Editor, and `node-pty`. The host and
-renderer boundary is mapped in [the architecture guide](docs/ARCHITECTURE.md) `current`.
+renderer boundary is mapped in [the architecture overview](docs/internals/overview.md)
+`current`; the full documentation index is [docs/README.md](docs/README.md) `current`, with
+user guides under [docs/user/](docs/user/getting-started.md) `current` and the build and
+release runbooks under [docs/operations/](docs/operations/development.md) `current`.
 
 ## Contributing
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,9 @@
+> **Superseded.** This page describes the Tauri 2 + Rust runtime, which is feature-frozen
+> and no longer ships from a tag. The current architecture, written for the Electron host,
+> is [`internals/overview.md`](internals/overview.md) and the pages beside it; the index is
+> [`README.md`](README.md). Kept unedited below because code and workflows still cite it;
+> where it disagrees with `internals/`, `internals/` is right.
+
 > Generated from `~/.claude/templates/ARCHITECTURE.template.md` — LIVING doc, update in place (D1).
 
 # SpaceVibe Deck — architecture

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
-> **Superseded.** This page describes the Tauri 2 + Rust runtime, which is feature-frozen
-> and no longer ships from a tag. The current architecture, written for the Electron host,
-> is [`internals/overview.md`](internals/overview.md) and the pages beside it; the index is
-> [`README.md`](README.md). Kept unedited below because code and workflows still cite it;
-> where it disagrees with `internals/`, `internals/` is right.
+**Superseded.** This page describes the Tauri 2 + Rust runtime, which is feature-frozen
+and no longer ships from a tag. The current architecture, written for the Electron host,
+is [`internals/overview.md`](internals/overview.md) and the pages beside it; the index is
+[`README.md`](README.md). Kept unedited below because code and workflows still cite it;
+where it disagrees with `internals/`, `internals/` is right.
 
 > Generated from `~/.claude/templates/ARCHITECTURE.template.md` — LIVING doc, update in place (D1).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,51 @@
+# SpaceVibe Deck documentation
+
+Three tiers, split by reader. Every page describes the shipped Electron host in the present
+tense; anything about the frozen Tauri host says so.
+
+## `user/` — using Deck
+
+- [Getting started](user/getting-started.md) — install, first launch, the window, panes and
+  files.
+- [Agents](user/agents.md) — the built-in commands, custom agents, what Deck knows about each
+  tool.
+- [Keyboard shortcuts](user/keyboard-shortcuts.md) — every shipped chord on macOS and Windows.
+- [Settings](user/settings.md) — each category, the privacy switch, where data lives.
+
+## `internals/` — how Deck is built
+
+- [Overview](internals/overview.md) — the Electron boundary, the bridge and its contract,
+  persistence, the load-bearing seams.
+- [Glossary](internals/glossary.md) — the words the code and docs use.
+- [Terminal, panes and tabs](internals/terminal.md) — PTY ownership, classification, layout,
+  materialization and launch, phase and attention, actions and menu, close, quit and
+  transfer.
+- [Agent Rail](internals/agent-rail.md) — the rail model, state, the session-tail pairing,
+  focus, close and order.
+- [File surface, browser tab and path opening](internals/file-surface.md) — the explorer,
+  editor, markdown policy, browser view and link routing.
+- [Session restore](internals/session-restore.md) — the journal, boot restore, resume
+  resolution and session history.
+- [Usage analytics](internals/telemetry.md) — the payload, consent state and when a POST
+  fires.
+- [Known traps and live switches](internals/traps.md) — what has bitten this codebase, and
+  the constants that currently switch behaviour off.
+
+## `operations/` — building and shipping
+
+- [Development](operations/development.md) — commands, CI, tests, what a green run proves.
+- [Cutting a release](operations/release.md) — the tag, the four jobs, the gates, secrets,
+  the updater client, the Tauri hotfix path.
+
+## Elsewhere
+
+- [`DESIGN-LANGUAGE.md`](DESIGN-LANGUAGE.md) — the numbered visual rules cited from code and
+  enforced by `scripts/design-language.test.ts`. It stays at this path because the test
+  reads it.
+- [`../AGENTS.md`](../AGENTS.md) — repository rules for contributors and agents.
+- [`../CHANGELOG.md`](../CHANGELOG.md) — user-facing release notes, read by the release
+  workflow.
+
+`ARCHITECTURE.md`, `CONTEXT.md`, `CONTEXT-archive.md`, `intent/`, `plans/`, `specs/` and
+`review/` are the earlier documentation set. They describe decisions as they were made and
+are superseded by the pages above wherever the two disagree.

--- a/docs/internals/agent-rail.md
+++ b/docs/internals/agent-rail.md
@@ -1,0 +1,153 @@
+# Agent Rail
+
+The rail is the left column: one cluster per project, one row per agent pane, each row
+saying what its agent last said and in what state. This page states the invariants of the
+model, the state derivation, the pairing that reads a sentence off the agent's own session
+log, and the close and order rules. Visual rules are in
+[`DESIGN-LANGUAGE.md` §27](../DESIGN-LANGUAGE.md).
+
+## Model
+
+[`src/ui/agent-rail-model.ts`](../../src/ui/agent-rail-model.ts) is a pure projection over
+`tabViews`, the active tab index, the repository scans, the workspace history, the tails and
+the stored `railOrder`. The clock is injected; nothing in it calls `Date.now`. It reuses
+`buildRail` from [`repository-model.ts`](../../src/repositories/repository-model.ts) for
+grouping rather than regrouping on its own.
+
+- **Every open tab produces a row.** The rail is the sidebar's only list. Shell panes and
+  panes with no recognised agent are dropped from a tab's agent rows in `paneRows` and
+  nowhere else.
+- **A cluster is a repository, keyed by its `--git-common-dir`,** so every worktree of one
+  repository folds into one cluster. A folder git does not know is a `plain:<path>` cluster.
+  `RailStreamGroup.orderKey` is produced, never derived by stripping a prefix off `key`: it is
+  the repository key or `plain:<path>`, and it is what the stored order is written against.
+- **Clusters sit where their oldest tab put them,** then remembered clusters follow: a
+  workspace-history folder with nothing open keeps a rowless header, deduplicated against
+  every live worktree path and folded per repository. `historyPaths` is populated for live
+  clusters too, so a header's ✕ can remove the project instead of demoting it to the
+  remembered tier.
+- **Rows are in open order, not recency.** `sortByOpenOrder` sorts by `openedAt` then index.
+- **A tab row's sentence and state are its loudest pane's:** highest `STATE_RANK`
+  (`failed` 4, `asked` 3, `working` 2, `done` 1, `idle` 0), then newest `changedAt`, then pane
+  order. `tabTail` exports the same fold for the tab strip's chips, so the two surfaces
+  cannot disagree.
+- **At most one row in the whole rail is focused.** `RailPaneRow.focused` is
+  `PaneView.focused` ANDed with the tab's `active`, in the model where it is assertable.
+  A document or the browser on the stage does not clear the mark; the row then reads as
+  where the keyboard returns to.
+
+## State
+
+`paneState` reads latched attention before live phase:
+
+| Attention                              | Phase     | `hasRun` | Rail state | Mark                  |
+| -------------------------------------- | --------- | -------- | ---------- | --------------------- |
+| `error`                                | any       | any      | `failed`   | red dot               |
+| `requested`, `warning`, `completed`    | any       | any      | `asked`    | yellow dot            |
+| `none`                                 | `working` | any      | `working`  | spinner, no dot       |
+| `none`                                 | other     | true     | `done`     | nothing               |
+| `none`                                 | other     | false    | `idle`     | nothing               |
+
+The words (`failed`, `needs you`, `working`, `done`, `idle`) live only in the row's title and
+accessible name. Where attention and phase come from is in
+[terminal.md](terminal.md#agent-phase-and-attention).
+
+## The sentence, and the pairing behind it
+
+The rail's sentence is the newest assistant text in the agent's own session log, read by
+[`electron/resume/session-tail.ts`](../../electron/resume/session-tail.ts) over the
+`session_tail` channel and requested by
+[`session-tail-store.ts`](../../src/terminal/session-tail-store.ts). Electron only: on Tauri
+and in the browser preview the channel does not exist, `installSessionTailSync` returns a
+no-op, and the rail falls back to agent names.
+
+- **Only Claude Code, Codex and OpenCode produce a tail.** Gemini has no candidate scan,
+  Antigravity's store is an undocumented protobuf, and custom agents are unknown. Those rows
+  keep their agent name.
+- **A pane is asked about only once it has run something** (`hasRun`, or it was resumed), so a
+  fresh pane cannot wear a previous session's sentence. Requests are debounced 300ms on
+  `tabViews`, never on a timer.
+- **The pane→session pairing is remembered and pinned.** A request carries `preferredId`,
+  and `resolveSessionTails` runs two passes: every pin is honoured through
+  `findCandidateById` (no 30-day cutoff, no ranking) before any unpinned pane is ranked by
+  mtime proximity through the same `selectCandidate` that session restore uses. One pass in
+  request order lets an earlier unpinned pane take a later pane's pinned session, which is how
+  three rows once printed the same sentence.
+- **The answer is `{ id, tail }`.** Only the id separates "same conversation, nothing new to
+  quote" (keep the row's text) from "different conversation" (take the new pairing and the
+  new text, even when empty).
+- **A pairing does not outlive its agent generation.** The store forgets a pane's pairing when
+  its agent label changes or `hasRun` goes true → false, and its fingerprint covers every
+  pane so a generation change cannot be skipped as a repeat.
+- **The read window grows.** 64 KiB, then 256 KiB, then 1 MiB from the end of the file, each
+  a fresh read; a working agent's tool traffic fills the last 64 KiB with `tool_result`
+  records. A short `readSync` is not EOF, so no step exits early.
+- **Reasoning is never quoted.** OpenCode parts match `type === "text"` exactly, not the
+  presence of a `text` field, because `reasoning` parts carry one too. OpenCode's store is
+  read through `node:sqlite` first, then the legacy JSON tree, deduplicated by id; sub-agent
+  sessions (`parent_id IS NOT NULL`) are excluded because they share their parent's
+  directory.
+- Every scanner caps at 300 files, and the request carries the tab's cwd, not the pane's.
+
+## Focus
+
+`onFocusPane` from a row runs the attention-focus coordinator, which activates the tab and
+pane and clears that pane's latched attention. The keyboard mark itself comes from
+`PaneView.focused`, projected from `TerminalManager.activePaneId()` and reported through
+`ManagerCallbacks.onActivePaneChange`, which fires from `setActive` because every focus path
+converges there. Split, close, respawn and adoption assign the active id directly and are
+covered by `onLayoutChange` and the pane poller, so the projection self-heals.
+
+## Close model
+
+The control closes the thing its row names ([`close-coordinator.ts`](../../src/terminal/close-coordinator.ts)):
+
+- An agent row's ✕ closes that **pane**, with ⌘W's own contract: the tab follows only when
+  the pane was its last, decided from `manager.paneCount()`, never from the rail's agent-row
+  count. A tab holding one agent beside a plain shell survives that agent's close.
+- A row with no agent is a shell tab and closes the **tab**.
+- A live project header's ✕ closes **every tab of the repository**, secondary worktrees
+  included, under one busy dialog, and only then drops the project's history entries.
+  `closeTabs` pins entries by identity before the first dispose and answers `false` on a
+  decline, so a cancelled close cannot forget a project whose tabs are all still open.
+- A remembered header's ✕ forgets every history entry it folds.
+- The window outlives its last agent: the last tab closing raises the Open board and leaves
+  the window standing. Only the pane-moved path (`removeEmptyTab`) still closes a window.
+
+## Order
+
+A project cluster goes where the user drags it and stays there
+([`rail-order.ts`](../../src/ui/rail-order.ts),
+[`rail-cluster-drag.ts`](../../src/ui/rail-cluster-drag.ts)).
+
+- The header is the whole cluster's drag handle; only clusters drag, never rows or panes.
+  One pointer controller is delegated on the list, because a header re-renders whenever an
+  agent speaks and a per-element controller would be disposed mid-drag.
+- `railOrder` is a settings field: pinned cluster keys first in stored order, everything else
+  in today's assembled order. An empty `railOrder` returns the assembled array itself.
+- A drop pins every cluster above it, or slot 1's open order would push slot 2 around. A
+  pinned cluster ignores the live/remembered boundary, because the position survives the
+  cluster's last tab closing. `pinAt` refuses a drag whose `orderKey` is not unique on screen.
+- `plain:<path>` entries written before a scan lands are rewritten to the repository key on
+  the next write, so the list canonicalizes instead of holding two spellings. The cap is
+  200 entries; entries naming no visible project are kept, since that is how a parked
+  project returns to its slot.
+- Settings are app-level, so a drag reorders every window's rail. There is no keyboard
+  equivalent.
+
+## Other surfaces in the column
+
+- Each project header carries `+`, which opens the quick picker with
+  `quickPickerWorkspace` pinned to that project; `newTab()` clears the signal so the next ⌘T
+  does not inherit the rail's target.
+- `PANE_TREE_HIDDEN` in [`agent-rail.tsx`](../../src/ui/agent-rail.tsx) renders a
+  multi-agent tab as flat agent rows inside a hairline frame (the `data-headless` CSS seam in
+  [`04b-agent-rail-rows.css`](../../src/styles/04b-agent-rail-rows.css)) instead of a parent
+  row with elbow guides. Flipping the constant restores the tree.
+- [`repository-rail.tsx`](../../src/ui/repository-rail.tsx) is the rail this one replaced.
+  It still builds and is mounted only in the gallery.
+- Repository scans come from `git_repository` (Electron only) through
+  [`repositories-store.ts`](../../src/repositories/repositories-store.ts): derived git facts
+  are never persisted, only collapse state is, a scan failure degrades to a `plain` cluster,
+  and a return to the window refreshes rather than invalidates so the sidebar does not jump.
+  No `git status` is run anywhere.

--- a/docs/internals/agent-rail.md
+++ b/docs/internals/agent-rail.md
@@ -70,9 +70,10 @@ no-op, and the rail falls back to agent names.
 - **The pane→session pairing is remembered and pinned.** A request carries `preferredId`,
   and `resolveSessionTails` runs two passes: every pin is honoured through
   `findCandidateById` (no 30-day cutoff, no ranking) before any unpinned pane is ranked by
-  mtime proximity through the same `selectCandidate` that session restore uses. One pass in
-  request order lets an earlier unpinned pane take a later pane's pinned session, which is how
-  three rows once printed the same sentence.
+  mtime proximity through the same `selectCandidate` that session restore uses. The two
+  passes exist because the earlier one-pass version let an unpinned pane earlier in the
+  request take a later pane's pinned session, which is how three rows once printed the same
+  sentence; reserving every pin first is what rules that out.
 - **The answer is `{ id, tail }`.** Only the id separates "same conversation, nothing new to
   quote" (keep the row's text) from "different conversation" (take the new pairing and the
   new text, even when empty).

--- a/docs/internals/file-surface.md
+++ b/docs/internals/file-surface.md
@@ -1,0 +1,162 @@
+# File surface, browser tab and path opening
+
+Three things share the stage with the terminal grid: documents opened from the file
+explorer, the browser tab, and the routing that turns a path an agent printed into one of
+those. All of it is Electron only: the file channels, the `WebContentsView` and the external
+app catalog have no Tauri counterpart, and `open_editor` is the one path Tauri keeps.
+
+## Surfaces beside tabs
+
+- **The file surface store lives beside `TabManager`, never inside it.**
+  [`file-surface-store.ts`](../../src/files/file-surface-store.ts) imports nothing from
+  `tab-manager.ts` and vice versa, because `syncViews` rebuilds tab views from a process poll
+  and a PTY-less tab could not survive that. `App`, `TabBar` and the strip are the only
+  modules that see both. The browser store keeps the same seam: `browserSurfaceActive` and
+  `activeFileTab` are held mutually exclusive by `App`, and the two stores never import each
+  other.
+- **`SurfaceStrip`** ([`stage-surface-strip.ts`](../../src/ui/stage-surface-strip.ts)) is
+  everything `TabManager` is allowed to know: `count`, `total`, `activeIndex`, activate,
+  deactivate, focus, close, save, and three optional methods, `orderKey`, `runEditCommand`
+  and `canToggleView`/`toggleView`. Index space is the active workspace's file tabs, then
+  the browser as the one index past them; the merged strip places every chip by `orderKey`,
+  so the browser can sit before a file tab.
+- **Exactly one of terminal grid, document or browser owns the stage.** The document and the
+  browser surface cover `.stage__tabs` rather than unmounting it, so taking the stage back
+  costs no xterm reflow and no PTY resize. A document stays mounted on `activeFileTab` alone,
+  not on the dock being open.
+- **Per window, in memory.** File tabs and view modes are not settings; only the dock's width
+  and default-open state persist. Session restore carries the main window's file list in
+  its own record.
+- **The preview slot** ([`preview-slot.ts`](../../src/files/preview-slot.ts)): a single click
+  opens a file into the workspace's one preview tab, replaced in place keeping its
+  `openedAt`; a double-click or the first edit promotes it to a kept tab; a dirty preview is
+  promoted rather than replaced, so replacing a preview never discards work.
+
+## Explorer and editor
+
+- The tree ([`file-tree.ts`](../../src/files/file-tree.ts)) is virtualized by plain index
+  arithmetic, 22px rows, hides `.git`, `node_modules`, `dist` and `target` by a fixed list
+  rather than by parsing `.gitignore`, sorts directories first with a locale compare and a
+  code-unit tie-break, and walks with a visited set so a symlink cycle inside the root cannot
+  loop. A symlink out of the root renders as a leaf and does not open.
+- Monaco is imported lazily on the first file tab and its languages are enumerated one
+  import at a time in [`editor-host.ts`](../../src/files/editor-host.ts), because a loop over
+  strings is not statically analyzable. Language services (TypeScript, JSON, CSS, HTML
+  workers) are deliberately not loaded. One editor instance swaps models per tab with saved
+  view state, so a silent reload keeps scroll and cursor; external changes are applied with
+  `pushEditOperations`, never `setValue`, to keep the undo stack.
+- **External change policy** ([`external-change.ts`](../../src/files/external-change.ts)):
+  a clean document reloads silently or is marked gone; a dirty one is asked (reload / keep
+  mine, save again / close); a prompt already up is never replaced under the pointer.
+  `fs.watch` misses events on every platform, so a re-`stat` of every open document on
+  window focus is the designed mitigation, one `stat_files` batch per workspace.
+- **Dirty resolves toward dirty.** The renderer's registry pushes its complete set to main on
+  every change (`set_dirty_files`), and main's copy is what the quit and window-close census
+  reads, so a wedged renderer cannot make ⌘Q forget an unsaved file. A failed save marks the
+  document `unknown`, which keeps the guard asking.
+- Content limits ([`file-content.ts`](../../src/files/file-content.ts), compiled into main
+  too): editable up to 2 MiB, readable up to 16 MiB, binary refused by a NUL byte in the
+  first 8 KiB, invalid UTF-8 decoded lossily and opened read-only, line endings detected by
+  the dominant kind.
+
+## Main-process file guards
+
+- **A path is legal only if, after `realpath`, it is inside the workspace root, itself
+  realpath'd** ([`path-guard.ts`](../../electron/fs/path-guard.ts)). Comparison is
+  `path.relative`, never `startsWith`; the root is resolved per call, not cached; a UNC-shaped
+  root is rejected before any filesystem call. `root` travels with every file channel
+  rather than being remembered per window, because two windows can hold different
+  workspaces.
+- A write target that exists but does not resolve inside the root **throws** even when its
+  parent is fine: `fs.writeFile` followed a committed symlink out of the workspace once.
+- **Atomic writes are one implementation** ([`write.ts`](../../electron/fs/write.ts)): a
+  unique temp sibling opened `wx` so a symlink planted at the temp name cannot be followed,
+  then rename; the store uses the same function. A directory target is refused because its
+  dirname would be the workspace's parent.
+- Watching is non-recursive, on directories not files (an atomic writer destroys the inode a
+  file watcher holds), and every `watch_paths` call **replaces** the window's whole scope so
+  a collapsed directory cannot leak a watcher. Caps: 256 directories and 2,048 files per
+  window, 512 paths per `stat_files` counted before deduplication, 64 roots per
+  `workspace_for_path`. Events coalesce over 40ms in main and 100ms in the renderer.
+- Listings are uncapped on purpose; the panel virtualizes. Symlink resolution runs through a
+  32-wide async pool so a large directory cannot stall the event loop.
+
+## Markdown
+
+`.md` and `.markdown` open rendered; `.mdx` opens as source. ⌘⇧V (`toggle-markdown-view`,
+macOS only) flips a document. The view is a read-only picture of the **live buffer**,
+debounced 150ms, so it rides the external-change path for free.
+
+The policy ([`markdown-policy.ts`](../../src/files/markdown-policy.ts)) is pure and exists so
+the feature needs no Content Security Policy; nothing in it may grow a rule only a CSP would
+enforce.
+
+- Raw HTML is escaped and shown verbatim, not sanitized.
+- A link carries its decision in `data-md-target` and its destination in `data-md-href`,
+  never in `href`: there is nothing to follow, so nothing to intercept. `http`, `https`,
+  `mailto` and `tel` go out through `shell_open_url` (which re-validates the scheme in main);
+  an in-workspace relative link raises the same `requestPathOpen` a ⌘+click does; `#anchor`
+  scrolls; `javascript:`, `data:`, `file:` and every unhandled scheme, and anything
+  resolving outside the root by segment-wise comparison, render as plain text.
+- Images are local only. A local image inside the root gets its bytes through
+  `workspace_for_path` (containment answered in main) and `read_image_as_data_url`
+  (extension allowlist, 1 MB cap); a remote image is a labelled placeholder, never a fetch.
+  `read_file` cannot serve this because it refuses every PNG as binary.
+- Fenced code is colorized by Monaco's own colorizer against the enumerated language set;
+  `mermaid` is imported only when a document holds a fence, and a diagram that fails keeps
+  its code block plus an error line.
+
+## Browser tab
+
+The browser is a chip on the strip whose surface is a native `WebContentsView`
+([`electron/browser/view.ts`](../../electron/browser/view.ts)).
+
+- **A native view paints above every DOM layer**, so the renderer tells the host when to hide
+  it. `browserPanelObscured` in [`app-policy.ts`](../../src/ui/app-policy.ts) is wider than
+  the focused-pane overlay check on purpose: any DOM pixel trying to paint over the stage
+  (the quick picker, the consent modal, the Prompt Board, the persist-error bar, a settings
+  load error) hides the view. The renderer measures its placeholder and sends the rectangle;
+  the host never guesses one.
+- One persistent session (`persist:deck-browser`) shared by every window; `sandbox: true`,
+  no node integration, every permission request denied, `window.open` denied and handed to
+  the OS. Only `http:` and `https:` load; `file:` is out because the panel injects a script
+  into whatever it loads. A typed host that does not normalize opens nothing rather than a
+  web search, because that would send the user's text off the machine.
+- Closing the tab hides the view rather than destroying it, so a reopen keeps the route,
+  scroll and dev-server session.
+- **Inspect** injects the vendored react-grab bundle into the page's main world with its
+  telemetry disabled before it initializes. A grab is untrusted: the preload forwards it only
+  within 3 seconds of a trusted gesture and at most every 250ms, main enforces a second
+  200ms floor, the payload is capped and re-parsed, and
+  [`grab-format.ts`](../../src/browser/grab-format.ts) strips every C0 and C1 control so a
+  bracketed-paste terminator cannot ride in. `GRAB_PASTE_DISABLED` in
+  [`browser-store.ts`](../../src/browser/browser-store.ts) currently stops a grab at the
+  clipboard; the paste path is kept, never submits, and is one constant away.
+
+## Opening a path an agent printed
+
+Detection ([`terminal-links.ts`](../../src/lib/terminal-links.ts)) is renderer-only and
+reaches both hosts; routing is Electron only.
+
+- Path segments use Unicode letter, mark and number classes so non-ASCII names match, and
+  exclude symbols so an agent TUI's box-drawing characters cannot fuse into a path. Grammars:
+  slashed, bare-with-extension, Windows drive, UNC and relative, tsc's `(line,col)`, quoted
+  paths (the only route to a space) with Python's `, line N`, git's `a/` and `b/` prefixes
+  stripped renderer-side, and ESLint's cross-line rows. At most 24 candidates per line.
+  Boundaries are consumed groups, not lookbehinds, because a lookbehind throws at module
+  evaluation on older JavaScriptCore.
+- Resolution goes through `resolve_paths` in a batch; misses are cached for 5 seconds and
+  hits for the pane's life, so a file an agent names before writing it becomes clickable.
+- **A path inside a workspace this window has open always opens in Deck**, as a preview tab
+  revealed at its line. Containment is answered by `workspace_for_path` in main through the
+  path guard, and it returns the root as the renderer spelled it, because every
+  file-surface lookup is keyed by that string. Anything else goes to the app selected on
+  the split button beside `More`: editors keep the `open_editor` template (the only route
+  that carries a line), git and terminal apps open the repository or directory, Finder
+  reveals. Installed means the bundle exists; launch is `execFile` argv, never a shell string.
+- The link provider raises `requestPathOpen` and never imports the file layer; `App` decides
+  where the path opens, clearing the request before the await so a second click during a
+  slow answer raises a fresh one.
+- On Tauri, and in any host that cannot answer `external_apps`, an editor selection keeps its
+  template, anything else falls back to VS Code, and the split button is hidden. On Windows,
+  `open_editor` is unavailable and no external app bundle is detected.

--- a/docs/internals/glossary.md
+++ b/docs/internals/glossary.md
@@ -1,0 +1,194 @@
+# Glossary
+
+The words Deck's code, tests and documents use, each with the terms to avoid. The UI
+hierarchy is Window → Tab → Pane; documents and the browser are surfaces beside tabs.
+
+## Window and stage
+
+**Window** — One Deck OS window owning its own tabs, panes and surfaces. Panes move between
+windows; each window's tabs are journaled for session restore. Not: tab, app, workspace.
+
+**Workspace** — A local folder chosen on the Open board as a tab's working root. A tab
+carries exactly one workspace, fixed for its life; a workspace may own any number of tabs.
+Recents live in `workspaces.json` with the layout and agent each was last opened with, and
+the session journal records every open tab's workspace so it comes back at launch. A pane's
+live cwd is not the workspace: `cd` never changes it. Not: window, session, folder.
+
+**Stage** — The centre column. Exactly one of the terminal grid, a document or the browser
+owns it at a time. Not: pane, tab.
+
+**Surface** — A document or the browser tab: something on the stage that is not a terminal
+tab. Surfaces sit beside `TabManager` behind the `SurfaceStrip` seam, are addressed by index,
+and share the strip with tabs. Not: overlay, panel.
+
+**Surface strip** — The one row of chips on the stage's frame row: terminal tabs, open
+documents and the browser tab share one chip shape, differ only by glyph, and are ordered by
+when they were opened. ⌘1–9 and tab cycling count chips. Not: tab bar, dock, toolbar.
+
+**Dock** (side panel) — The docked right column with three tabs: file explorer, token usage,
+session history. It displaces the terminal grid rather than covering it. Not: sidebar, rail.
+
+**Agent Rail** — The left column: one cluster per project, one row per agent pane, each
+showing the agent's newest sentence or its name, and a dot for failed, asked or working.
+Every row keeps full legibility. Clicking a row focuses the pane; each row's ✕ closes what
+the row names. Not: repository rail, attention rail, task list, sidebar.
+
+## Tabs, panes, layout
+
+**Tab** — A container holding one or more panes as a split layout tree, plus its chrome
+(name, dot colour) and its workspace. Closing a tab disposes every pane inside it.
+Not: window, session.
+
+**Pane** — One visible terminal region backed by exactly one PTY. Every tab has at least one;
+splitting adds more. Not: split, cell, terminal window.
+
+**Focused pane** — The pane receiving keyboard input in a tab; one per tab. The rail marks the
+focused pane of the active tab. Not: active pane, selected pane.
+
+**Layout** — The split tree of a tab: nested row/column splits with ratios. Preserved across
+a closed-tab reopen; pane ids and PTYs are recreated. The layout engine maps it to the DOM.
+Not: grid, arrangement.
+
+**Layout preset** — A named, persisted split tree with optional per-pane cwds, created from
+the live layout (⌘⇧N) or overwritten (⌘⇧S). A preset can no longer be renamed or deleted in
+the app. Not: session, workspace, launch profile, theme.
+
+**Closed tab snapshot** — An in-memory record taken when a tab closes: layout, cwds, name,
+colour. ⌘⇧T reopens with fresh shells at the saved cwds; at most 10, not persisted.
+Not: undo, session backup, history.
+
+**Swap pane** — Exchange two panes' positions; each pane's PTY moves with it. Not: drag-dock.
+
+**Move to window** — Detach a pane into another or a new OS window, through the coordinator's
+transfer protocol. Does not prompt when busy. Not: close pane, swap.
+
+**Buffer** — A pane's scrollback above the current prompt. Clear Buffer (⌘K) drops it with no
+undo; the action is `destructive`. Not: screen, viewport.
+
+**Search** — Incremental, case-insensitive find in one pane's scrollback (⌘F). One search bar
+across the app; the last term is app-wide so find-next works after the bar closed.
+Not: filter, grep.
+
+**CWD** — A pane's shell working directory as the PTY reports it. New panes inherit the
+focused pane's cwd; missing paths fall back to `$HOME`. Not: directory, folder.
+
+## Processes and agents
+
+**Agent** — An AI-agent CLI. For chrome, recognised by foreground process name; for launch,
+a binary discovered on the login shell's `PATH` or a command the user declared.
+Not: process, bot.
+
+**Built-in agent** — One of the six Deck ships: `claude`, `codex`, `opencode`, `agy`,
+`gemini`, `cursor-agent`. Its id, binary name and bare command are the same string.
+
+**Custom agent** — A user-declared name plus a full command line, id `custom:<slug>`, matched
+to processes by its label. Not: preset, launch profile.
+
+**Launch profile** (preset, in the UI) — A command line the user wrote for an agent, stored as
+a string and typed verbatim; the agent is derived from its first word. Not: layout preset.
+
+**Agent launch** — Typing `<command>\r` into a new pane's interactive shell once it is ready,
+rather than spawning the agent from main, so the shell's real `PATH` applies. Each pane is
+typed into exactly once. Not: spawn, agent picker.
+
+**Materialize** — Turning a `MaterializeIntent` (layout, cwds, agent or per-pane commands,
+chrome, workspace) into a live tab with fresh shells. One seam behind the Open board, the
+quick picker, reopen, presets, rail drop and session restore. Not: restore, open.
+
+**Quick picker** (AgentQuickPicker) — The ⌘T modal: a destination row naming the worktree,
+then agents as rows picked by click or digit. Spawns one pane in the active tab's live cwd.
+Not: Open board.
+
+**Busy** — A pane whose foreground process is not an idle shell (an agent, `vim`, anything).
+The close and quit census asks about busy panes. `unknown` is neither busy nor idle.
+Not: running, working.
+
+**Agent phase** — The live per-pane work signal: `unknown`, `idle`, `working`, `exited`, from
+OSC 9;4 progress or the sustained-output heuristic, only after the pane's process is
+classified as an agent. Not: busy, attention.
+
+**Attention** — The latched, actionable per-pane state: `none`, `completed`, `requested`,
+`warning`, `error`. Explicit signals outrank the heuristic, which produces only `completed`.
+Never downgraded until acknowledged; the UI reads it before phase. Not: notification, unread.
+
+**Acknowledge** — Focusing a pane, which clears its attention and unread. Never clears phase.
+Not: selectTab, dismiss.
+
+**Unread** — Per pane, whether output has been seen since it last changed; cleared only on
+real DOM focus while the window is foreground. Distinct from the tab-level unread flag.
+
+**Rail state** — What the rail draws from attention and phase: `failed`, `asked`, `working`,
+`done`, `idle`. `done` means the pane has run something and is quiet; `idle` means it never
+ran. Not: attention kind.
+
+**Turn** (session tail) — The agent's newest assistant sentence, read off its own session
+log by `session_tail` and shown on the rail row and the strip chip. Only Claude Code, Codex
+and OpenCode produce one. Not: title, status.
+
+**Census** — Main's answer to "what would this close or quit kill": busy process names, busy
+pane count, and every unsaved document. A reading that fails is refused, never treated as
+empty. Not: busy check.
+
+## Files and browser
+
+**File explorer** — The dock's tree of the workspace root. A click opens a preview tab, a
+double-click a kept tab; the document renders on the stage. Electron only.
+Not: editor, file sidebar.
+
+**Preview tab** — A workspace's one italic file tab, replaced in place by the next single
+click; promoted to a kept tab by a double-click or the first edit. Not: temporary file.
+
+**Rendered view** — A markdown document shown as a read-only picture of its live buffer;
+⌘⇧V flips it to source. Not: preview.
+
+**Browser tab** — A chip on the strip whose surface is a native `WebContentsView`, hidden
+whenever DOM chrome paints over the stage. Electron only. Not: panel, webview.
+
+**Grab** — A snippet react-grab copied from the browser page. It stops at the clipboard today;
+the paste path never submits. Not: paste, prompt.
+
+## Sessions
+
+**Session journal** — `session.json`, continuously written from every window's live tabs,
+debounced one second, plus a per-workspace archive. Not: closed tab snapshot.
+
+**Session restore** — At launch, reopening the journaled tabs and typing each built-in
+pane's exact resume command, behind a crash-loop marker and a liveness pass.
+`Settings.restoreSessions` is the kill switch. Not: closed tab snapshot, history.
+
+**Session history** — The dock's third tab and the board's "Resume a previous session…":
+Claude Code and Codex conversations found on disk, each resumable into a new tab.
+Not: session restore.
+
+**Remembered cluster** — A rail header for a workspace with nothing open, kept from the
+workspace history so its `+` can launch into it. Not: archived session.
+
+## Chrome
+
+**Open board** — The start surface: recent workspaces, Open workspace…, Create worktree…,
+Resume a previous session…. One click opens a workspace with its last combo; choosing an
+agent per open is the quick picker's job. Not: settings, quick picker.
+
+**Worktree** — A git worktree: a separate directory checked out on exactly one branch. Deck
+never offers a branch without its worktree. Not: branch, clone.
+
+**Modal** — The one dialog shell (scrim, frame, focus-on-mount, Escape at the document, scrim
+press-and-release) that the quick picker, save-preset dialog, preset editor and consent
+dialog mount into. Not: popup, overlay, full-window screen.
+
+**Overlay guard** — The rank order `pane` < `settings` < `board` < `modal` that decides which
+actions may run while something covers the stage. Not: z-index.
+
+**Performable** — Whether a matched chord may consume its keystroke where the user is; a
+declined chord reaches whatever holds focus. Not: enabled.
+
+**Prompt Board** — The ⌘⇧P popover that pastes a saved template into the pane captured when it
+opened, optionally with Claude Code or Codex skills and subagents referenced, and submits
+only behind a triple gate. Not: quick launch, composer.
+
+**Theme mode** — Light or Dark, the whole of Appearance's theme choice. The theme gallery,
+colour overrides and file import still build and resolve stored ids but mount nowhere.
+Not: theme gallery.
+
+**Quit** — Exiting Deck: ⌘Q, or the last window closing on Windows. Closing the last tab does
+not quit and does not close the window; it raises the Open board. Not: close tab.

--- a/docs/internals/glossary.md
+++ b/docs/internals/glossary.md
@@ -99,8 +99,10 @@ quick picker, reopen, presets, rail drop and session restore. Not: restore, open
 then agents as rows picked by click or digit. Spawns one pane in the active tab's live cwd.
 Not: Open board.
 
-**Busy** — A pane whose foreground process is not an idle shell (an agent, `vim`, anything).
-The close and quit census asks about busy panes. `unknown` is neither busy nor idle.
+**Busy** — A pane whose foreground process was classified as something other than an idle
+shell (an agent, `vim`, any known non-shell process). The close and quit census asks about
+busy panes. A pane whose process could not be classified is `unknown`, which is neither busy
+nor idle, so the census refuses rather than guesses.
 Not: running, working.
 
 **Agent phase** — The live per-pane work signal: `unknown`, `idle`, `working`, `exited`, from

--- a/docs/internals/overview.md
+++ b/docs/internals/overview.md
@@ -1,0 +1,152 @@
+# Architecture overview
+
+SpaceVibe Deck is an Electron desktop terminal for running several AI agent CLIs side by
+side. The main process (`electron/`) owns everything the renderer cannot: PTYs, the process
+table, windows, persistent stores, the native menu, the updater, usage analytics, git
+worktrees and agent session lookup. The renderer (`src/`) is Preact plus xterm.js, and reaches
+the host only through the facades in `src/host/`.
+
+## Two hosts, one renderer
+
+`main` still carries a second host, the Tauri 2 + Rust app under `src-tauri/`. It is
+**feature-frozen**: releases ship Electron on both platforms, `release.yml` builds Tauri only
+by hand from a tag that already shipped, its last version is 0.12.3, and its updater endpoint
+now answers 404. It stays in the tree because a hotfix must remain possible and because CI
+still compiles and tests it. New product features land on Electron so they are not
+implemented twice. See [release.md](../operations/release.md#tauri-hotfix).
+
+Consequences for anyone reading `src/`:
+
+- A renderer change reaches both hosts. A feature that needs a new host command exists only
+  on Electron; the renderer degrades on Tauri through an `available` flag rather than a
+  separate Tauri implementation.
+- Command and event names are **identical** to the Tauri build's, so the renderer's call
+  sites and tests did not change with the host.
+- Electron-only channels are the majority now: session restore and tails, repositories and
+  worktrees, the file explorer, the browser tab, themes, session history, external apps,
+  telemetry, the updater and GitHub star. Both hosts share the PTY surface, `pty_info`,
+  `git_branch`, `dirs_exist`, `detect_agents`, `resolve_paths`, `open_editor`,
+  `usage_snapshot`, the store, dialog, shell and window facades, and the quit and
+  window-close protocol.
+
+## Process model
+
+**Main** ([`electron/main.ts`](../../electron/main.ts)) keeps two rules: the quit and
+window-close census is computed in main from live PTY state, so a wedged webview cannot make
+quit unanswerable; and every pane command validates ownership through the coordinator
+before it touches a session. Windows are `BrowserWindow`s with `contextIsolation`, no node
+integration, a preload, and `will-navigate` and `window.open` denied, because a navigation
+would re-inject the host bridge into whatever just loaded. On Windows a single-instance lock
+keeps two processes from sharing one `userData`.
+
+| Directory              | Owns                                                                              |
+| ---------------------- | --------------------------------------------------------------------------------- |
+| `electron/pty/`        | node-pty sessions, output batching, the streaming UTF-8 decoder, `pty_info`      |
+| `electron/platform/`   | Process classification, the `ps` / WMI snapshot, kill, shell launch per platform |
+| `electron/coordinator.ts`, `window-lifecycle.ts`, `quit-flow.ts`, `dirty-registry.ts` | Pane → window routing, transfers, labels, the census and its flights |
+| `electron/menu.ts`, `menu-state.ts` | The macOS menu built from the action registry at runtime                   |
+| `electron/store.ts`, `settings-merge.ts`, `settings-ipc.ts` | JSON stores in `userData`, write locks on unreadable files, the settings patch |
+| `electron/fs/`         | Path guard, reads, atomic writes, directory watches, workspace containment        |
+| `electron/browser/`    | The `WebContentsView`, URL policy, react-grab injection                          |
+| `electron/resume/`, `sessions/` | Session scanners per agent, resume resolution, session tails, history  |
+| `electron/usage/`      | Token-usage scanner (a port of the Rust one, held equal by a golden fixture)     |
+| `electron/updater/`    | electron-updater lifecycle and the cross-window check flight                     |
+| `electron/telemetry/`  | Consent state, day buffers, the daily POST                                       |
+| `electron/git.ts`, `worktrees.ts`, `git/worktree.ts` | `git_branch`, repository scans, `git worktree add` via `execFile` |
+| `electron/agents.ts`, `links.ts`, `external-apps.ts`, `images.ts`, `prompt-assets.ts`, `github-star.ts`, `themes.ts` | Discovery, path resolution, external apps, images, prompt assets, `gh`, the themes folder |
+| `electron/ipc/`        | The channel table and one `register-*.ts` per service                            |
+
+**Renderer** ([`src/main.tsx`](../../src/main.tsx)) boots in a fixed order: desktop
+environment, the window's boot mode (normal or adopting a transferred pane, read before
+anything renders), settings, store-failure listener, then presets, workspaces,
+repositories, logo, banner and custom themes in parallel, then `render`. Custom themes are
+awaited before first paint so an imported theme cannot flash.
+
+| Directory           | Owns                                                                                   |
+| ------------------- | -------------------------------------------------------------------------------------- |
+| `src/host/`         | One facade per host service, built from the preload's two functions                    |
+| `src/terminal/`     | `TabManager`, `TerminalManager`, panes, layout, materialization, launch, attention, keymaps, the journal and restore |
+| `src/ui/`           | The shell: `App`, the rail, the strip, the dock, modals, settings, toolbar             |
+| `src/files/`        | File surfaces, the explorer tree, the editor, the rendered markdown view               |
+| `src/browser/`      | The browser tab's store and grab delivery                                              |
+| `src/links/`, `src/lib/terminal-links.ts` | Path detection and external-app routing                          |
+| `src/open-board/`   | The start surface: recents, the worktree form                                          |
+| `src/launcher/`, `src/prompts/` | The new-task prompt composer (partially wired) and the Prompt Board        |
+| `src/settings/`, `src/presets/`, `src/repositories/`, `src/sessions/`, `src/usage/`, `src/telemetry/`, `src/updater/` | Stores and pure models per feature |
+| `src/lib/`          | Pure helpers: the agent catalog, launch profiles, split tree, colour derivation, keybindings, strip order |
+| `src/chrome/events.ts` | Window-scoped chrome signals (board, settings, picker, path-open requests)           |
+| `src/styles/`       | The one stylesheet, numbered partials imported in cascade order                        |
+| `src/gallery/`      | The design gallery, a second Vite entry that must never enter the shipping bundle      |
+
+State is Preact signals; module stores are window-scoped (R5).
+
+## The bridge and its contract
+
+The preload exposes exactly two functions on `window.__deckHost`, `invoke(channel, payload)`
+and `listen(event, handler)`, mirroring Tauri's `invoke` / `listen`. `invoke` refuses any
+channel outside `INVOKABLE_CHANNELS`, the closed set of
+[`CHANNELS`](../../electron/ipc/channels.ts) plus the eighteen plugin-derived names; an open
+bridge in a `sandbox: false` renderer was one injected script away from `spawn_shell` plus
+`write_pty`. `listen` returns an unlisten function and drops the Electron event object.
+
+- **Payloads are flat (R6).** Where the frozen contract sends flat keys, handlers destructure
+  flat keys. [`scripts/electron-ipc-contract.test.ts`](../../scripts/electron-ipc-contract.test.ts)
+  scrapes both sides and fails when a handler reads a key the renderer never sends or the
+  renderer invokes a channel nothing registers. Both sides are typed separately, so this is
+  the only place a mismatch shows before the running app.
+- **Host detection is one presence check.** `available` in
+  [`worktree-host.ts`](../../src/host/worktree-host.ts) (and its twins) reads
+  `globalThis.__deckHost` directly: Electron true, Tauri and the browser preview false. A
+  facade that can degrade answers null or an empty list; one that cannot throws
+  "Deck host bridge is unavailable", which is what a browser-only `npm run dev` shows on
+  every host call.
+- **Requests, not replies, bound batched answers.** A facade that sends N requests walks its
+  own N when decoding, so a host answering with a different length cannot change how many
+  panes get an answer.
+- Events are colon-namespaced (`pty:output`, `settings:merged`, `fs:changed`,
+  `browser:state`, `telemetry:state-changed`, `store:write-failed`); commands are snake_case.
+
+## Persistence
+
+Everything lives under `app.getPath("userData")` (`SpaceVibe Deck` for the release identity).
+The renderer may open only the allowlisted stores `settings.json`, `workspaces.json`,
+`presets.json`, `logo.json`, `workspace-logos.json`, `sidebar-banner.json`,
+`update-attempt.json`, `repositories.json` and `session.json`. `telemetry.json` and
+`usage-cache.json` are main-only on purpose, and `themes/` is read as text.
+
+- A store that parses to a non-object, or fails to read for any reason but `ENOENT`, is
+  **unreadable and write-locked**: a failed read never becomes permission to overwrite
+  recoverable bytes with defaults. Settings' Retry re-reads it.
+- The settings patch is a shallow top-level merge that drops three named retired keys and
+  nothing else, then broadcasts `settings:merged` to every window including the sender,
+  which is the one authoritative path; the reply exists only to detect a failed write.
+- Every write is atomic through one implementation in `electron/fs/write.ts`.
+- `saveAll` on quit uses `allSettled`, so one failing store cannot skip the rest.
+
+## Load-bearing seams (R4)
+
+These modules require a plan and cross-boundary verification, not a drive-by refactor:
+
+- PTY ownership and process classification (`electron/pty/`, `electron/platform/`).
+- The window coordinator and transfer protocol (`electron/coordinator.ts`).
+- Tab materialization (`MaterializeIntent`, `TabManager.materialize`, `AgentLauncher`).
+- Layout (`split-tree.ts`, `layout-engine.ts`).
+- Close and quit coordination (`quit-flow.ts`, `close-coordinator.ts`, the census).
+- The `SurfaceStrip` seam between `TabManager` and the file and browser stores.
+- `ManagerCallbacks` between `TerminalManager` and the tab layer.
+
+Each is described in [terminal.md](terminal.md), [file-surface.md](file-surface.md) and
+[agent-rail.md](agent-rail.md).
+
+## Other fixed points
+
+- The macOS menu is derived from [`action-registry.ts`](../../src/terminal/action-registry.ts)
+  at runtime on Electron and generated into `src-tauri/src/menu_registry.rs` for Tauri; the
+  registry is edited, never the output (R3).
+- Chrome styling follows the numbered rules in [`DESIGN-LANGUAGE.md`](../DESIGN-LANGUAGE.md),
+  cited from code and parsed by a test (R2). That file does not move.
+- Every icon comes from `@phosphor-icons/react` through one `DeckIcon` primitive; CSS never
+  sets an icon's geometry.
+- Everything in the repository is English (R1).
+- `marketing/` shares the renderer's components and a virtual clock for its stage and video,
+  ships nothing into the app, and has no lint signal of its own.

--- a/docs/internals/session-restore.md
+++ b/docs/internals/session-restore.md
@@ -1,0 +1,81 @@
+# Session restore
+
+On launch Deck reopens the tabs that were open at quit and resumes each built-in agent's
+conversation. Electron only: the lookup channel has no Tauri counterpart.
+`Settings.restoreSessions` (default on) is the kill switch.
+
+## The journal
+
+[`session-journal.ts`](../../src/terminal/session-journal.ts) mirrors every window's live
+tabs into `session.json` continuously, debounced 1 second, so the file is current at a hard
+power-off rather than only at a clean quit.
+
+- Keys: `windowLabels` (the store has no list-keys primitive), `window:<label>` records,
+  `archive` (per-workspace, the rail's remembered rows) and `restoreAttempt` (the marker).
+- A `WindowRecord` holds `savedAt`, `activeTabIndex`, `tabs`, `files` and `activeFileTab`.
+  Each `SessionTab` holds `workspacePath`, `layout`, `panes`, `name` and `dotColor`; each
+  `SessionPane` holds `cwd`, `agent` and `launchCommand`. The journal stores the **command**,
+  not a preset id, so editing or removing a preset cannot rewrite a running session.
+- Caps: 32 tabs per window and 24 archived workspaces, enforced on the write path too.
+- A write is skipped when the record minus `savedAt` is unchanged. `capture()` reads the
+  2-second poll cache with no IPC and no awaits: that is the deliberate accuracy bound.
+- Restore suspends the journal so it cannot clobber what it is reading; quit flushes it with
+  `force`, because the quit flow suspends first and an unforced flush was a no-op.
+- A deliberate window close clears that window's record, so a closing window's tabs cannot
+  resurrect as ghost tabs on the next boot.
+
+## Boot restore
+
+[`session-restore.ts`](../../src/terminal/session-restore.ts) runs from `App`, not from
+`TabManager`.
+
+1. **Crash-loop marker.** If `restoreAttempt` is already set, a previous attempt never
+   finished: clear it and skip restoring this boot. Otherwise set it, and clear it in
+   `finally`.
+2. **Order.** The main window's tabs in order, then every other window's record newest
+   first; a detached window's tabs fold into the main window.
+3. **Liveness.** One `dirs_exist` call over every workspace path and pane cwd. A tab whose
+   workspace is gone is dropped; a pane whose cwd is gone gets a null cwd and skips the
+   lookup, because a stale cwd sent into a scanner that ranks by cwd match produces a wrong
+   or wasted match.
+4. **One batched `resume_lookup`** with one `{ agent, cwd, lastSeenAt }` per surviving
+   built-in-agent pane, answered positionally.
+5. **Materialize** each tab sequentially through `MaterializeIntent.paneCommands`, so each
+   pane types its own resume command. A tab that throws is skipped and the rest continue.
+6. Secondary window records are cleared **before** files and tab selection are restored, so
+   a throw there cannot leave a stale record to fold in twice on the next boot.
+
+Scrollback, unsaved edits and window placement never restore. The rail's remembered rows use
+the same core for one workspace, without the marker.
+
+## Resolving a conversation
+
+[`electron/resume/resolve.ts`](../../electron/resume/resolve.ts) answers each request with an
+exact id, `latest`, or nothing, and never rejects.
+
+| Agent          | Scan                                                        | Answer                                   |
+| -------------- | ----------------------------------------------------------- | ---------------------------------------- |
+| `claude`       | `~/.claude/projects/<project>/*.jsonl`, files directly in the project dir | exact id, else nothing      |
+| `codex`        | Codex rollouts, interactive sources only, archived included | exact id, else nothing                   |
+| `opencode`     | `opencode.db` via `node:sqlite` first, then the legacy JSON tree, deduplicated by id; sub-agent sessions excluded | exact id, else nothing |
+| `gemini`       | none                                                        | always `latest`                          |
+| `agy`          | `~/.gemini/antigravity/conversations/*.pb` head bytes       | best-effort id, else `latest`            |
+| `cursor-agent` | none                                                        | nothing; relaunches bare                 |
+| custom         | none                                                        | the declared command, unchanged          |
+
+- Candidates within 30 days of `lastSeenAt` whose cwd matches are ranked by mtime proximity;
+  a candidate is marked taken on selection, not on success, so two panes cannot resume the
+  same conversation. Scans cap at 300 files and 64 KiB of head per file.
+- The command comes from `COMMAND_TABLE` in [`agent-resume.ts`](../../src/lib/agent-resume.ts):
+  `claude --resume <id>` / `--continue`, `codex resume <id>` / `--last`,
+  `opencode -s <id>` / `-c`, `gemini --resume latest`, `agy --conversation <id>` /
+  `--continue`, `cursor-agent --resume <id>`. An id is checked against
+  `SESSION_REF_SAFE` (`[A-Za-z0-9._-]{1,128}`) in the one place before it can reach a PTY
+  write; a failing id degrades to the bare command.
+- Only `claude` is re-flagged on restore: the pane's own recorded `launchCommand` is the
+  source, not the preset's current text, and the flags sit beside `--resume`.
+- Session history (the dock's third tab and the board's "Resume a previous session…") lists
+  Claude Code and Codex only, newest 500 per agent by default, titles read from the file
+  head in batches of 8 with a `setImmediate` breath so the main process keeps serving PTYs.
+  A history row refuses to resume unless the built command actually contains the session id,
+  because a degraded bare command would silently open a new conversation.

--- a/docs/internals/telemetry.md
+++ b/docs/internals/telemetry.md
@@ -1,0 +1,88 @@
+# Usage analytics
+
+Deck sends one small usage snapshot per day, on by default, and the only state it never
+infers away is an explicit "off". This page is the contract: what leaves the machine, who
+owns the state, and when a POST fires. Electron only: the Tauri host sends nothing.
+
+## The payload
+
+[`src/telemetry/payload.ts`](../../src/telemetry/payload.ts) is the one readable statement of
+what a participating install sends, and its snapshot test is the privacy contract in
+executable form: adding a field turns it red. `schemaVersion` is 1.
+
+| Field              | Meaning                                                                 |
+| ------------------ | ----------------------------------------------------------------------- |
+| `dailyId`          | A fresh random UUID v4 per local day, unrelated to every other day      |
+| `day`              | The client's local calendar day, `YYYY-MM-DD`, not a timestamp          |
+| `version`          | Deck's version                                                          |
+| `platform`, `arch` | `darwin` / `win32`, `arm64` / `x64`                                     |
+| `agents`           | Launches that day keyed by the closed set `claude`, `codex`, `opencode`, `agy`, `gemini`, `cursor-agent`, `custom` |
+| `surfaces`         | Times the `browser`, `explorer` and `usage` surfaces went from hidden to visible |
+| `maxTabs`, `maxPanes` | The busiest single window's high-water marks that day                |
+| `restoredSessions` | Whether boot restore materialized at least one pane                     |
+
+Deliberately absent: a permanent install identifier, file paths, repository names, branch
+names, file names, terminal output, prompts, agent replies, hostname, username, locale,
+timezone, and any per-action timestamp. Every custom agent folds into the single `custom`
+bucket in the renderer before anything leaves it, because a custom agent's name is a string
+the user typed. Public copy never calls the payload "anonymous"; the copy test pins that word
+out.
+
+## Ownership
+
+- **Consent lives in main, in `telemetry.json`,** not in the settings schema, so a copied
+  `settings.json` can never carry a consent choice, and the file is outside the renderer's
+  store allowlist so no daily id is ever one `store_get` away.
+  [`electron/telemetry/model.ts`](../../electron/telemetry/model.ts) and
+  [`service.ts`](../../electron/telemetry/service.ts) own it.
+- **Main re-validates every count** against the same closed key sets the renderer uses; a
+  parity test pins the two lists together. The renderer is not the trust boundary.
+- **The renderer counts edges.** [`usage-counters.ts`](../../src/telemetry/usage-counters.ts)
+  treats surface visibility as a transition with a seeded first tick, so a dock that was
+  persisted open reads as state, not as an open; tabs and panes are gauges folded into a
+  per-day maximum.
+- Three flat channels: `telemetry_count` (fire and forget), `telemetry_state` (also the
+  "a window is ready" signal) and `telemetry_set_enabled`; one broadcast event,
+  `telemetry:state-changed`, so every window's Privacy switch moves together.
+
+## State
+
+- `EMPTY_STATE` is `enabled`. `parsePersisted` folds every stored spelling except
+  `declined` into `enabled`: a missing field, garbage, or an opt-in-era `unanswered` all
+  read as on. `USAGE_CONSENT_ASKED` in
+  [`usage-notice.ts`](../../src/telemetry/usage-notice.ts) is `false`, so the consent modal
+  mounts nowhere; it stays in the tree behind that constant.
+- **Unreadable fails closed.** When `telemetry.json` exists but cannot be read, consent reports
+  `unreadable`, nothing counts, nothing sends, `setEnabled` throws, and Deck neither guesses
+  nor overwrites the file. Settings → Privacy says so and tells the user to repair the file
+  and restart, because it is read once at launch.
+- **Off means off.** `setEnabled(false)` stops the timer, replaces the state with
+  `declined` and an empty day map (every unsent buffer and daily id deleted), then flushes.
+- Counters cap at 1,000,000 so a runaway loop cannot push the body past the server's 4 KB
+  limit. Days are keyed by the local calendar day, and at most 7 pending days are kept.
+
+## When a POST fires
+
+The endpoint is `https://api.deck.spacevibe.dev/v1/ping`, POSTed as JSON with a 5-second
+timeout by [`register-telemetry.ts`](../../electron/ipc/register-telemetry.ts).
+
+- At boot when enabled, and once when the first window reports ready.
+- On a 15-minute timer (`unref`'d, so it never keeps the process alive): a dirty buffer sends
+  after 15 minutes since the last send; an unchanged one sends as a 6-hour heartbeat.
+- Immediately on `setEnabled(true)`.
+- On quit and before an update install, as a best-effort final snapshot bounded by the
+  timeout, so quit cannot hang on a dead Worker.
+
+Every send replaces the whole day row server-side, so a retry cannot double-count. A network
+failure keeps the buffer and waits for the next check, with no backoff and no fast retry.
+A 2xx clears `dirty` only if the buffer object was not replaced mid-flight; a past day is
+deleted outright. A 400 or 413 marks the buffer terminal and it is never resent; every other
+status keeps it under the seven-day cap.
+
+## Privacy surface
+
+Settings → Privacy ([`privacy-section.tsx`](../../src/ui/settings/sections/privacy-section.tsx))
+is a view over `telemetry.json` reached through `telemetry_state`: one switch, "Share usage
+stats", disabled while loading, unavailable or unreadable, plus the disclosure in plain words
+and a link to `USAGE_PRIVACY_URL`. A failed write surfaces through the persist-error bar; the
+UI never claims a change main did not keep.

--- a/docs/internals/terminal.md
+++ b/docs/internals/terminal.md
@@ -1,0 +1,219 @@
+# Terminal, panes and tabs
+
+The stage is a set of tabs, each a split tree of panes, each pane one xterm.js instance bound
+to one PTY that the main process owns. This page covers the PTY manager and its ownership
+model, the tab and layout layer in the renderer, how a tab is materialized and an agent
+launched into it, how a pane's phase and attention are derived, and the close, quit and
+window-transfer protocols. The vocabulary is in [glossary.md](glossary.md).
+
+## PTY ownership (main)
+
+[`electron/pty/manager.ts`](../../electron/pty/manager.ts) spawns and owns every PTY.
+Ids are process-local integers from 1, never reused.
+
+- **Every pane command validates ownership through the coordinator first.** `write_pty`,
+  `resize_pty` and `kill_pty` call `assertOwner(paneId, windowLabel)`; a pane routed to
+  another window, or one mid-transfer, is refused with a `PaneAccessError`. Output is
+  delivered by `coordinator.deliver`, which drops (never broadcasts) an event with no route.
+- **Spawn** runs the user's login shell (`$SHELL -l` on macOS; `pwsh.exe` or Windows
+  PowerShell on Windows, which throws rather than falling back to `cmd.exe`) with
+  `TERM=xterm-256color`, `COLORTERM=truecolor`, `TERM_PROGRAM=SpaceVibeDeck` and
+  `encoding: null` so bytes arrive as Buffers and a streaming UTF-8 decoder can hold back a
+  split code point. `ConEmuANSI=ON` is set on macOS only, so Claude Code emits OSC 9;4.
+  On Windows node-pty ignores the encoding and delivers strings, which the decoder passes
+  through untouched.
+- **Output is batched** ([`stream.ts`](../../electron/pty/stream.ts)): chunks queue up to
+  64 KiB per batch, the source is paused above 512 KiB queued, and batches go out on a
+  microtask. Three events reach the renderer: `pty:output` `{ id, data }`, `pty:exit`
+  `{ id }` and `pty:prompt-ready` `{ id }`.
+- **Main parses exactly two OSC sequences** ([`shell-integration.ts`](../../electron/shell-integration.ts)):
+  `133;B` (prompt ready) and `9;9;<path>` (current directory). At most the last 8 cwd
+  candidates per batch are probed, backwards, and a UNC-shaped root is rejected before any
+  filesystem call, because probing `\\host\share` offers NTLM credentials to that host.
+- **Kill** signals the foreground process group with SIGHUP, then SIGKILL after 500ms, and
+  the shell group outright; groups 0 and 1 are refused. `killAll` reads the process table
+  once for the whole batch. On Windows it is `taskkill /T`, which only walks the tree that
+  exists at call time, so a crashed Deck orphans agents; accepted.
+
+## Process classification
+
+`pty_info` answers `{ id, cwd, process, kind, agent }` per pane
+([`electron/pty/info.ts`](../../electron/pty/info.ts)), where
+`kind` is `idle-shell` / `agent` / `busy` / `unknown`.
+
+- The foreground process is found from a **measured `ps` snapshot**, not node-pty's
+  `.process` getter, which reads a truncated `p_comm` and once answered a version string for
+  a `claude` pane. macOS runs `/bin/ps -A -o pid=,pgid=,tpgid=,tty=,args=` and joins on the
+  pane's tty; `tpgid` names the foreground group. Windows runs one `Get-CimInstance
+  Win32_Process` snapshot and walks the shell's descendant tree, picking the deepest, newest
+  process. Both reads reject rather than answer when the table cannot be read.
+- Classification ([`platform/classify.ts`](../../electron/platform/classify.ts)): a built-in
+  agent by binary name or by the script an interpreter is running, then a user-declared
+  matcher (label as identity), then a shell name → `idle-shell`, otherwise `busy`. An
+  incomplete reading is `unknown`.
+- **`unknown` is neither idle nor busy.** The census treats it as "cannot say", and a failed
+  reading never becomes an empty census.
+- cwd is the live `lsof -d cwd` answer first (macOS only), then the last OSC 9;9 the shell
+  printed. On Windows the injected prompt's OSC 9;9 is the whole cwd story.
+
+## Tabs, panes and layout (renderer)
+
+- **[`TabManager`](../../src/terminal/tab-manager.ts)** owns the tabs: a list of
+  `TabEntry { key, manager, openedAt, workspacePath }`. `workspacePath` is fixed for the
+  tab's life and never re-derived from a pane's cwd. It publishes `tabViews` and
+  `activeTabIndex` ([`tabs-store.ts`](../../src/terminal/tabs-store.ts)); every pane appears
+  in `TabView.panes`, agent or not, and filtering belongs to the surface that renders rows.
+  `syncViews` rebuilds the views from the 2-second pane poll and re-applies name and colour
+  overrides so a rename survives polling.
+- **[`TerminalManager`](../../src/terminal/terminal-manager.ts)** owns one tab's panes and its
+  split tree ([`split-tree.ts`](../../src/lib/split-tree.ts), immutable; every operation
+  returns a new tree). A split or dock takes a **fresh** cwd from `pty_info`, not the poll
+  cache, and assigns `activeId` directly because `setActive` applies ratios to a DOM that
+  does not match the just-split tree yet. `closePane` refuses a pane whose route is
+  transferring: an aborted transfer would return an agent to a window with no UI for it.
+- **[`LayoutEngine`](../../src/terminal/layout-engine.ts)** maps the tree to the DOM: Focus
+  Expand gives the active pane at least 65% along its path, ratios clamp to 15–85%, zoom is an
+  overlay that a structural rebuild drops first, and hit-testing goes through the engine so
+  no consumer queries `.pane-slot` itself.
+- **Pane** ([`pane.ts`](../../src/terminal/pane.ts)): xterm with fit, search, serialize,
+  unicode-graphemes and WebGL addons. WebGL is attempted once at mount; failure or context
+  loss disposes the addon and leaves the DOM renderer, never restarting the pane. `flush()`
+  waits for xterm's write drain so a transfer serializes after every byte landed. Paste is
+  bracketed and `\n` becomes `\r`, the only route that lands a multi-line body in an agent
+  TUI's composer as one block.
+- **Strip order** is one window-wide clock ([`open-sequence.ts`](../../src/lib/open-sequence.ts)):
+  terminal tabs, documents and the browser tab share it, keys are never reused, and
+  [`mergeStripOrder`](../../src/lib/strip-order.ts) is walked by both the keyboard
+  (`TabManager`) and the paint (`TabStrip`), so ⌘1–9 and tab cycling count chips.
+- The closed-tab stack holds 10 snapshots in memory (`layout`, `cwds`, `name`, `dotColor`,
+  `workspacePath`); ⌘⇧T reopens with fresh shells and does not re-run agents.
+
+## Materialization and agent launch
+
+`MaterializeIntent` ([`tab-materialize.ts`](../../src/terminal/tab-materialize.ts)) is the
+one interface behind the Open board, the quick picker, closed-tab reopen, presets, rail drop
+and session restore. `TabManager.materialize` owns the implementation.
+
+| Field           | Contract                                                                                   |
+| --------------- | ------------------------------------------------------------------------------------------ |
+| `layout`, `cwds` | The split tree and one cwd per leaf, left to right; cwd policy is `fresh`, `polled`, `none` or `given` |
+| `agent`         | The agent to type into every pane; `null` for a reopen                                     |
+| `launchCommand` | `undefined` resolves the agent's default preset, `null` forces the bare binary, a string is typed as is |
+| `paneCommands`  | Per-pane commands that override `agent`; session restore's path                            |
+| `workspacePath` | Absent means a tab with no workspace                                                       |
+
+- **An agent is typed, not spawned.** [`AgentLauncher`](../../src/terminal/agent-launch.ts)
+  writes `<command>\r` into the pane's interactive shell once it is ready, so the command
+  inherits the shell's real `PATH`. On macOS readiness is first output, with a 3-second
+  fallback; on Windows only `pty:prompt-ready` counts and a 15-second timeout cancels that
+  pane and reports it. Each pane is typed into exactly once; a failed write leaves a plain
+  shell and never sinks the tab. The launcher's keystrokes count as input so the echo does
+  not light the working spinner.
+- **The command is a string, validated at the door.** `commandProblem` in
+  [`launch-profile.ts`](../../src/lib/launch-profile.ts) refuses separators, substitution,
+  redirects, quotes, globs and newlines, and caps at 200 characters, because the string
+  reaches a live shell verbatim. Resolution order in
+  [`launch-command.ts`](../../src/lib/launch-command.ts): the starred preset, then any
+  preset for the agent, then the catalog's shipped `defaultCommand`, then the bare binary.
+- **The catalog** ([`agent-catalog.ts`](../../src/lib/agent-catalog.ts)): a built-in's id, its
+  binary name and its bare command are the same string, which is what keeps every
+  `lastAgent` on disk resolving. Order is the digit-key contract, so new agents append.
+  Discovery probes `sh -ilc "command -v <name>"` on macOS (interactive and login, because
+  CLIs register `PATH` in rc files) and walks `PATH` with `.cmd`/`.exe` suffixes on Windows.
+  Probe names are restricted to `[A-Za-z0-9._~+/-]`, enforced again in main.
+
+## Agent phase and attention
+
+Two independent axes per pane, both computed in the renderer and both gated on the last
+poll having classified the pane's foreground process as an agent.
+
+- **Phase** ([`agent-activity.ts`](../../src/terminal/agent-activity.ts)):
+  `unknown` / `idle` / `working` / `exited`. OSC 9;4 progress, parsed from every output chunk,
+  is the sole source once a pane has emitted one (state 0 clears; 2 is error; 4 is warning;
+  anything else is working). Otherwise a sustained-output heuristic: at least 400ms of
+  continuous output still fresh within 3 seconds, ignoring output within 300ms of the user's
+  own keystrokes. A process change resets the record so a stale "busy" cannot pin the
+  spinner. A 3.2-second re-sync timer feeds a synthetic idle when activity decays.
+- **Attention** ([`agent-attention.ts`](../../src/terminal/agent-attention.ts)):
+  `none` / `completed` / `requested` / `warning` / `error`, latched until acknowledged and
+  never downgraded. Explicit signals (OSC 9;4 severity, OSC 9 or 777 notifications, the
+  bell) outrank the heuristic, which may only ever produce `completed`. The UI reads
+  attention before phase. `hasRun` separates a pane that finished and was checked (`done`)
+  from one that never ran anything (`idle`).
+- **Acknowledge** clears attention and per-pane unread, never phase. Focus counts only when
+  the window is foreground, the tab is active, and DOM focus rests inside the pane.
+- Notifications dedupe on the latch identity, so only a newly raised or escalated kind is
+  forwarded, and the OSC classifier never carries the payload's title or body text.
+
+## Actions, keymaps and the menu
+
+- [`action-registry.ts`](../../src/terminal/action-registry.ts) is the one list of actions:
+  id, label, scope, menu placement and the `destructive` flag. Keymaps live in
+  [`default-keymaps.ts`](../../src/terminal/default-keymaps.ts) as `MACOS_KEYMAP` and
+  `WINDOWS_KEYMAP`; user rebinds are applied by `active-keymap.ts`.
+- **Bind on whatever the menu accelerator binds on.** An action with a macOS menu item must
+  use a character binding, because a Cocoa accelerator is declared by character; physical
+  (`event.code`) bindings are only for actions with no menu item, which is what makes the
+  bracket and digit chords work on non-US layouts. Ctrl+Alt chords are skipped while AltGr
+  is down.
+- **The overlay guard** ranks open overlays `pane` 0 < `settings` 20 < `board` 30 <
+  `modal` 40 and blocks an action while any open rank is `>=` its scope's rank; `>=` is
+  what makes two modals exclude each other with no extra concept.
+- **A chord that cannot act does not eat the key.**
+  [`action-performable.ts`](../../src/terminal/action-performable.ts) is asked before
+  `preventDefault()`; a false answer leaves the event to whatever holds focus. Three
+  predicates exist: `copy-selection` needs a terminal on the stage; `copy-or-interrupt`
+  (Ctrl+C on Windows) needs a terminal and a selection, and otherwise lets xterm encode the
+  interrupt itself, because Deck writes no `\x03`; `toggle-markdown-view` needs a document
+  that can toggle.
+- **The menu is generated on Tauri and derived at runtime on Electron.**
+  `scripts/generate-menu.ts` writes `src-tauri/src/menu_registry.rs`; `electron/menu.ts`
+  imports the registry directly and builds the native menu on macOS only, installing
+  `null` elsewhere so Electron's default accelerators cannot reload or close the window.
+  Accelerators are suspended app-wide while any window records a shortcut, keyed by sender
+  so a dead window cannot strip them for the rest of the run. The `destructive` actions
+  (`close-pane`, `close-tab`, `clear-buffer`) are suppressed while a chrome text field holds
+  the caret, because a menu event cannot say whether it came from a keystroke or a click.
+
+## Close, quit and the census
+
+- **The census is computed in main from live PTY state**, so a wedged renderer cannot make
+  quit unanswerable. `censusFor` ([`quit-flow.ts`](../../electron/quit-flow.ts)) names busy
+  processes and counts busy panes; `agent` and `busy` are busy, `unknown` makes the census
+  not fully named. A reading that fails yields null, and null is refused, not treated as
+  empty: refusing to close is recoverable, killing an agent on a guess is not.
+- **Window close** always routes through the renderer, even with nothing busy, because the
+  renderer's guard flushes debounced state before it auto-confirms. Order is load-bearing:
+  abort any transfer involving the window first, then census. `CloseFlight` is per window;
+  `QuitFlight` is app-wide, so a second ⌘Q while the dialog is open does nothing.
+- **Quit** asks one window with every window's unsaved files deduplicated, and skips the
+  question only when there are no panes and nothing dirty. With no window to answer it kills
+  the PTYs and exits. `confirm_quit` runs `killAll` → telemetry flush → `saveAll` → exit.
+- **An update install bypasses the census** through `isInstalling()`, because
+  `quitAndInstall` closes every window before `before-quit` and the renderer already
+  confirmed. `prepareForInstall` runs the same three steps.
+- **Renderer-side** ([`close-coordinator.ts`](../../src/terminal/close-coordinator.ts)): ⌘W
+  closes the pane, or the tab when it is the last pane; the busy dialog runs on the final
+  target and the id confirmed is the id closed, re-pinned after the dialog because a
+  `pty:exit` can move focus during it. Tab-level guards never aggregate busy and dirty into
+  one dialog; only window close and quit do. The last tab closing leaves the window on the
+  Open board.
+
+## Moving a pane between windows
+
+The coordinator ([`electron/coordinator.ts`](../../electron/coordinator.ts)) routes every
+pane to exactly one window or to an in-flight transfer.
+
+1. `prepare_transfer` moves the route to `transferring`; output buffers up to 4 MiB.
+2. The source serializes the pane (after `flush()`) and `stage_transfer`s the payload.
+3. `open_pane_window` (flat `{ token, screenX?, screenY? }`) or `offer_transfer` names the
+   destination; the destination `claim`s the payload and `commit`s.
+4. Buffered events flush in order, then `transfer:settled` reaches both sides and the route
+   is re-owned. Abort, a 10-second timeout, a full buffer or a dead destination settle as
+   aborted and return the pane to the source; a dead source does not abort.
+
+`paneId` crosses `prepare_transfer` as a string and is coerced; `offer_transfer` sends
+`targetLabel`; `open_pane_window` takes its arguments flat. All three shapes are frozen by
+[`scripts/electron-ipc-contract.test.ts`](../../scripts/electron-ipc-contract.test.ts).
+A window's `close` aborts transfers involving it before anything else; `closed` terminates
+the panes it still owned.

--- a/docs/internals/traps.md
+++ b/docs/internals/traps.md
@@ -1,0 +1,96 @@
+# Known traps and live switches
+
+Things that have bitten this codebase and are not obvious from reading one file, plus the
+constants that currently switch behaviour off and are meant to be flipped back.
+
+## Layout and CSS
+
+- **`#root` is `overflow: clip`, not `hidden`.** `hidden` still builds a scroll container, so
+  the first `scrollIntoView` the browser runs on focus shifted the traffic lights, the strip
+  and every fixed thing up with nothing to scroll them back. Treat "the top bar looks
+  misaligned" as a scroll report.
+- **There is no global `box-sizing` reset.** `width: 100%` beside a padding overflows its box.
+  Form controls get `border-box` from the user agent; a plain element does not, which is how
+  `.session-row` grew a horizontal scrollbar the moment it stopped being a `<button>`.
+  Declare it on any element you give a percentage size and a padding.
+- **A 1px overflow in the rail moves the whole column.** `.asr-rail__list` clips
+  horizontally without removing the scroll container, so a border bled by `margin: 0 -1px`
+  slid the column on the first focus. The multi-agent frame is an inset `box-shadow` for
+  this reason: it paints inside, needs no layout and clips nothing.
+- **`.iconbtn` never resets the user agent's button padding**, so every icon in one sits
+  1.5px left of centre: the grid track is 12px against a 15px glyph, and Chromium clamps
+  the negative offset. The rendered view's toggle carries its own `padding: 0`; the app-wide
+  fix has not been made.
+- **A custom scrollbar does not repaint when only the scroller's `:hover` flips.** The
+  app-wide thumb is transparent at rest and lit through `*:hover::-webkit-scrollbar-thumb`,
+  and that rule never reaches the screen: Chromium repaints a custom scrollbar on its own
+  state change or an inherited property change, not on the originating element's hover.
+  Every scroll surface is effectively thumbless until the pointer lands on the 6px strip;
+  only `.md-doc` declares a resting colour.
+- **A shorthand holding `var()` restarts its animation on any global style recalc.** Put
+  `var()`-carrying animation values on the longhands.
+- **`src/styles.css` is an import index whose order is the cascade.** Several rules rely on
+  position, not specificity. Add rules inside the partial, never in the index, and note
+  that the design-language test concatenates the partials in that order.
+- **Props on the element `DesktopChrome` returns are applied on mount and never updated.**
+  The sidebar's live width and collapsed flag are written to `:root` imperatively to
+  sidestep it.
+
+## Hosts and evidence
+
+- **The app running an update is the old build.** An updater fix cannot protect the
+  transition into the release that carries it.
+- **Two hosts means two answers.** A renderer change that passes under Electron says nothing
+  about Tauri. Name the host a change runs on rather than implying both.
+- **Green unit and build checks are not native evidence.** They say nothing about PTYs, menu
+  accelerators, window close, the updater or packaging on real hardware, and nothing about
+  Windows, where no owner has run a real-hardware pass.
+- **Browser `npm run dev` paints the shell because IPC failures are caught.** It cannot prove
+  persistence, PTY, updater or packaging behaviour.
+- **Only the macOS menu is native.** Electron installs no menu on other platforms, so every
+  chord there is a renderer binding; a macOS menu-bound chord (Find, Clear Buffer, zoom) is
+  consumed by Cocoa before a document can see it.
+- **`windows-check` in CI has pre-existing failures** unrelated to the Electron host, which is
+  why the Windows packaging job is deliberately not gated on it.
+
+## Data and contracts
+
+- **A store that cannot be read is write-locked.** Do not "fix" an unreadable file by
+  writing defaults over it; the lock exists so recoverable bytes survive.
+- **`CHANGELOG.md` is machine-read** by the release workflow. Its `## <version>` headings and
+  its location are part of the release contract.
+- **`docs/DESIGN-LANGUAGE.md` is read by a test at runtime.** Moving, renaming or trimming
+  a cited rule breaks `npm test`.
+- **IPC payloads are typed separately on each side.** A key the handler destructures and the
+  renderer never sends is green everywhere but the running app; the contract test is the
+  only early signal. Keep flat keys where the contract is flat.
+- **`open_pane_window`, `prepare_transfer` and `offer_transfer` have frozen shapes:** flat
+  arguments, a string `paneId`, and `targetLabel`. Two of the three shipped broken once.
+- **`node-pty` delivers strings on Windows** whatever encoding you ask for, and it ignores
+  `encoding: null`; the streaming decoder passes strings through. Handing one to
+  `TextDecoder.decode` throws inside node-pty's emitter and kills the main process.
+- **The spawn helpers lose their executable bit** on install; the postinstall restores it and
+  the only symptom otherwise is `posix_spawnp failed`.
+- **`marketing/**` has no lint gate.** It is in `.prettierignore` and oxlint's ignore list, so
+  a "prettier clean" claim over that tree is vacuous. It also shares application components
+  and a virtual clock, so a component change can silently alter rendered media.
+- **`npm run refresh:pricing` reaches the network** and must never run from a build.
+- The Rust and Electron usage scanners are held equal by a golden fixture that must be
+  regenerated from the Rust side, never from the port's own output.
+
+## Live switches
+
+Each is one typed constant whose other branch is kept in the tree on purpose, so reverting
+is flipping it back. They are typed `boolean` rather than left as literals so a dead-code
+pass cannot delete the half they exist to keep.
+
+| Constant                   | Where                                                             | Currently | Effect                                                                                  |
+| -------------------------- | ----------------------------------------------------------------- | --------- | --------------------------------------------------------------------------------------- |
+| `GRAB_PASTE_DISABLED`      | [`src/browser/browser-store.ts`](../../src/browser/browser-store.ts) | `true`  | A browser grab stops at the clipboard and is never pasted into a pane                   |
+| `MIGRATION_NOTICE_ENABLED` | [`src/updater/migration-notice.ts`](../../src/updater/migration-notice.ts) | `true` | Tauri builds show the "this build no longer updates itself" row                       |
+| `USAGE_CONSENT_ASKED`      | [`src/telemetry/usage-notice.ts`](../../src/telemetry/usage-notice.ts) | `false` | No consent question is asked; analytics is on by default and the modal mounts nowhere |
+| `PANE_TREE_HIDDEN`         | [`src/ui/agent-rail.tsx`](../../src/ui/agent-rail.tsx)             | `true`    | A multi-agent tab renders flat framed rows instead of a parent row with elbow guides    |
+
+Two more retirements follow the same pattern without a constant: the theme gallery, colour
+overrides and theme import are unmounted from Settings but still build and still resolve a
+stored id; and `RepositoryRail` is mounted only in the gallery.

--- a/docs/operations/development.md
+++ b/docs/operations/development.md
@@ -1,0 +1,117 @@
+# Development
+
+How to build, run, test and check the repository. Architecture is in
+[`../internals/`](../internals/overview.md); cutting a release is in [release.md](release.md).
+
+## Prerequisites
+
+Node.js 22 (what CI runs) and the native toolchain `node-pty` needs on your platform. The
+Rust toolchain is required only to build the frozen Tauri host or to run its tests.
+`npm ci` runs a postinstall that restores the executable bit on node-pty's spawn helpers,
+whose only symptom when lost is `posix_spawnp failed`.
+
+## Commands
+
+| Command                              | What it does                                                                                                   |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| `npm run electron:dev`               | Build the renderer and the main process, then launch Electron from `dist-electron/`                            |
+| `npm run electron:dev:watch`         | Same host with hot reload: the renderer loads the Vite dev server, main rebuilds and relaunches on save         |
+| `npm run dev`                        | Browser-only Vite preview of the renderer; every IPC call fails soft                                            |
+| `npm run tauri dev`                  | The frozen Tauri host                                                                                          |
+| `npm test`                           | The Vitest suite                                                                                               |
+| `npm run build`                      | `tsc` over `src/` plus the shipping renderer bundle                                                            |
+| `npm run electron:build`             | `tsc -p tsconfig.electron.json` plus the CommonJS rename pass; this is the whole typecheck of `electron/`       |
+| `npm run lint`                       | oxlint, then `prettier --check`                                                                                |
+| `npm run generate:menu`              | Regenerate `src-tauri/src/menu_registry.rs` from the action registry                                           |
+| `npm run generate:menu:check`        | Fail if the generated file is stale                                                                            |
+| `npm run electron:package`           | Local unsigned `Deck Electron.app` (arm64, `dir` target) in `dist-electron-app/`                               |
+| `npm run electron:package:release`   | The shipping config: signing preflight, signed and notarized, published nowhere                                 |
+| `npm run electron:package:monaco-smoke` | The packaged Monaco regression smoke (universal, unsigned)                                                  |
+| `npm run electron:verify:monaco-smoke` | Verify that package's structure and drive it over CDP                                                        |
+| `npm run electron:smoke`             | Headed smoke of the real bridge; needs a display and a real PTY                                                |
+| `npm run shoot`                      | Screenshot the running app through `webContents.capturePage`                                                   |
+| `npm run prototype:gallery`          | The chrome gallery at `127.0.0.1:5175`, mounting real components through `src/gallery/`                        |
+| `npm run refresh:pricing`            | Rewrite the usage pricing snapshot from LiteLLM. By hand only, never from a build                              |
+| `npm run build:landing`              | The landing production build                                                                                   |
+| `npm run video:render`               | Render the marketing video from the DOM stage                                                                  |
+
+`predev` and `prebuild` run `generate:menu`, so a plain `npm run build` always regenerates
+the Rust registry first.
+
+## CI
+
+[`ci.yml`](../../.github/workflows/ci.yml) runs on every push to `main`, every pull request,
+and by hand.
+
+- `check` (ubuntu): `generate:menu:check`, `lint`, `test`, `build`, `electron:build`,
+  `cargo fmt --check`, `cargo test`.
+- `windows-check` (windows): the same without lint, plus the Windows bundle validator's own
+  test and `tauri build --no-bundle`. `npm test` there spawns a real ConPTY through
+  `electron/pty/windows-pty.test.ts`.
+- Two `workflow_dispatch`-only packaging jobs: a Tauri Windows engineering bundle that
+  refuses to run in a public repository, and the unsigned Electron Windows preview, kept as
+  7-day artifacts.
+
+Lint is oxlint with `correctness` as errors and `max-lines` at 300 as a warning, so the
+over-length files that predate the rule stay a visible backlog without failing the build.
+Prettier ignores every `*.md`, `electron/vendor/**`, `marketing/**`, test fixtures and the
+generated pricing snapshot. `marketing/**` is also outside oxlint's scope, so no lint signal
+covers that tree.
+
+## Tests
+
+Vitest with the `node` environment by default; component tests opt into jsdom with an
+`@vitest-environment jsdom` pragma. `npm test` excludes two `node:test` suites (run with
+`npm run test:updater-manifest` and in CI directly) and the superseded Tauri IPC contract
+test, which stays untouched until `src-tauri/` goes.
+
+Tests that guard a repository rule rather than a module:
+
+- [`scripts/electron-ipc-contract.test.ts`](../../scripts/electron-ipc-contract.test.ts):
+  every payload key a main handler destructures is one the renderer sends, and every channel
+  the renderer invokes has a handler. Both sides are typed separately, so a key mismatch is
+  green everywhere else and fails only in the running app.
+- [`scripts/design-language.test.ts`](../../scripts/design-language.test.ts): parses
+  `src/styles.css` through its `@import` index and reads
+  [`docs/DESIGN-LANGUAGE.md`](../DESIGN-LANGUAGE.md) at test time; every `DL-x.y` cited in
+  `src/`, `electron/` or `scripts/` must resolve to a declared rule. **Moving or renaming
+  that document breaks `npm test`.**
+- [`scripts/electron-release-config.test.ts`](../../scripts/electron-release-config.test.ts):
+  locks the lines of `electron-builder.release.yml` and `electron-release.yml` whose loss
+  fails silently (the zip target, hardened runtime, the entitlements file, the secret name
+  mapping, the direct `needs` on `prepare`).
+- [`scripts/gallery-entry.test.ts`](../../scripts/gallery-entry.test.ts): no shipping module
+  imports `src/gallery/`.
+- [`scripts/icon-system.test.ts`](../../scripts/icon-system.test.ts): no hand-drawn SVG
+  outside the icon primitive.
+- [`electron/usage/parity.test.ts`](../../electron/usage/parity.test.ts): the Electron usage
+  scanner reproduces a golden snapshot produced by the Rust scanner. Regenerate the fixture
+  from the Rust side, never from this port's own output.
+
+## What a green run proves
+
+Suite and build evidence is renderer and main-process evidence. It says nothing about:
+
+- native behaviour in a running host (PTY, menu accelerators, window close, updater), which
+  needs `npm run electron:dev` or a packaged build on the platform;
+- Windows, where no owner has run a real-hardware pass;
+- the Tauri host, which shares the renderer but has its own commands and is run by nobody.
+
+Name the class of evidence a change has when describing it.
+
+## Generated and vendored files
+
+- `src-tauri/src/menu_registry.rs` is generated. Edit
+  [`src/terminal/action-registry.ts`](../../src/terminal/action-registry.ts) and run
+  `generate:menu`. The Electron menu needs no generated file: main imports the registry.
+- `src/lib/usage-pricing-snapshot.ts` is generated by `refresh:pricing`.
+- `electron/vendor/react-grab/` is vendored; its `SOURCE.md` records the version and hash,
+  and a test pins the same SHA-256.
+
+## Marketing
+
+`marketing/` ships nothing into the app. `stage/` is the shared app-window mock the landing
+hero, the tour and the video all draw from; `landing-prototype/` is the site Vercel builds
+(`vercel.json` builds only that tree); `video/` renders the film from the DOM through a
+virtual clock. Component changes under `src/` can change rendered media, because the stage
+shares application components.

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -1,0 +1,224 @@
+# Cutting a release
+
+One pushed tag ships SpaceVibe Deck for macOS and Windows, both self-updating, through
+[`electron-release.yml`](../../.github/workflows/electron-release.yml). Nothing ships the
+Tauri host automatically any more; [`release.yml`](../../.github/workflows/release.yml) is a
+hand-run hotfix path for a build that already shipped. This page is the runbook for both.
+
+## What a release is
+
+- **The trigger tag is `build/<release tag>`.** Two shapes are accepted:
+  `build/vX.Y.Z` (stable, the updater's default `latest` channel) and
+  `build/vX.Y.Z-electron.N` (prerelease, the `electron` channel).
+- **The release tag is the trigger tag without the `build/` prefix**, and it does not exist
+  until the run has finished. GitHub creates it when the draft is promoted. Pushing a bare
+  `vX.Y.Z` tag would advertise the version through `releases.atom` ten minutes before its
+  manifests existed, and every running app that checked in that window would report a
+  failed update check. `build/v…` is not valid semver, so the updater client skips it.
+- **The tagged commit must be reachable from `origin/main`**, and the tag must equal
+  `v<version>` for the `version` in [`package.json`](../../package.json). Either mismatch
+  fails the run before anything is built.
+- **The version is the channel.** A bare `X.Y.Z` is stable; `X.Y.Z-electron.N` is a
+  prerelease. Both halves of the update path derive the channel from that one string:
+  electron-builder from the version's prerelease component (`publish.channel` is deliberately
+  unset in [`electron-builder.release.yml`](../../electron-builder.release.yml)), and
+  electron-updater from the release tag on the client.
+- **The design is fail-closed.** Every artifact lands in a draft release, and the draft goes
+  public only after a downstream job has counted the full two-platform asset set on the
+  release itself. A failure anywhere leaves a draft that no installed app can see. A run that
+  dies in `promote` and publishes nothing is the design working, not a bug.
+
+## The four jobs
+
+`prepare` → `mac` + `windows` (parallel) → `promote`. All four run on Node 22 with `npm ci`.
+
+### `prepare` (ubuntu)
+
+1. Full-history checkout, then refuse a tag whose commit is not an ancestor of `origin/main`.
+2. Validate the tag against `package.json`'s version and derive the channel.
+3. Validate source: `npm run generate:menu:check`, `npm test`, `npm run build`.
+4. Create the draft release with `gh release create "$TAG" --draft --target "$GITHUB_SHA"`.
+   Creating it upstream of both platform jobs is what stops the two electron-builder
+   publishers from each creating their own release. `--target` is required because the
+   release tag does not exist yet.
+
+### `mac` (macos-latest)
+
+1. Import the Developer ID certificate into a throwaway keychain, including
+   `set-key-partition-list` so `codesign` cannot block on a GUI prompt.
+2. Run [`scripts/verify-electron-release-signing.mjs`](../../scripts/verify-electron-release-signing.mjs).
+   A missing identity does not fail electron-builder; it silently produces an unsigned app,
+   which this preflight refuses in seconds instead of at notarization ten minutes later.
+3. `npm run build`, `npm run electron:build`, then
+   `npx electron-builder --config electron-builder.release.yml --mac --arm64 --publish always`.
+4. Verify the outputs: exactly one `.app`, one `.dmg`, one `.zip` and one `latest-mac.yml`;
+   `codesign --verify --deep --strict` on the bundle and on node-pty's `spawn-helper` (it
+   lives outside the asar and is the first thing a dependency bump breaks); `spctl --assess`;
+   `xcrun stapler validate`; and `codesign --test-requirement="=notarized"`, the one offline
+   proof. The DMG is not asserted: electron-builder staples the `.app` and packs it into an
+   unsigned image on purpose, and Gatekeeper assesses the app at launch, not the image.
+
+### `windows` (windows-latest)
+
+`npm run build`, `npm run electron:build`, then
+`npx electron-builder --config electron-builder.release.yml --win --x64 --publish always`,
+under Git Bash with `set -euo pipefail` because pwsh only fails a step on the last command's
+exit code. **There is no signing step**: no certificate is configured, electron-builder warns
+and continues, and SmartScreen warns on first install. No runtime assertion is possible on a
+runner, so this job proves only that the installer and its manifest were produced.
+
+### `promote` (ubuntu)
+
+`needs: [prepare, mac, windows]` names `prepare` directly on purpose: `needs.<job>.outputs`
+resolves only for jobs in that list, and an empty `TAG` makes `gh release view ""` answer
+with the latest release, so every assertion would run against whatever shipped last.
+
+1. Refuse empty `TAG` or `CHANNEL`.
+2. Read the asset names the release actually serves and require all six:
+
+   | Asset            | Role                                                             |
+   | ---------------- | ---------------------------------------------------------------- |
+   | `*.dmg`          | macOS first install                                              |
+   | `*-mac.zip`      | macOS update payload (electron-updater reads the zip, never the dmg) |
+   | `latest-mac.yml` | macOS update feed                                                |
+   | `*-setup.exe`    | Windows first install and update payload (NSIS reruns the installer) |
+   | `latest.yml`     | Windows update feed                                              |
+   | `*.blockmap`     | Differential download                                            |
+
+   The manifests are `latest-mac.yml` / `latest.yml`, not `electron-mac.yml`: for the GitHub
+   provider app-builder-lib always writes the default name. The client asks for its channel
+   file first and falls back to the default one, so the two halves meet.
+3. Write the final notes. A fixed header states the platform limitations (unsigned Windows
+   installer, Windows not runtime-verified, no Intel Macs). Under it, a **stable** release
+   carries the `## <version>` section of the **tagged commit's** `CHANGELOG.md`; a
+   prerelease keeps GitHub's generated commit list. A stable release is titled
+   `SpaceVibe Deck X.Y.Z`; a prerelease keeps the bare tag.
+4. Promote: stable becomes `--latest`, prerelease becomes `--prerelease`. Promotion is what
+   creates the release tag, so the version becomes discoverable only now.
+5. Write the run summary (source SHA, channel, promoted, published assets).
+
+## `CHANGELOG.md` is machine-read
+
+The `promote` job extracts the section between `## <version>` and the next `## ` heading
+from [`CHANGELOG.md`](../../CHANGELOG.md) at the tagged commit and **fails the run if that
+section is empty**. Consequences:
+
+- A stable tag without its section stays a draft. Write the section in the release PR before
+  tagging.
+- Do not rename, move or restructure the file, and keep the `## <version>` heading exact.
+- Each section is written for users and frozen at its tag. It is never an auto-generated
+  commit list.
+
+## Secrets
+
+Stored on the repository; `GITHUB_TOKEN` is supplied by Actions.
+
+| Secret                       | Used by                                                              |
+| ---------------------------- | -------------------------------------------------------------------- |
+| `APPLE_CERTIFICATE`          | Base64 `.p12` Developer ID Application certificate                   |
+| `APPLE_CERTIFICATE_PASSWORD` | Password of that `.p12`                                              |
+| `KEYCHAIN_PASSWORD`          | The throwaway build keychain                                         |
+| `APPLE_ID`                   | Notarization account                                                 |
+| `APPLE_PASSWORD`             | App-specific password; exported to the build as `APPLE_APP_SPECIFIC_PASSWORD`, the name app-builder-lib reads |
+| `APPLE_TEAM_ID`              | Notarization team                                                    |
+
+Run [`verify-signing-credentials.yml`](../../.github/workflows/verify-signing-credentials.yml)
+(`workflow_dispatch`) before the first release and after rotating any credential. It imports
+the certificate into a throwaway keychain and reads `notarytool history`, submitting and
+publishing nothing, so a mistyped secret surfaces in a minute instead of at notarization.
+
+Locally, `npm run electron:package:release` runs the same signing preflight and the same
+config with `--publish never`. The preflight accepts one of three credential sets: Apple ID
+(`APPLE_ID` + `APPLE_APP_SPECIFIC_PASSWORD` + `APPLE_TEAM_ID`), API key
+(`APPLE_API_KEY` + `APPLE_API_KEY_ID` + `APPLE_API_ISSUER`), or `APPLE_KEYCHAIN_PROFILE`, and
+requires a `Developer ID Application` identity in the keychain.
+
+## The shipping package
+
+[`electron-builder.release.yml`](../../electron-builder.release.yml) is the only config that
+produces a release. The other two are not release paths:
+[`electron-builder.yml`](../../electron-builder.yml) is the local unsigned `Deck Electron`
+preview (`appId: dev.spacevibe.deck.electron`, `dir` target) and
+[`electron-builder.monaco-smoke.yml`](../../electron-builder.monaco-smoke.yml) is the packaged
+Monaco regression smoke.
+
+- `appId: dev.spacevibe.deck`, `productName: SpaceVibe Deck`. This is the Tauri bundle's own
+  identity, so the build replaces an installed Tauri `SpaceVibe Deck` rather than standing
+  beside it. userData still differs (`SpaceVibe Deck` vs `dev.spacevibe.deck` under
+  Application Support), so nothing migrates and no updater bridges the two hosts.
+- macOS: `dmg` **and** `zip`, both `arm64`, hardened runtime,
+  [`build/entitlements.mac.plist`](../../build/entitlements.mac.plist), `notarize: true`.
+  A dmg-only release could never self-update. node-pty is `asarUnpack`ed and signed in place.
+- Windows: `nsis` `x64`, artifact `SpaceVibe-Deck-<version>-win-x64-setup.exe`, per-user,
+  not one-click, and the install-directory chooser is kept on purpose.
+- Both hosts share the icon set in `src-tauri/icons/`.
+- Publish provider is GitHub (`mxrsv/spacevibe-deck`) with no explicit `channel`.
+
+A Windows `Deck Electron` preview that auto-updates into this build gets a **new** side-by-side
+`SpaceVibe Deck` install with fresh userData; the preview stays in Add/Remove Programs until
+removed by hand.
+
+## Platform limits
+
+- macOS: Apple Silicon (`arm64`) only. Intel Macs are not served.
+- Windows: `x64` only, unsigned, SmartScreen warns on first install, and no real-hardware
+  runtime verification pass has been run. Windows ARM is not served.
+- Both platforms update from the moving `releases/latest`, never from a pinned asset.
+
+## The updater client
+
+[`electron/updater/updater.ts`](../../electron/updater/updater.ts) wraps electron-updater with
+four rules that are correctness, not preference:
+
+- `allowPrerelease` is on, so a prerelease build walks the release feed for its own channel
+  instead of resolving `releases/latest`.
+- `autoDownload` and `autoInstallOnAppQuit` are off. The user chooses when to download and
+  when to install; nothing installs behind an ordinary quit.
+- `install()` never resolves on success: `quitAndInstall` hands the app to Squirrel or NSIS,
+  which relaunch Deck themselves.
+- `isInstalling()` is read by main's quit and window-close census, because `quitAndInstall`
+  closes every window before `before-quit` fires and the renderer has already confirmed.
+
+A dev run (`app.isPackaged === false`) never constructs the updater. One update check runs at a
+time across windows ([`update-flight.ts`](../../electron/updater/update-flight.ts)); a window
+that dies releases the flight. The renderer side is host-agnostic
+([`src/updater/update-controller.ts`](../../src/updater/update-controller.ts)).
+
+## Tauri hotfix
+
+The Tauri host is feature-frozen and its last shipped version is `0.12.3`
+([`src-tauri/tauri.conf.json`](../../src-tauri/tauri.conf.json)). Its updater endpoint,
+`releases/latest/download/latest.json`, now answers 404 because `releases/latest` is an
+Electron release, so a deployed Tauri client's update check fails, and Tauri builds carry an
+in-app migration notice ([`migration-notice.ts`](../../src/updater/migration-notice.ts),
+`MIGRATION_NOTICE_ENABLED`) telling the user to reinstall by hand.
+
+To rebuild a Tauri hotfix:
+
+1. Run `release.yml` by `workflow_dispatch` with the `tag` input set to an **existing**
+   `vX.Y.Z` or `vX.Y.Z-rc.N` source tag. The `release-freeze` job refuses any tag push, and
+   `resolve-target` refuses a tag that does not match that exact shape or does not exist. It
+   rebuilds from the tag's commit, never from `main`.
+2. The DAG is `resolve-target` → `prepare-release-notes` + `validate-source` → the macOS
+   stable draft and the unsigned Windows preview draft → per-platform validation
+   ([`scripts/verify-updater-manifest.mjs`](../../scripts/verify-updater-manifest.mjs)
+   re-downloads every draft asset and verifies the Minisign-signed manifest against
+   `DECK_UPDATER_PUBLIC_KEY`) → publish → channel promotion.
+3. Beyond the Apple secrets above it needs `TAURI_SIGNING_PRIVATE_KEY` and
+   `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`.
+
+A hotfix built from a commit on `main` carries the migration notice unless
+`MIGRATION_NOTICE_ENABLED` is set to false for that build; the notice is what tells its users
+the build no longer updates itself.
+
+## Preview and local builds
+
+- `npm run electron:package` — local unsigned `Deck Electron.app` (`arm64`, `dir` target) in
+  `dist-electron-app/`.
+- `npm run electron:package:release` — the shipping config, signed and notarized, published
+  nowhere.
+- `npm run electron:package:monaco-smoke` then `npm run electron:verify:monaco-smoke` — the
+  packaged Monaco regression smoke (universal, unsigned). Rerun it after adding a CSP.
+- [`ci.yml`](../../.github/workflows/ci.yml)'s `windows-electron-package` job
+  (`workflow_dispatch`) builds the unsigned Electron Windows preview on a Windows runner and
+  keeps it as a 7-day artifact. It is deliberately not gated on `windows-check`.

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -99,7 +99,7 @@ with the latest release, so every assertion would run against whatever shipped l
 
 ## `CHANGELOG.md` is machine-read
 
-The `promote` job extracts the section between `## <version>` and the next `## ` heading
+The `promote` job extracts the section between `## <version>` and the next level-2 heading
 from [`CHANGELOG.md`](../../CHANGELOG.md) at the tagged commit and **fails the run if that
 section is empty**. Consequences:
 

--- a/docs/user/agents.md
+++ b/docs/user/agents.md
@@ -1,0 +1,80 @@
+# Agents
+
+An agent is a command-line AI tool that Deck runs inside a terminal pane. Deck does not
+replace the tool's own workflow: it starts the command in a real shell, watches the pane,
+and reads the tool's own session logs where it knows their format.
+
+## Built-in agents
+
+Deck recognises six agents out of the box. Each ships with a launch command, and the command
+is shown on screen in Settings → Agents rather than hidden behind a label.
+
+| Agent       | Launch command                                     |
+| ----------- | -------------------------------------------------- |
+| Claude Code | `claude --dangerously-skip-permissions`            |
+| Codex       | `codex --dangerously-bypass-approvals-and-sandbox` |
+| OpenCode    | `opencode`                                         |
+| Antigravity | `agy --dangerously-skip-permissions`               |
+| Gemini CLI  | `gemini --yolo`                                    |
+| Cursor      | `cursor-agent --force`                             |
+
+Several of these skip the tool's own confirmation prompts. That is the point of Deck, which
+exists to run agents that keep working, and it is also why every command is spelled out and
+why each one can be disabled. OpenCode ships bare because its `--auto` mode is opt-in per
+session.
+
+This order is also the digit-key order in the quick picker.
+
+## Settings → Agents
+
+The catalog splits on what Deck found on your login shell's `PATH`:
+
+- **Installed** — agents whose binary was found, with the path. **Refresh** re-runs the probe.
+- **Available to install** — the rest, each with a link to the tool's page.
+
+Per row:
+
+- **Enable / Disable.** The switch is the only thing that takes a built-in out of the pickers;
+  a built-in cannot be deleted because the next probe would find it again.
+- **Default.** Offered on installed rows only. The starred agent is what a recent workspace
+  opens with when it has no remembered agent of its own.
+- **Add command.** Type a full command line, for example `claude --plan`. It replaces the
+  shipped command for that agent; nothing merges. The agent is derived from the command's
+  first word.
+
+A command is typed verbatim into a live interactive shell, so it may use only letters, digits,
+spaces and `. , : @ + = _ - /`. Pipes, `&&`, `;`, quotes, redirects, variables and newlines
+are refused with a message saying why. A pipeline belongs in a wrapper script declared as a
+custom agent.
+
+## Custom agents
+
+Under **Declared**, add any CLI with a name and the command to type into each pane. Click
+the name or the command to edit either; ✕ removes it. A declared agent stays listed when its
+binary is missing from `PATH` so that an uninstalled tool reads as missing rather than as
+lost data.
+
+Custom agents show a name and a state in the rail but no "latest words": Deck reads session
+logs only for the built-ins it knows.
+
+## What Deck knows about each agent
+
+| Agent       | Latest words in the rail | Resume on relaunch                         |
+| ----------- | ------------------------ | ------------------------------------------ |
+| Claude Code | yes                      | exact session id                           |
+| Codex       | yes                      | exact session id                           |
+| OpenCode    | yes                      | exact session id                           |
+| Gemini CLI  | no                       | `--resume latest`                          |
+| Antigravity | no                       | best-effort session id, else `--continue`  |
+| Cursor      | no                       | relaunches the command bare                |
+| Custom      | no                       | relaunches the declared command unchanged  |
+
+Working, asked and failed states come from the terminal itself (bell, notification and
+progress sequences the tool emits, plus sustained output) and work for any agent.
+
+## Token usage
+
+The Token usage tab (**⌘⇧U**) reads the local session logs of Claude Code and Codex, including
+Claude Code's sub-agent logs, and groups tokens and estimated cost by agent and day. Ranges
+are local calendar days: Today, 7 days, 30 days, All. Costs use a pricing snapshot that ships
+with Deck.

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -1,0 +1,108 @@
+# Getting started
+
+SpaceVibe Deck is a desktop terminal for running several AI agent CLIs side by side. Each
+agent runs in its own terminal pane; Deck shows which one is working, which one is asking
+for you, and what each one just said, and brings you back to the pane that needs you.
+
+## Install
+
+Download the current release from
+[github.com/mxrsv/spacevibe-deck/releases/latest](https://github.com/mxrsv/spacevibe-deck/releases/latest).
+
+- **macOS, Apple Silicon (arm64).** The `.dmg` is signed and notarized. Intel Macs are not
+  served.
+- **Windows, x64.** The `-setup.exe` installer is unsigned, so SmartScreen warns on first
+  install. It installs per user, without elevation. Windows ARM is not served, and the
+  Windows build has not been verified on real hardware.
+
+Deck checks for updates on its own, tells you when one is ready, and lets you choose when to
+download, install and relaunch. See [Settings → About](settings.md#about).
+
+If you ran the older Tauri-based Deck: that build no longer updates itself and shows a notice
+saying so. Install the current release by hand. Nothing migrates; it is a clean install.
+
+## First launch
+
+Deck opens on the **Open board**, the start surface. It offers:
+
+- **Open workspace…** — pick a folder. A workspace is a local folder that becomes the working
+  root for a tab.
+- **Recent workspaces** — one click reopens a folder with the layout and agent it was last
+  opened with. A folder that has disappeared from disk is listed separately and cannot be
+  opened.
+- **Create worktree…** — for a git repository, create a new git worktree on a new branch and
+  open it. Worktree and branch are one choice: Deck never offers a branch without its
+  worktree.
+- **Resume a previous session…** — the session history, listing Claude Code and Codex
+  conversations Deck found in those tools' own local logs; a row opens a tab in that
+  session's directory and types the CLI's exact resume command.
+
+If "Restore sessions on launch" is on (the default), Deck instead reopens the tabs that were
+open when it quit and resumes each agent conversation it can resolve. Scrollback, unsaved
+file edits and window placement are not restored.
+
+## Launch an agent
+
+Press **⌘T** (Windows: **Ctrl+Shift+T**) or the `+` on a project header in the Agent Rail.
+The quick picker lists the agents Deck found on your `PATH`; pick one with a click or its
+digit key. The agent starts in a new pane in the active tab's current directory, using the
+launch command shown in [Settings → Agents](agents.md). The picker also lets you choose
+which worktree of the repository to run in.
+
+**Shell** starts a plain shell with no agent.
+
+A declared agent whose binary has left your `PATH` shows as missing; choosing it opens
+Settings instead of a shell that prints `command not found`.
+
+## The window
+
+- **Agent Rail** (left column). One cluster per project, one row per agent pane. The row
+  shows what the agent last said, or its name if it has said nothing yet. A dot marks state:
+  red for failed, yellow for asking you, neutral for working. Clicking a row focuses that
+  pane. Each row's ✕ closes the thing it names: an agent row closes that pane, a project
+  header closes every tab of that repository. Drag a project header to reorder clusters.
+- **Stage** (centre). The terminal panes of the active tab, split as you like. Above them, one
+  strip of chips: terminal tabs, open documents and the browser tab share one shape and are
+  ordered by when they were opened.
+- **Side panel** (right, **⌘⇧J**). Three tabs: **File explorer** (**⌘⇧B**), **Token usage**
+  (**⌘⇧U**) and **Session history** (**⌘⇧Y**).
+- **Browser tab** (**⌘⇧I**). A page beside your terminals, opening on the home address from
+  Settings → Browser.
+
+Drag the seam between the rail and the stage to resize it; drag it past its floor to hide the
+rail completely. The toggle beside the traffic lights brings it back.
+
+## Panes and tabs
+
+- Split with **⌘D** (side by side) or **⌘⇧D** (stacked). Move between panes with **⌘⌥ arrows**;
+  swap two panes with **⌘⌥⇧ arrows**.
+- **⌘E** expands the focused pane; **⌘⇧Enter** zooms it over the whole tab.
+- **⌘W** closes the focused pane; **⌘⇧W** closes the whole tab. Deck asks first if a process
+  other than an idle shell is running there.
+- **⌘⇧T** reopens the last closed tab with fresh shells at the same directories.
+- **⌘⇧M** moves the focused pane into its own window.
+- **⌘1**–**⌘8** select a chip by position; **⌘9** the last one; **⌘⇧]** / **⌘⇧[** cycle.
+- **⌘⇧A** jumps to the pane that most needs you.
+
+## Files
+
+Open the file explorer (**⌘⇧B**) to browse the workspace. A file opens as a document on the
+stage: an editor with **⌘S** to save. Markdown opens rendered; **⌘⇧V** flips it to source.
+
+**⌘+click** (Windows: **Ctrl+click**) on a path an agent prints opens it. A path inside a
+workspace this window has open lands in Deck's own editor at that line; anything else goes to
+the app chosen in [Settings → Links & editor](settings.md#links--editor). On Windows only
+the in-Deck half works in this release.
+
+## Usage and privacy
+
+The Token usage tab reads Claude Code's and Codex's own local session logs and groups tokens
+and estimated cost by agent and day. It needs no account.
+
+Deck sends one small usage snapshot per day by default: a fresh random id for that day,
+Deck's version, platform and architecture, launch counts per built-in agent, how often the
+browser, explorer and usage surfaces were opened, the day's highest tab and pane counts,
+and whether sessions were restored. It never contains code, paths, prompts, file names,
+repository names or a permanent identifier. Turn it off in
+[Settings → Privacy](settings.md#privacy). The full field list is
+[`src/telemetry/payload.ts`](../../src/telemetry/payload.ts).

--- a/docs/user/keyboard-shortcuts.md
+++ b/docs/user/keyboard-shortcuts.md
@@ -1,0 +1,86 @@
+# Keyboard shortcuts
+
+Every shortcut is an action with a name, and Settings → Shortcuts lets you record a different
+key for any of them. The tables below are the shipped defaults, taken from
+[`src/terminal/default-keymaps.ts`](../../src/terminal/default-keymaps.ts).
+
+On macOS, bare **⌘C** and **⌘V** are the system Copy and Paste. On Windows, bare **Ctrl+**
+chords stay available to the shell and the agent, with two exceptions: **Ctrl+V** pastes, and
+**Ctrl+C** copies while the terminal holds a selection and otherwise interrupts the running
+program as usual.
+
+## Launch and navigate
+
+| Action                       | macOS       | Windows              |
+| ---------------------------- | ----------- | -------------------- |
+| Launch an agent (quick picker) | ⌘T        | Ctrl+Shift+T         |
+| Jump to the pane that needs you | ⌘⇧A      | Ctrl+Shift+A         |
+| Next / previous chip         | ⌘⇧] / ⌘⇧[  | Ctrl+Tab / Ctrl+Shift+Tab |
+| Select chip 1–8              | ⌘1 … ⌘8    | Ctrl+1 … Ctrl+8      |
+| Select the last chip         | ⌘9         | Ctrl+9               |
+| Reopen the last closed tab   | ⌘⇧T        | Ctrl+Alt+Shift+T     |
+
+Chips count terminal tabs, open documents and the browser tab in the order they were opened.
+
+## Panes
+
+| Action                        | macOS            | Windows                 |
+| ----------------------------- | ---------------- | ----------------------- |
+| Split side by side            | ⌘D               | Ctrl+Shift+D            |
+| Split stacked                 | ⌘⇧D              | Ctrl+Alt+Shift+D        |
+| Close pane                    | ⌘W               | Ctrl+Shift+W            |
+| Close tab                     | ⌘⇧W              | Ctrl+Alt+Shift+W        |
+| Focus next / previous pane    | ⌘] / ⌘[          | Ctrl+Alt+] / Ctrl+Alt+[ |
+| Focus left / right / up / down | ⌘⌥ arrows       | Ctrl+Alt+arrows         |
+| Swap with neighbour           | ⌘⌥⇧ arrows       | Ctrl+Alt+Shift+arrows   |
+| Expand the focused pane       | ⌘E               | Ctrl+Shift+E            |
+| Zoom pane over the tab        | ⌘⇧Enter          | Ctrl+Shift+Enter        |
+| Move pane to a new window     | ⌘⇧M              | Ctrl+Shift+M            |
+
+## Terminal
+
+| Action                     | macOS      | Windows                          |
+| -------------------------- | ---------- | -------------------------------- |
+| Find in scrollback         | ⌘F         | Ctrl+Shift+F                     |
+| Find next / previous       | ⌘G / ⌘⇧G   | F3 / Shift+F3                    |
+| Clear scrollback (no undo) | ⌘K         | Ctrl+Shift+K                     |
+| Copy selection             | ⌘C         | Ctrl+Shift+C, or Ctrl+C with a selection |
+| Paste                      | ⌘V         | Ctrl+V, Ctrl+Shift+V, Shift+Insert |
+| Copy working directory     | ⌘⇧C        | Ctrl+Alt+Shift+C                 |
+| Zoom in / out / reset      | ⌘= / ⌘- / ⌘0 | Ctrl+= / Ctrl+- / Ctrl+0       |
+| Scroll a page up / down    | ⇧PageUp / ⇧PageDown | Shift+PageUp / Shift+PageDown |
+| Scroll to top / bottom     | ⇧Home / ⇧End | Shift+Home / Shift+End         |
+
+## Surfaces
+
+| Action                     | macOS | Windows      |
+| -------------------------- | ----- | ------------ |
+| Toggle the side panel      | ⌘⇧J   | Ctrl+Shift+J |
+| File explorer              | ⌘⇧B   | Ctrl+Shift+B |
+| Token usage                | ⌘⇧U   | Ctrl+Shift+U |
+| Session history            | ⌘⇧Y   | Ctrl+Shift+Y |
+| Browser tab                | ⌘⇧I   | Ctrl+Shift+I |
+| Prompt Board               | ⌘⇧P   | Ctrl+Shift+P |
+| Save the open document     | ⌘S    | —            |
+| Markdown: rendered ↔ source | ⌘⇧V  | —            |
+| Settings                   | ⌘,    | Ctrl+,       |
+
+## Layout presets
+
+| Action                              | macOS | Windows          |
+| ----------------------------------- | ----- | ---------------- |
+| New layout preset from scratch      | ⌘⇧N   | Ctrl+Alt+Shift+N |
+| Save the live layout as a preset    | ⌘⇧S   | Ctrl+Alt+Shift+S |
+
+A preset is a named split layout with optional per-pane directories. A preset can be created
+and overwritten, but not renamed or deleted from inside the app.
+
+## Notes
+
+- A shortcut that cannot do anything where you are does not eat the key. For example a pane
+  chord pressed over an open document reaches the document instead.
+- On macOS, menu-bound chords such as Find and Clear Buffer are consumed by the menu bar
+  before a document can see them.
+- Bracket and digit chords bind to the physical key position, so they work on non-US layouts.
+- ⌘S and ⌘⇧V have no Windows binding: bare Ctrl+S is terminal flow control and Ctrl+Shift+V is
+  paste. Use the controls on the document surface instead.

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -1,0 +1,86 @@
+# Settings
+
+Open Settings with **⌘,** (Windows: **Ctrl+,**). It covers the whole window; leave with
+**Back** or Escape. Settings are stored per machine in Deck's data folder as `settings.json`
+and apply to every Deck window.
+
+## Appearance
+
+- **Theme** — Light or Dark. Dark is the default. On Dark, the terminal is the deepest surface
+  in the window and the chrome stands above it.
+- **Font size** — the terminal font size (default 13).
+- **Tab bar position** — the chips live in the sidebar layout (default) or along the top.
+- **Show pane bar** — a name bar inside each split (off by default).
+- **Show status bar** — branch, path and window readout along the bottom (off by default).
+
+## Browser
+
+- **Home address** — the page the browser tab opens on when it has no page yet (default
+  `http://localhost:3000`).
+
+## Terminal
+
+- **Scrollback** — lines kept per pane: 1,000 / 5,000 / 10,000 (default) / 50,000 / 100,000.
+
+## Agents
+
+The agent catalog: installed and available built-ins, per-agent launch commands, the default
+agent, the enable switch, and declared custom agents. See [Agents](agents.md).
+
+## Links & editor
+
+- **Open with** — the app that opens a path when you ⌘+click one that no open workspace
+  holds. The list is what Deck found installed among VS Code, Cursor, Zed, GitHub Desktop,
+  GitKraken, Finder, Terminal, iTerm2, Ghostty and Hyper. Paths inside an open workspace
+  always open in Deck's own editor. Detection looks for macOS application bundles, so on
+  Windows no external app is offered in this release.
+
+## Shortcuts
+
+Every action with its current key. Click a row to record a new chord; a conflict with another
+action is called out on the row, and the reset control returns the shipped default. Recording
+a chord temporarily suspends the menu accelerators so the key reaches the recorder.
+
+## Notifications
+
+- **Agent notifications** — a native alert when a background agent finishes or needs you
+  (off by default).
+- **Restore sessions on launch** — reopen the last session's tabs and resume agent
+  conversations (on by default). Turning it off is the kill switch for session restore.
+
+## About
+
+Deck's version, **Check for updates**, and **Release notes**. An update is never downloaded or
+installed without your choice; Deck asks before closing panes to install.
+
+## Privacy
+
+- **Share usage stats** — on by default. Off stops counting immediately, and an "off" choice
+  is never inferred away. The row states exactly what a daily snapshot contains.
+
+This switch is deliberately not part of `settings.json`: it is stored in `telemetry.json` in
+Deck's data folder so that a copied settings file never carries a consent choice. If that
+file exists but cannot be read, sharing stays off and Deck says so here.
+
+## Reset
+
+**Restore defaults** returns every preference (theme, font, colours, behaviour, agents,
+prompts) to a fresh install's state, after a confirmation. It does not touch your agents' own
+session logs.
+
+## Where Deck keeps its data
+
+| File or folder        | Contents                                                             |
+| --------------------- | -------------------------------------------------------------------- |
+| `settings.json`       | Every setting above                                                  |
+| `workspaces.json`     | Recent workspaces and the layout and agent each was last opened with |
+| `presets.json`        | Layout presets                                                       |
+| `repositories.json`   | Cached git repository and worktree scans for the rail                |
+| `session.json`        | The live tab journal used by session restore                         |
+| `update-attempt.json` | The last update install attempt, so a failed relaunch is reported    |
+| `telemetry.json`      | The usage-stats choice and the current day's counters                |
+| `usage-cache.json`    | Parsed token-usage results, keyed by log file                        |
+| `themes/`             | Imported theme files                                                 |
+
+On macOS the folder is `~/Library/Application Support/SpaceVibe Deck`; on Windows it is
+`%APPDATA%\SpaceVibe Deck`.

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -72,7 +72,7 @@ session logs.
 
 | File or folder        | Contents                                                             |
 | --------------------- | -------------------------------------------------------------------- |
-| `settings.json`       | Every setting above                                                  |
+| `settings.json`       | Every setting above except the usage-stats choice                    |
 | `workspaces.json`     | Recent workspaces and the layout and agent each was last opened with |
 | `presets.json`        | Layout presets                                                       |
 | `repositories.json`   | Cached git repository and worktree scans for the rail                |

--- a/src/terminal/action-registry.ts
+++ b/src/terminal/action-registry.ts
@@ -90,8 +90,8 @@ export interface ActionDefinition {
   /**
    * Set (only ever `true`) when this action destroys live state with no
    * confirmation step of its own — killing a pane/tab's running process, or
-   * wiping scrollback with no undo (`clear-buffer`, per CONTEXT.md's own
-   * "Buffer" entry). Absent (the default) for everything else.
+   * wiping scrollback with no undo (`clear-buffer`, per the "Buffer" entry in
+   * `docs/internals/glossary.md`). Absent (the default) for everything else.
    *
    * Read by `runAction` (tab-manager.ts, F-B1/F-B2, 2026-07-27 code review)
    * to decide whether a chrome text field (tab rename input, search bar,
@@ -278,7 +278,7 @@ export const ACTION_REGISTRY = [
     id: "clear-buffer",
     label: "Clear Buffer",
     scope: "pane",
-    // Drops scrollback with no undo (CONTEXT.md "Buffer") — always, no
+    // Drops scrollback with no undo (glossary "Buffer") — always, no
     // confirmation step of its own. See ActionDefinition.destructive.
     destructive: true,
     menu: { submenu: "Edit" },

--- a/src/terminal/search-bar.ts
+++ b/src/terminal/search-bar.ts
@@ -32,11 +32,12 @@ let current: OpenBar | null = null;
  * the platform find-next/find-previous chords (`advanceSearch` below) can
  * repeat it once the bar itself is gone.
  * Deliberately ONE app-wide string, not keyed by pane id: the bar is already
- * a single global instance (`current` above), and CONTEXT.md's "Search…
- * scoped to one pane at a time" describes which pane a term is applied
- * against, not which pane it was typed on. Because it is a plain string with
- * no pane reference, `closeSearchBarForPane` (a pane dying mid-search) never
- * needs to touch it — there is nothing pane-specific here to leak.
+ * a single global instance (`current` above), and the glossary's "Search…
+ * scoped to one pane at a time" (`docs/internals/glossary.md`) describes
+ * which pane a term is applied against, not which pane it was typed on.
+ * Because it is a plain string with no pane reference,
+ * `closeSearchBarForPane` (a pane dying mid-search) never needs to touch it —
+ * there is nothing pane-specific here to leak.
  */
 let lastQuery: string | null = null;
 

--- a/src/ui/sidebar-shell.ts
+++ b/src/ui/sidebar-shell.ts
@@ -9,7 +9,7 @@
  * its children update normally. The same defect already reaches shipped
  * behaviour — flipping `tabBarPosition` in Settings leaves `window--sidebar`
  * on the shell — so it pre-dates this work and is reported rather than fixed
- * here (`docs/CONTEXT.md`). Writing to `:root` sidesteps it entirely: nothing
+ * here (`docs/internals/traps.md`). Writing to `:root` sidesteps it entirely: nothing
  * about these two values needs to travel through the shell's props.
  *
  * `:root` is also where the CSS fallbacks for both already live, so a value


### PR DESCRIPTION
Linear: [MXR-18](https://linear.app/mxrsv/issue/MXR-18)

## What

`docs/ARCHITECTURE.md` described the retired Tauri runtime while README called it the architecture guide. This replaces it with a `docs/README.md` index and three reader-split tiers written against the shipping Electron host, from a survey of `electron/`, `src/`, `scripts/` and the workflows.

- **`docs/internals/`** — `overview` (Electron boundary, the `__deckHost` bridge and its contract, persistence, the R4 seams), `glossary` (merges the root `CONTEXT.md` and corrects the Workspace, Theme gallery, Agent rail, Close tab and Quit entries), `terminal`, `agent-rail`, `file-surface`, `session-restore`, `telemetry`, `traps` (known traps plus the four live feature switches).
- **`docs/operations/`** — `release` (tag shape, the four fail-closed jobs, the six-asset gate, the machine-read `CHANGELOG.md` section, secrets, the updater client, platform limits, the Tauri hotfix path) and `development` (commands, CI, tests, what a green run proves).
- **`docs/user/`** — `getting-started`, `agents`, `keyboard-shortcuts`, `settings`. The issue left this tier undecided; built minimally rather than left to README, since a three-tier index missing a tier is not three tiers.

## Also

- README and `AGENTS.md` point at the new index instead of the Tauri-era page.
- `docs/ARCHITECTURE.md` and the root `CONTEXT.md` gain a "Superseded" banner. Nothing is deleted; MXR-21 owns reference replacement before any deletion.
- The four code comments citing `CONTEXT.md` (`action-registry.ts`, `search-bar.ts`, `sidebar-shell.ts`) now cite `docs/internals/glossary.md` / `traps.md`, ending the two-files-one-name collision.
- `docs/DESIGN-LANGUAGE.md` does not move; `scripts/design-language.test.ts` reads it at test time.

## Verification

- Relative-link check over the 15 new files: 0 dead links, 0 dated names, 0 checklists.
- `npm test` 3870 passed / 0 failed; `npx tsc --noEmit` clean; prettier clean on the three edited source files; `design-language` and `electron-ipc-contract` gates green.
- `npm run lint` reports `import/no-duplicates` and `vitest/valid-expect` errors in files this PR does not touch; they reproduce on `main` at `f11ff0e`.

Out of scope, noted on the issue: `updater.cjs` at the repo root is a stray `tsc` output of `electron/updater/updater.ts` that nothing references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Db5v9EXX6fEwnhAJLNTyiG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Db5v9EXX6fEwnhAJLNTyiG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a central documentation index organizing user guides, internal references, and release resources.
  * Added user guides for getting started, agents, keyboard shortcuts, and settings.
  * Added development and release runbooks for building, testing, and shipping the app.
  * Added architecture, terminal, file handling, session restore, telemetry, glossary, and troubleshooting documentation.
  * Updated existing documentation to identify superseded references and link to current guidance.
  * Clarified keyboard shortcut and build-from-source documentation in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->