### PR TITLE
fix(ci): get the Linux gate green and pin LF checkouts (MXR-34)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,35 @@
+# Line endings are part of the test contract on this repo.
+#
+# Many suites read a source file with `readFileSync(path, "utf8")` and assert
+# that it CONTAINS an LF-spelled snippet -- `scripts/design-language.test.ts`
+# reads `docs/DESIGN-LANGUAGE.md` and concatenates the CSS partials,
+# `src/ui/agent-rail.test.tsx` matches rule bodies out of
+# `src/styles/04a-agent-rail.css`, and several scripts hash a checked-in file
+# and compare the digest. Git for Windows defaults to `core.autocrlf=true`, so
+# a `windows-latest` checkout rewrote every LF to CRLF in the working tree and
+# those assertions compared LF needles against CRLF haystacks. That is what the
+# `windows-check` job's CSS diffs were: every "Received" line ended in `\r`.
+#
+# `eol=lf` overrides `core.autocrlf` for the working tree, so the bytes a test
+# reads are the bytes that were committed, on every platform. Nothing in the
+# index changes -- no tracked text file in this repo contains a CR today.
+* text=auto eol=lf
+
+# Byte-exact fixtures and vendored data: never normalized in either direction,
+# because their bytes ARE the contract (`.prettierignore` says the same of
+# them). `-text` tells git to leave them alone on checkin and checkout alike.
+electron/usage/fixtures/** -text
+*.jsonl -text
+
+# Binaries: no conversion, and no diff attempted.
+*.png binary
+*.webp binary
+*.gif binary
+*.ico binary
+*.icns binary
+*.mp4 binary
+*.webm binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -38,7 +38,9 @@
         "vitest/no-conditional-expect": "off",
         "jest/valid-title": "off",
         "vitest/valid-title": "off",
-        "vitest/require-mock-type-parameters": "off"
+        "vitest/require-mock-type-parameters": "off",
+        "jest/valid-expect": ["error", { "maxArgs": 2 }],
+        "vitest/valid-expect": ["error", { "maxArgs": 2 }]
       }
     }
   ],

--- a/electron/agents.ts
+++ b/electron/agents.ts
@@ -50,9 +50,7 @@ const PROBE_SAFE = /^[A-Za-z0-9._~+/-]+$/;
  * caller lands here first.
  */
 export function isProbeSafe(name: string): boolean {
-  return (
-    name.length > 0 && name.length <= PROBE_NAME_MAX && PROBE_SAFE.test(name)
-  );
+  return name.length > 0 && name.length <= PROBE_NAME_MAX && PROBE_SAFE.test(name);
 }
 
 /** Every built-in, then each safe caller-supplied name not already present.
@@ -130,10 +128,7 @@ export function stripAnsi(line: string): string {
  * Keep only absolute paths whose basename was asked for; first hit per name
  * wins, ordered by first appearance so numbering in the picker stays stable.
  */
-export function parseCommandVOutput(
-  output: string,
-  probed: readonly string[],
-): AgentInfo[] {
+export function parseCommandVOutput(output: string, probed: readonly string[]): AgentInfo[] {
   const wanted = new Set(probed.map(probeKey));
   const found: AgentInfo[] = [];
   const seen = new Set<string>();
@@ -170,8 +165,7 @@ export function parseCommandVOutput(
  */
 export function discoverAgentsWindows(
   requested: readonly string[],
-  resolve: (name: string) => string | null = (name) =>
-    windows.resolveOnPath(name),
+  resolve: (name: string) => string | null = (name) => windows.resolveOnPath(name),
 ): AgentInfo[] {
   const found: AgentInfo[] = [];
   const seen = new Set<string>();
@@ -194,9 +188,7 @@ export function discoverAgentsWindows(
  * hanging past the timeout — degrades to an empty list rather than leaving the
  * picker waiting forever.
  */
-export function discoverAgents(
-  requested: readonly string[],
-): Promise<AgentInfo[]> {
+export function discoverAgents(requested: readonly string[]): Promise<AgentInfo[]> {
   if (process.platform === "win32") {
     return Promise.resolve(discoverAgentsWindows(requested));
   }
@@ -233,9 +225,7 @@ export async function dirsExist(paths: readonly string[]): Promise<boolean[]> {
  * rather than surface an error, which is what the Rust command did by
  * returning an empty vector on every failure path.
  */
-export async function detectAgentsSafely(
-  names: readonly string[],
-): Promise<AgentInfo[]> {
+export async function detectAgentsSafely(names: readonly string[]): Promise<AgentInfo[]> {
   try {
     return await discoverAgents(names);
   } catch {

--- a/electron/external-apps.test.ts
+++ b/electron/external-apps.test.ts
@@ -2,12 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import {
-  EXTERNAL_APP_CATALOG,
-  bundlePath,
-  repositoryRoot,
-  resolveTarget,
-} from "./external-apps";
+import { EXTERNAL_APP_CATALOG, bundlePath, repositoryRoot, resolveTarget } from "./external-apps";
 import { EXTERNAL_APPS } from "../src/lib/external-app-catalog";
 
 const temps: string[] = [];

--- a/electron/external-apps.ts
+++ b/electron/external-apps.ts
@@ -60,10 +60,7 @@ export const EXTERNAL_APP_CATALOG: readonly CatalogEntry[] = [
     id: "vscode",
     label: "VS Code",
     group: "editor",
-    bundles: [
-      "/Applications/Visual Studio Code.app",
-      "~/Applications/Visual Studio Code.app",
-    ],
+    bundles: ["/Applications/Visual Studio Code.app", "~/Applications/Visual Studio Code.app"],
     opensFile: "as-is",
     opensFolder: "as-is",
   },
@@ -87,10 +84,7 @@ export const EXTERNAL_APP_CATALOG: readonly CatalogEntry[] = [
     id: "github-desktop",
     label: "GitHub Desktop",
     group: "git",
-    bundles: [
-      "/Applications/GitHub Desktop.app",
-      "~/Applications/GitHub Desktop.app",
-    ],
+    bundles: ["/Applications/GitHub Desktop.app", "~/Applications/GitHub Desktop.app"],
     opensFile: "repository",
     opensFolder: "repository",
   },
@@ -164,10 +158,7 @@ function expandHome(target: string, home: string): string {
 }
 
 /** The first bundle of `entry` that exists, or null. */
-export function bundlePath(
-  entry: CatalogEntry,
-  home: string = os.homedir(),
-): string | null {
+export function bundlePath(entry: CatalogEntry, home: string = os.homedir()): string | null {
   for (const candidate of entry.bundles) {
     const full = expandHome(candidate, home);
     try {
@@ -227,9 +218,7 @@ async function icnsPath(bundle: string): Promise<string | null> {
       ])
     ).trim();
     if (declared.length > 0) {
-      const base = declared.endsWith(".icns")
-        ? declared.slice(0, -".icns".length)
-        : declared;
+      const base = declared.endsWith(".icns") ? declared.slice(0, -".icns".length) : declared;
       const full = path.join(resources, `${base}.icns`);
       if (fs.existsSync(full)) {
         return full;
@@ -239,9 +228,7 @@ async function icnsPath(bundle: string): Promise<string | null> {
     // No key, unreadable plist — fall through to the directory scan.
   }
   try {
-    const first = fs
-      .readdirSync(resources)
-      .find((entry) => entry.endsWith(".icns"));
+    const first = fs.readdirSync(resources).find((entry) => entry.endsWith(".icns"));
     return first === undefined ? null : path.join(resources, first);
   } catch {
     return null;
@@ -355,17 +342,13 @@ export function resolveTarget(
   rule: TargetRule,
   target: string,
   isDirectory: boolean,
-):
-  | { readonly path: string; readonly reveal: boolean }
-  | { readonly error: string } {
+): { readonly path: string; readonly reveal: boolean } | { readonly error: string } {
   switch (rule) {
     case "as-is":
       return { path: target, reveal: false };
     case "reveal":
       // A folder has nothing to reveal it INSIDE — open it instead.
-      return isDirectory
-        ? { path: target, reveal: false }
-        : { path: target, reveal: true };
+      return isDirectory ? { path: target, reveal: false } : { path: target, reveal: true };
     case "directory":
       return {
         path: isDirectory ? target : path.dirname(target),
@@ -423,9 +406,7 @@ export function openInApp(request: OpenInAppRequest): Promise<void> {
   if ("error" in resolved) {
     throw new Error(resolved.error);
   }
-  const args = resolved.reveal
-    ? ["-R", resolved.path]
-    : ["-a", bundle, resolved.path];
+  const args = resolved.reveal ? ["-R", resolved.path] : ["-a", bundle, resolved.path];
   return new Promise((resolve, reject) => {
     const child = execFile(
       "/usr/bin/open",

--- a/electron/fs/workspace-for-path.ts
+++ b/electron/fs/workspace-for-path.ts
@@ -24,9 +24,7 @@ export interface WorkspaceForPathRequest {
   readonly roots: readonly string[];
 }
 
-export function workspaceForPath(
-  request: WorkspaceForPathRequest,
-): string | null {
+export function workspaceForPath(request: WorkspaceForPathRequest): string | null {
   const { path: target, roots } = request;
   if (typeof target !== "string" || target.length === 0) {
     return null;

--- a/electron/fs/write.test.ts
+++ b/electron/fs/write.test.ts
@@ -37,7 +37,11 @@ describe("writeFileAtomically", () => {
     expect(fs.readFileSync(target, "utf8")).toBe("x");
   });
 
-  it("applies the mode it is given", async () => {
+  // POSIX only, the `scripts/spawn-helper-permissions.test.ts` precedent:
+  // Windows has no permission bits for `chmod` to set, so `stat().mode & 0o777`
+  // answers 0o666 (438) there whatever mode was asked for. The assertion stays
+  // exact where the bits exist rather than being widened to pass everywhere.
+  it.runIf(process.platform !== "win32")("applies the mode it is given", async () => {
     const target = path.join(root, "moded.sh");
     await writeFileAtomically(target, "#!/bin/sh\n", { mode: 0o755 });
     expect(fs.statSync(target).mode & 0o777).toBe(0o755);
@@ -61,13 +65,17 @@ describe("writeTextFile", () => {
     expect(fs.readFileSync(target, "utf8")).toBe("a\r\nb\r\nc\r\n");
   });
 
-  it("preserves the mode, so saving a script does not strip its +x", async () => {
-    const target = path.join(root, "script.sh");
-    fs.writeFileSync(target, "#!/bin/sh\necho old\n");
-    fs.chmodSync(target, 0o755);
-    await writeTextFile(root, target, "#!/bin/sh\necho new\n", "lf");
-    expect(fs.statSync(target).mode & 0o777).toBe(0o755);
-  });
+  // POSIX only, same reason as `applies the mode it is given` above.
+  it.runIf(process.platform !== "win32")(
+    "preserves the mode, so saving a script does not strip its +x",
+    async () => {
+      const target = path.join(root, "script.sh");
+      fs.writeFileSync(target, "#!/bin/sh\necho old\n");
+      fs.chmodSync(target, 0o755);
+      await writeTextFile(root, target, "#!/bin/sh\necho new\n", "lf");
+      expect(fs.statSync(target).mode & 0o777).toBe(0o755);
+    },
+  );
 
   it("resolves symlinks and replaces the TARGET, not the link", async () => {
     const target = path.join(root, "src", "real.ts");

--- a/electron/github-star.ts
+++ b/electron/github-star.ts
@@ -80,10 +80,7 @@ interface GhOutcome {
   readonly spawnFailed: boolean;
 }
 
-function runGh(
-  args: readonly string[],
-  executable: string,
-): Promise<GhOutcome> {
+function runGh(args: readonly string[], executable: string): Promise<GhOutcome> {
   return new Promise((resolve) => {
     execFile(
       executable,
@@ -123,10 +120,7 @@ export async function readStarState(): Promise<GithubStarState> {
   if (executable === null) {
     return "unavailable";
   }
-  const outcome = await runGh(
-    ["api", "--silent", `user/starred/${REPOSITORY}`],
-    executable,
-  );
+  const outcome = await runGh(["api", "--silent", `user/starred/${REPOSITORY}`], executable);
   if (outcome.ok) {
     return "starred";
   }

--- a/electron/ipc/register-services.ts
+++ b/electron/ipc/register-services.ts
@@ -81,10 +81,8 @@ export function registerServices(deps: RegisterServicesDeps): void {
     workspaceForPath({ path: target, roots: roots ?? [] }),
   );
   ipcMain.handle(CHANNELS.externalApps, () => listExternalApps());
-  ipcMain.handle(
-    CHANNELS.openInApp,
-    (_event, { appId, path: target, isDirectory }) =>
-      openInApp({ appId, path: target, isDirectory: isDirectory === true }),
+  ipcMain.handle(CHANNELS.openInApp, (_event, { appId, path: target, isDirectory }) =>
+    openInApp({ appId, path: target, isDirectory: isDirectory === true }),
   );
   ipcMain.handle(CHANNELS.listPromptAssets, (_event, { agent, cwd }) =>
     listPromptAssets(agent, cwd ?? null),

--- a/electron/resume/agy.ts
+++ b/electron/resume/agy.ts
@@ -19,12 +19,7 @@
  * `{ kind: "latest" }`, since `agy --continue` needs no id at all.
  */
 import path from "node:path";
-import {
-  datedFilesIn,
-  headBytes,
-  type CandidateSession,
-  type FileCandidate,
-} from "./head";
+import { datedFilesIn, headBytes, type CandidateSession, type FileCandidate } from "./head";
 
 const AGY_CONVERSATIONS_DIR = path.join(".gemini", "antigravity", "conversations");
 const AGY_EXTENSION = ".pb";

--- a/electron/resume/opencode.ts
+++ b/electron/resume/opencode.ts
@@ -71,7 +71,6 @@ const MAX_TAIL_PARTS = 60;
  */
 const SAFE_ID = /^[A-Za-z0-9_-]+$/;
 
-
 /** Every `.json` directly inside `dir`, newest mtime first. A missing or
  *  unreadable directory is an empty list, never a throw. */
 function newestFirstIn(dir: string): FileCandidate[] {

--- a/scripts/capture-landing-stage.mjs
+++ b/scripts/capture-landing-stage.mjs
@@ -174,12 +174,14 @@ async function measure(page, width) {
       // T17's floors. 768 is the WORST legibility case, not 390: the
       // breakpoint is 47.5rem = 760px, so 768 sits above it and gets none of
       // the narrow rules.
-      const sized = railType.flatMap((selector) =>
-        [...document.querySelectorAll(selector)].map((node) => ({
-          selector,
-          size: px(getComputedStyle(node).fontSize),
-        })),
-      ).filter((entry) => Number.isFinite(entry.size));
+      const sized = railType
+        .flatMap((selector) =>
+          [...document.querySelectorAll(selector)].map((node) => ({
+            selector,
+            size: px(getComputedStyle(node).fontSize),
+          })),
+        )
+        .filter((entry) => Number.isFinite(entry.size));
       const smallest = sized.reduce(
         (low, entry) => (entry.size < low.size ? entry : low),
         sized[0] ?? { selector: "—", size: Number.NaN },
@@ -285,9 +287,7 @@ if (!existsSync(join(DIST, "landing-prototype/index.html"))) {
 }
 
 const outDir = resolve(flag("out", "/tmp/spacevibe-deck-landing-stage"));
-const widths = String(flag("widths", "1440,768,390"))
-  .split(",")
-  .map(Number);
+const widths = String(flag("widths", "1440,768,390")).split(",").map(Number);
 
 await mkdir(outDir, { recursive: true });
 
@@ -325,7 +325,14 @@ try {
 
       console.log(`── ${width}px · prefers-reduced-motion: ${motion}`);
 
-      shots.push(await shoot(page, ".direction-a .a-appwin", join(outDir, `hero-${width}-${tag}.png`), "hero"));
+      shots.push(
+        await shoot(
+          page,
+          ".direction-a .a-appwin",
+          join(outDir, `hero-${width}-${tag}.png`),
+          "hero",
+        ),
+      );
 
       for (const panel of await page.$$("article.panel")) {
         const scene = await panel.evaluate((node) => node.dataset.scene);
@@ -374,7 +381,9 @@ try {
 
 await writeFile(join(outDir, "report.json"), `${JSON.stringify(report, null, 2)}\n`);
 
-console.log(`${report.reduce((n, run) => n + run.shots.length, 0)} images + report.json in ${outDir}`);
+console.log(
+  `${report.reduce((n, run) => n + run.shots.length, 0)} images + report.json in ${outDir}`,
+);
 
 if (failures > 0) {
   console.log(`\n${failures} check(s) FAILED.`);

--- a/scripts/security-regressions.test.ts
+++ b/scripts/security-regressions.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 function sourceFiles(directory: string): string[] {
@@ -14,7 +15,11 @@ function sourceFiles(directory: string): string[] {
 
 describe("terminal diagnostics", () => {
   it("never ships a raw keystroke network tap", () => {
-    const terminalRoot = new URL("../src/terminal/", import.meta.url).pathname;
+    // `fileURLToPath`, not `URL.pathname`: on Windows the latter yields
+    // `/D:/a/…`, which `readdirSync` resolves against the current drive as
+    // `D:\\D:\\a\\…` and cannot open. `scripts/design-language.test.ts` and
+    // `scripts/gallery-entry.test.ts` already carry the same note.
+    const terminalRoot = fileURLToPath(new URL("../src/terminal/", import.meta.url));
     const sources = sourceFiles(terminalRoot)
       .map((file) => readFileSync(file, "utf8"))
       .join("\n");

--- a/scripts/verify-electron-monaco-smoke-package.test.ts
+++ b/scripts/verify-electron-monaco-smoke-package.test.ts
@@ -91,7 +91,9 @@ describe("packaged process cleanup", () => {
         child.stdout.once("data", (data) => resolve(Number(String(data)))),
       );
       await verifierModule.stopChild?.(child);
-      expect(() => process.kill(nestedPid, 0)).toThrow();
+      // ESRCH specifically: EPERM would mean the process is still alive but
+      // owned by another user, which is not the cleanup this asserts.
+      expect(() => process.kill(nestedPid, 0)).toThrow(/ESRCH/);
     } finally {
       if (child.exitCode === null && child.signalCode === null) {
         child.kill("SIGKILL");

--- a/src/files/ui/file-editor.tsx
+++ b/src/files/ui/file-editor.tsx
@@ -1,3 +1,6 @@
+// oxlint-disable react-hooks/exhaustive-deps -- both effects below narrow their
+// deps on purpose and each says why at its own call site; oxlint 1.78 ignores
+// per-line disables for this rule, so the scope is this one file, this one rule.
 /**
  * The editor surface (plan T33).
  *
@@ -81,6 +84,12 @@ export function FileEditor(props: FileEditorProps) {
   // so this effect can resolve after the component has already unmounted —
   // hence `cancelled`. Flipping to a refusal unmounts the host, and the
   // cleanup below disposes the editor with it.
+  //
+  // The narrow dep list is deliberate, so the rule is silenced HERE rather than
+  // relaxed repo-wide: `ready` is a signal this effect WRITES (`ready.value += 1`),
+  // so listing it would re-run the effect that set it and re-create Monaco on
+  // every mount, forever; and `props.controller` is a stable per-surface object
+  // whose identity must not tear down and re-create the editor.
   useEffect(() => {
     const host = hostRef.current;
     if (host === null) {
@@ -193,6 +202,10 @@ export function FileEditor(props: FileEditorProps) {
 
   // Swap the model when the path changes, and re-apply the content whenever the
   // document's baseline moves — a reload, or the first read landing.
+  //
+  // Silenced HERE, not repo-wide: the effect reads only `document.text` and
+  // `document.file`, and both are listed. Depending on `document` itself would
+  // re-swap the model on every identity change of an unchanged document.
   useEffect(() => {
     const handle = handleRef.current;
     if (handle === null || document === undefined) {

--- a/src/gallery/agent-rail-variants.tsx
+++ b/src/gallery/agent-rail-variants.tsx
@@ -605,9 +605,7 @@ function FlatAgentRow({ pane }: { readonly pane: TreePane }) {
 }
 
 function ClusterHead({ cluster }: { readonly cluster: GroupingCluster }) {
-  return cluster.labelled ? (
-    <span class="gxa-head gxa-head--label">{cluster.project}</span>
-  ) : null;
+  return cluster.labelled ? <span class="gxa-head gxa-head--label">{cluster.project}</span> : null;
 }
 
 /** A — what ships today: every pane is a row and the tab leaves no trace. */
@@ -618,9 +616,7 @@ function FlatColumn() {
         <section key={cluster.project} class="gxa-cluster">
           <ClusterHead cluster={cluster} />
           {cluster.tabs.flatMap((tab) =>
-            tab.panes.map((pane) => (
-              <FlatAgentRow key={`${tab.name}-${pane.agent}`} pane={pane} />
-            )),
+            tab.panes.map((pane) => <FlatAgentRow key={`${tab.name}-${pane.agent}`} pane={pane} />),
           )}
         </section>
       ))}
@@ -645,11 +641,7 @@ function FlatColumn() {
  * 2026-08-16 and nothing has set since `TabPopover` was deleted. Cyan and
  * magenta on purpose — red and yellow are the status dot's words.
  */
-function BandedColumn({
-  mark,
-}: {
-  readonly mark: "rule" | "wash" | "outline" | "tint";
-}) {
+function BandedColumn({ mark }: { readonly mark: "rule" | "wash" | "outline" | "tint" }) {
   return (
     <div class="gxa-rail">
       {GROUPING_CLUSTERS.map((cluster) => (
@@ -759,8 +751,8 @@ export function multiAgentGroupingSpecimen() {
           <span class="gxa-variant__index">B3</span>
           <span class="gxa-variant__title">band, outline — SHIPPING</span>
           <span class="gxa-variant__note">
-            DL-27.19 since 2026-08-20: a rounded hairline frame draws the
-            block's own edge; two tabs back to back close as two objects
+            DL-27.19 since 2026-08-20: a rounded hairline frame draws the block's own edge; two tabs
+            back to back close as two objects
           </span>
         </div>
         <BandedColumn mark="outline" />
@@ -770,8 +762,8 @@ export function multiAgentGroupingSpecimen() {
           <span class="gxa-variant__index">B4</span>
           <span class="gxa-variant__title">band, outline in tab colour</span>
           <span class="gxa-variant__note">
-            turned down 2026-08-20: the same frame wearing the tab's own dot
-            colour, which the status dot's red and yellow would fight
+            turned down 2026-08-20: the same frame wearing the tab's own dot colour, which the
+            status dot's red and yellow would fight
           </span>
         </div>
         <BandedColumn mark="tint" />

--- a/src/gallery/chrome-fixtures.tsx
+++ b/src/gallery/chrome-fixtures.tsx
@@ -33,13 +33,7 @@ export const NOOP = (): void => {};
 
 /** The shipping leading frame cluster, with drag disabled in the gallery. */
 export function sidebarFrameActionsSpecimen(onToggle = NOOP) {
-  return (
-    <SidebarFrameActions
-      collapsed={false}
-      onToggle={onToggle}
-      onOpenWorkspace={NOOP}
-    />
-  );
+  return <SidebarFrameActions collapsed={false} onToggle={onToggle} onOpenWorkspace={NOOP} />;
 }
 
 /**

--- a/src/gallery/rail-structure-variants.tsx
+++ b/src/gallery/rail-structure-variants.tsx
@@ -139,11 +139,7 @@ function TabMap({ tab }: { readonly tab: MapTab }) {
       {tab.rows.map((row, rowIndex) => (
         <span key={rowIndex} class="gxs-map__row">
           {row.map((pane) => (
-            <span
-              key={pane.agent}
-              class="gxs-map__pane"
-              data-state={pane.state}
-            >
+            <span key={pane.agent} class="gxs-map__pane" data-state={pane.state}>
               <AgentGlyph agent={pane.agent} className="gxs-map__logo" />
             </span>
           ))}
@@ -154,19 +150,11 @@ function TabMap({ tab }: { readonly tab: MapTab }) {
 }
 
 /** The loudest pane's state, the rollup the row mark already speaks with. */
-const STATE_ORDER: readonly RailState[] = [
-  "failed",
-  "asked",
-  "working",
-  "done",
-  "idle",
-];
+const STATE_ORDER: readonly RailState[] = ["failed", "asked", "working", "done", "idle"];
 
 function rollup(tab: MapTab): RailState {
   const states = tab.rows.flat().map((pane) => pane.state);
-  return (
-    STATE_ORDER.find((state) => states.includes(state)) ?? ("idle" as RailState)
-  );
+  return STATE_ORDER.find((state) => states.includes(state)) ?? ("idle" as RailState);
 }
 
 /**
@@ -189,11 +177,7 @@ function MapColumn({
   readonly carrier: "map" | "row";
 }) {
   return (
-    <div
-      class="gxs-rail"
-      data-carrier={carrier}
-      style={{ width: `${width}px` }}
-    >
+    <div class="gxs-rail" data-carrier={carrier} style={{ width: `${width}px` }}>
       {CLUSTERS.map((cluster) => (
         <section key={cluster.project} class="gxs-cluster">
           <span class="gxs-head">{cluster.project}</span>
@@ -206,13 +190,9 @@ function MapColumn({
               <TabMap tab={tab} />
               <span class="gxs-card__body">
                 <span class="gxs-card__line">
-                  {tab.name !== "" && (
-                    <strong class="gxs-card__name">{tab.name}</strong>
-                  )}
+                  {tab.name !== "" && <strong class="gxs-card__name">{tab.name}</strong>}
                   <span class="gxs-card__msg">
-                    {tab.message !== ""
-                      ? tab.message
-                      : tab.rows.flat()[0].agent}
+                    {tab.message !== "" ? tab.message : tab.rows.flat()[0].agent}
                   </span>
                 </span>
                 {tab.age !== "" && <span class="gxs-card__age">{tab.age}</span>}
@@ -228,11 +208,8 @@ function MapColumn({
 
 /** How a collapsed project summarises itself: counts, loudest state first. */
 function summarise(cluster: MapCluster): string {
-  const states = cluster.tabs.flatMap((tab) =>
-    tab.rows.flat().map((pane) => pane.state),
-  );
-  const count = (state: RailState) =>
-    states.filter((each) => each === state).length;
+  const states = cluster.tabs.flatMap((tab) => tab.rows.flat().map((pane) => pane.state));
+  const count = (state: RailState) => states.filter((each) => each === state).length;
   const parts = [
     count("failed") > 0 ? `${count("failed")} failed` : "",
     count("asked") > 0 ? `${count("asked")} asks` : "",
@@ -281,10 +258,7 @@ function DashboardColumn() {
             </div>
             {loudest !== null && !open && (
               <div class="gxs-project__loudest">
-                <AgentGlyph
-                  agent={loudest.agent}
-                  className="gxs-project__logo"
-                />
+                <AgentGlyph agent={loudest.agent} className="gxs-project__logo" />
                 <span class="gxs-project__agent">{loudest.agent}</span>
                 <span class="gxs-card__age">{loudest.age}</span>
                 <RailStatusMark state={loudest.state} />
@@ -301,14 +275,10 @@ function DashboardColumn() {
                   <span class="gxs-card__body">
                     <span class="gxs-card__line">
                       <span class="gxs-card__msg">
-                        {tab.message !== ""
-                          ? tab.message
-                          : tab.rows.flat()[0].agent}
+                        {tab.message !== "" ? tab.message : tab.rows.flat()[0].agent}
                       </span>
                     </span>
-                    {tab.age !== "" && (
-                      <span class="gxs-card__age">{tab.age}</span>
-                    )}
+                    {tab.age !== "" && <span class="gxs-card__age">{tab.age}</span>}
                   </span>
                   <RailStatusMark state={rollup(tab)} />
                 </div>
@@ -344,8 +314,7 @@ export function railStructureSpecimen() {
           <span class="gxs-variant__index">M2</span>
           <span class="gxs-variant__title">tab map — 200px (floor)</span>
           <span class="gxs-variant__note">
-            the same card where the sidebar is narrowest — the case the map has
-            to survive
+            the same card where the sidebar is narrowest — the case the map has to survive
           </span>
         </div>
         <MapColumn width={200} carrier="map" />
@@ -355,8 +324,7 @@ export function railStructureSpecimen() {
           <span class="gxs-variant__index">M3</span>
           <span class="gxs-variant__title">tab map, uncoloured — 275px</span>
           <span class="gxs-variant__note">
-            topology only; state stays on the one row mark, so no state is said
-            twice (DL-27.2)
+            topology only; state stays on the one row mark, so no state is said twice (DL-27.2)
           </span>
         </div>
         <MapColumn width={275} carrier="row" />
@@ -366,8 +334,8 @@ export function railStructureSpecimen() {
           <span class="gxs-variant__index">P</span>
           <span class="gxs-variant__title">project dashboard</span>
           <span class="gxs-variant__note">
-            one row per project, counts in the header, the loudest agent named;
-            the open project shows its tabs
+            one row per project, counts in the header, the loudest agent named; the open project
+            shows its tabs
           </span>
         </div>
         <DashboardColumn />
@@ -424,12 +392,7 @@ function LadderColumn({ level }: { readonly level: 1 | 2 | 3 }) {
               )
             : cluster.tabs.map((tab, tabIndex) => {
                 const panes = tab.rows.flat();
-                const label =
-                  tab.name !== ""
-                    ? tab.name
-                    : panes.length === 1
-                      ? panes[0].agent
-                      : "";
+                const label = tab.name !== "" ? tab.name : panes.length === 1 ? panes[0].agent : "";
                 return (
                   <div
                     key={`${cluster.project}-${tabIndex}`}
@@ -448,10 +411,7 @@ function LadderColumn({ level }: { readonly level: 1 | 2 | 3 }) {
                                 : undefined
                             }
                           >
-                            <AgentGlyph
-                              agent={pane.agent}
-                              className="gxs-lad__logo"
-                            />
+                            <AgentGlyph agent={pane.agent} className="gxs-lad__logo" />
                           </span>
                         ))}
                       </span>
@@ -482,8 +442,7 @@ export function railSimplicityLadderSpecimen() {
           <span class="gxs-variant__index">L1</span>
           <span class="gxs-variant__title">less ink — one row per pane</span>
           <span class="gxs-variant__note">
-            the sentence and the age are gone; the row is glyph, agent, mark.
-            Reverts DL-27.15
+            the sentence and the age are gone; the row is glyph, agent, mark. Reverts DL-27.15
           </span>
         </div>
         <LadderColumn level={1} />
@@ -493,8 +452,7 @@ export function railSimplicityLadderSpecimen() {
           <span class="gxs-variant__index">L2</span>
           <span class="gxs-variant__title">fewer rows — one row per tab</span>
           <span class="gxs-variant__note">
-            agents as glyphs, badged only when that pane is loud — the rail
-            spec's own §2.1 row
+            agents as glyphs, badged only when that pane is loud — the rail spec's own §2.1 row
           </span>
         </div>
         <LadderColumn level={2} />

--- a/src/gallery/sections/chrome-section.tsx
+++ b/src/gallery/sections/chrome-section.tsx
@@ -112,11 +112,11 @@ export function ChromeSection() {
             // seam, and a seam a screenshot cannot drag is only a cursor
             // change.
             sidebarToggle={
-              railCollapsed.value ? null : (
-                sidebarFrameActionsSpecimen(() => {
-                  railCollapsed.value = true;
-                })
-              )
+              railCollapsed.value
+                ? null
+                : sidebarFrameActionsSpecimen(() => {
+                    railCollapsed.value = true;
+                  })
             }
             toolbar={null}
             sidebarNavigation={agentRailNavigationSpecimen({

--- a/src/gallery/sections/launch-profiles-section.tsx
+++ b/src/gallery/sections/launch-profiles-section.tsx
@@ -20,9 +20,7 @@ import { SectionHead, Specimen } from "../specimen";
  * owner's real `settings.json`.
  */
 
-const SEEDED: readonly LaunchProfile[] = [
-  { id: "lp:opencode-auto", command: "opencode --auto" },
-];
+const SEEDED: readonly LaunchProfile[] = [{ id: "lp:opencode-auto", command: "opencode --auto" }];
 
 const SEEDED_DEFAULTS: Readonly<Record<string, string>> = {
   opencode: "lp:opencode-auto",

--- a/src/gallery/sections/matrix-section.tsx
+++ b/src/gallery/sections/matrix-section.tsx
@@ -9,19 +9,11 @@ import {
 } from "../../lib/derive-colors";
 import { applyThemeVars } from "../../lib/theme-vars";
 import { settings } from "../../settings/settings-store";
-import {
-  resolveTheme,
-  THEME_PRESETS,
-  type ThemePreset,
-} from "../../settings/themes";
+import { resolveTheme, THEME_PRESETS, type ThemePreset } from "../../settings/themes";
 import { DesktopChrome } from "../../ui/desktop-chrome";
 import { StatusBar } from "../../ui/status-bar";
 import { DockToggle } from "../../ui/dock/dock-toggle";
-import {
-  ConfigGroup,
-  ConfigRow,
-  ToggleRow,
-} from "../../ui/controls/config-row";
+import { ConfigGroup, ConfigRow, ToggleRow } from "../../ui/controls/config-row";
 import {
   agentRailNavigationSpecimen,
   deckToolbarSpecimen,
@@ -30,11 +22,7 @@ import {
   sidebarFrameActionsSpecimen,
   tabBarSpecimen,
 } from "../chrome-fixtures";
-import {
-  FORCE_CLASS,
-  installForcedStates,
-  type ForcedState,
-} from "../force-states";
+import { FORCE_CLASS, installForcedStates, type ForcedState } from "../force-states";
 import { SectionHead } from "../specimen";
 import { TreatmentDirectionReview } from "./treatment-direction-review";
 /**
@@ -154,8 +142,7 @@ const STATE_ROWS: readonly StateRow[] = [
  * so the caption now names the treatment the row is showing rather than the
  * absence it used to show.
  */
-const DISABLED_FINDING =
-  "--text-faint, hover border and hint accent both off (DL-5.2, DL-21.4)";
+const DISABLED_FINDING = "--text-faint, hover border and hint accent both off (DL-5.2, DL-21.4)";
 
 /**
  * A theme scope. `applyThemeVars` takes a `CSSStyleDeclaration`, so pointing it
@@ -217,25 +204,19 @@ function WindowCell({
         <span class="gx-native-terminal__prompt">❯</span> npm test
       </p>
       <p class="gx-native-terminal__result">✓ 2631 tests passed</p>
-      <p class="gx-native-terminal__muted">
-        terminal stage remains at full contrast
-      </p>
+      <p class="gx-native-terminal__muted">terminal stage remains at full contrast</p>
     </div>
   ) : null;
 
   return (
     <DesktopChrome
       sidebar={sidebar}
-      sidebarToggle={
-        sidebar ? sidebarFrameActionsSpecimen() : null
-      }
+      sidebarToggle={sidebar ? sidebarFrameActionsSpecimen() : null}
       // The shipping frame row carries window controls only in sidebar mode;
       // its toolbar lives at the trailing end of the stage strip.
       toolbar={null}
       sidebarNavigation={
-        sidebar
-          ? agentRailNavigationSpecimen({ promptsDisabled: disabled })
-          : null
+        sidebar ? agentRailNavigationSpecimen({ promptsDisabled: disabled }) : null
       }
       topTabs={sidebar ? null : tabBarSpecimen({ promptsDisabled: disabled })}
       stage={
@@ -287,11 +268,7 @@ function ControlCell({ disabled }: { disabled: boolean }) {
         </button>
       </ConfigRow>
       <ConfigRow label="Restore defaults" danger>
-        <button
-          type="button"
-          class="cfg-btn cfg-btn--danger"
-          disabled={disabled}
-        >
+        <button type="button" class="cfg-btn cfg-btn--danger" disabled={disabled}>
           reset
         </button>
       </ConfigRow>
@@ -305,10 +282,7 @@ function ControlCell({ disabled }: { disabled: boolean }) {
  * built sheet rather than written here, because a hand-kept list would go on
  * claiming `:active` is missing the day somebody adds one.
  */
-function rowFinding(
-  row: StateRow,
-  absent: readonly ForcedState[],
-): string | null {
+function rowFinding(row: StateRow, absent: readonly ForcedState[]): string | null {
   if (row.force !== null && absent.includes(row.force)) {
     return `identical to selected: styles.css declares no ${row.force === "focus" ? ":focus" : `:${row.force}`} rule`;
   }
@@ -407,12 +381,7 @@ const NATIVE_BALANCED_TYPE_SCALE = {
  * painted by the shipping variable and the readout is the same value measured
  * back off the DOM.
  */
-const TYPE_SCALE_TOKENS = [
-  "--type-title",
-  "--type-body",
-  "--type-meta",
-  "--type-micro",
-] as const;
+const TYPE_SCALE_TOKENS = ["--type-title", "--type-body", "--type-meta", "--type-micro"] as const;
 
 const TYPE_SCALE_ALIAS = [
   "--gx-type-title:var(--type-title)",
@@ -422,38 +391,22 @@ const TYPE_SCALE_ALIAS = [
 ].join(";");
 
 function contrastRows(preset: ThemePreset) {
-  const chrome = deriveChromeColors(
-    preset.theme.background,
-    preset.theme.foreground,
-  );
-  const commonSurfaces = [
-    chrome.sidebarBg,
-    chrome.chrome1,
-    chrome.chrome2,
-    chrome.tabActiveBg,
-  ];
+  const chrome = deriveChromeColors(preset.theme.background, preset.theme.foreground);
+  const commonSurfaces = [chrome.sidebarBg, chrome.chrome1, chrome.chrome2, chrome.tabActiveBg];
 
   return TEXT_CONTRAST_ROLES.map((role) => {
-    const surfaces =
-      role.id === "primary"
-        ? [chrome.inputBg, ...commonSurfaces]
-        : commonSurfaces;
+    const surfaces = role.id === "primary" ? [chrome.inputBg, ...commonSurfaces] : commonSurfaces;
     return {
       ...role,
       minimum: Math.min(
-        ...surfaces.map((surface) =>
-          contrastRatio(chrome[role.colorKey], surface),
-        ),
+        ...surfaces.map((surface) => contrastRatio(chrome[role.colorKey], surface)),
       ),
     };
   });
 }
 
 function surfaceContrastRows(preset: ThemePreset) {
-  const chrome = deriveChromeColors(
-    preset.theme.background,
-    preset.theme.foreground,
-  );
+  const chrome = deriveChromeColors(preset.theme.background, preset.theme.foreground);
   const surfaces = [
     { id: "stage", label: "Stage", color: preset.theme.background },
     { id: "sidebar", label: "Sidebar", color: chrome.sidebarBg },
@@ -482,19 +435,13 @@ function ContrastReview() {
       <header class="gx-specimen__head">
         <span class="gx-specimen__name">text contrast ladder</span>
         <span class="gx-specimen__note">
-          minimum ratio across the real sidebar, chrome, selected and input
-          surfaces · 4 themes · live derived tokens
+          minimum ratio across the real sidebar, chrome, selected and input surfaces · 4 themes ·
+          live derived tokens
         </span>
       </header>
       <div class="gx-contrast-grid">
         {THEME_PRESETS.map((preset) => (
-          <ThemeCell
-            key={preset.id}
-            themeId={preset.id}
-            force={null}
-            inactive={false}
-            width={270}
-          >
+          <ThemeCell key={preset.id} themeId={preset.id} force={null} inactive={false} width={270}>
             <article class="gx-contrast-card">
               <header class="gx-contrast-card__head">
                 <strong>{preset.label}</strong>
@@ -515,9 +462,7 @@ function ContrastReview() {
               {contrastRows(preset).map((role) => (
                 <div key={role.id} class="gx-contrast-row">
                   <div>
-                    <span
-                      class={`gx-contrast-row__sample gx-contrast-row__sample--${role.id}`}
-                    >
+                    <span class={`gx-contrast-row__sample gx-contrast-row__sample--${role.id}`}>
                       {role.sample}
                     </span>
                     <span class="gx-contrast-row__use">{role.use}</span>
@@ -543,8 +488,8 @@ function SurfaceContrastReview() {
       <header class="gx-specimen__head">
         <span class="gx-specimen__name">text-to-surface contrast</span>
         <span class="gx-specimen__note">
-          each number is measured independently · green meets that text role's
-          floor · amber exposes a pairing that must not be used
+          each number is measured independently · green meets that text role's floor · amber exposes
+          a pairing that must not be used
         </span>
       </header>
       <div class="gx-surface-matrix-grid">
@@ -567,9 +512,7 @@ function SurfaceContrastReview() {
                   <span />
                   {matrix.surfaces.map((surface) => (
                     <span key={surface.id} class="gx-surface-matrix__surface">
-                      <i
-                        class={`gx-surface-matrix__dot gx-surface-matrix__dot--${surface.id}`}
-                      />
+                      <i class={`gx-surface-matrix__dot gx-surface-matrix__dot--${surface.id}`} />
                       {surface.label}
                     </span>
                   ))}
@@ -621,9 +564,9 @@ function TypeScaleReview() {
     if (node === null) return;
     const style = getComputedStyle(node);
     setSizes(
-      TYPE_SCALE_TOKENS.map((token) =>
-        style.getPropertyValue(token).trim(),
-      ).filter((value) => value !== ""),
+      TYPE_SCALE_TOKENS.map((token) => style.getPropertyValue(token).trim()).filter(
+        (value) => value !== "",
+      ),
     );
   }, []);
   return (
@@ -631,8 +574,7 @@ function TypeScaleReview() {
       <header class="gx-specimen__head">
         <span class="gx-specimen__name">type hierarchy</span>
         <span class="gx-specimen__note">
-          Native balanced · selected gallery theme · sized by the shipping
-          --type-* variables
+          Native balanced · selected gallery theme · sized by the shipping --type-* variables
         </span>
       </header>
       <div class="gx-type-grid">
@@ -643,18 +585,14 @@ function TypeScaleReview() {
           </header>
           <div class="gx-type-card__sample">
             <strong class="gx-type-card__title">Workspace settings</strong>
-            <span class="gx-type-card__body">
-              Restore tabs and agent sessions when Deck opens.
-            </span>
+            <span class="gx-type-card__body">Restore tabs and agent sessions when Deck opens.</span>
             <span class="gx-type-card__meta">Resumed 2 min ago</span>
             <span class="gx-type-card__micro">⌘⇧B · Toggle explorer</span>
           </div>
           {/* Empty until the layout effect has run, and empty for good if
               `styles.css` ever stops declaring the tokens — which is a finding
               worth seeing, not a gap worth filling with a written-down number. */}
-          <footer>
-            {sizes.length === 0 ? "--type-* not resolved" : sizes.join(" / ")}
-          </footer>
+          <footer>{sizes.length === 0 ? "--type-* not resolved" : sizes.join(" / ")}</footer>
         </article>
       </div>
     </section>
@@ -673,8 +611,7 @@ function NativeWindowReview() {
       <header class="gx-specimen__head">
         <span class="gx-specimen__name">native window treatment</span>
         <span class="gx-specimen__note">
-          real Deck chrome · selected gallery theme · inactive is a proposal,
-          not shipping policy
+          real Deck chrome · selected gallery theme · inactive is a proposal, not shipping policy
         </span>
       </header>
       <div class="gx-native-detail-strip">
@@ -721,11 +658,7 @@ function MatrixBlock({
         <div class="gx-matrix__row">
           <span class="gx-matrix__rowhead" />
           {THEME_PRESETS.map((preset) => (
-            <span
-              key={preset.id}
-              class="gx-matrix__colhead"
-              style={{ width: `${CELL_WIDTH}px` }}
-            >
+            <span key={preset.id} class="gx-matrix__colhead" style={{ width: `${CELL_WIDTH}px` }}>
               {preset.id}
             </span>
           ))}
@@ -736,9 +669,7 @@ function MatrixBlock({
               <span class="gx-matrix__statename">{row.id}</span>
               <span class="gx-matrix__statenote">{row.note}</span>
               {rowFinding(row, absent) !== null && (
-                <span class="gx-matrix__finding">
-                  {rowFinding(row, absent)}
-                </span>
+                <span class="gx-matrix__finding">{rowFinding(row, absent)}</span>
               )}
             </span>
             {THEME_PRESETS.map((preset) => (
@@ -748,9 +679,7 @@ function MatrixBlock({
                 force={row.force}
                 inactive={row.inactive}
               >
-                <div
-                  class={`gx-cell__inner ${tall ? "gx-cell__inner--tall" : ""}`}
-                >
+                <div class={`gx-cell__inner ${tall ? "gx-cell__inner--tall" : ""}`}>
                   {render(row.disabled)}
                 </div>
               </ThemeCell>
@@ -785,9 +714,7 @@ export function MatrixSection() {
           specimens below inherit them from the theme itself and a gallery-only
           override would only be able to disagree with what ships. */}
       <TreatmentDirectionReview
-        renderWindow={() => (
-          <WindowCell sidebar disabled={false} stageWitness />
-        )}
+        renderWindow={() => <WindowCell sidebar disabled={false} stageWitness />}
       />
       <TypeScaleReview />
       <ContrastReview />
@@ -799,9 +726,7 @@ export function MatrixSection() {
         note="real DesktopChrome; hover, active and focus are the app's own rules re-scoped, not copies"
         tall
         absent={absent}
-        render={(disabled) => (
-          <WindowCell sidebar={false} disabled={disabled} />
-        )}
+        render={(disabled) => <WindowCell sidebar={false} disabled={disabled} />}
       />
 
       <MatrixBlock

--- a/src/gallery/sections/navigation-section.tsx
+++ b/src/gallery/sections/navigation-section.tsx
@@ -6,10 +6,7 @@ import {
   restingMarkVariantsSpecimen,
   statePaletteSpecimen,
 } from "../agent-rail-variants";
-import {
-  railSimplicityLadderSpecimen,
-  railStructureSpecimen,
-} from "../rail-structure-variants";
+import { railSimplicityLadderSpecimen, railStructureSpecimen } from "../rail-structure-variants";
 import { SectionHead, Specimen } from "../specimen";
 
 export function NavigationSection() {

--- a/src/lib/derive-colors.test.ts
+++ b/src/lib/derive-colors.test.ts
@@ -26,10 +26,7 @@ describe("contrastRatio", () => {
   });
 
   it("is symmetric", () => {
-    expect(contrastRatio("#16161e", "#c0caf5")).toBeCloseTo(
-      contrastRatio("#c0caf5", "#16161e"),
-      5,
-    );
+    expect(contrastRatio("#16161e", "#c0caf5")).toBeCloseTo(contrastRatio("#c0caf5", "#16161e"), 5);
   });
 });
 
@@ -110,13 +107,7 @@ describe("deriveChromeColors", () => {
           continue;
         }
         const c = deriveChromeColors(bg, fg);
-        const ladder = [
-          c.inputBg,
-          c.sidebarBg,
-          c.chrome1,
-          c.chrome2,
-          c.tabActiveBg,
-        ].map(luminance);
+        const ladder = [c.inputBg, c.sidebarBg, c.chrome1, c.chrome2, c.tabActiveBg].map(luminance);
         for (let step = 1; step < ladder.length; step += 1) {
           expect(ladder[step]).toBeGreaterThan(ladder[step - 1]);
         }
@@ -138,14 +129,10 @@ describe("deriveChromeColors", () => {
       const deckDark = THEME_PRESETS[0];
       expect(deckDark.id).toBe("deck-dark");
       const bg = deckDark.theme.background;
-      expect(deriveChromeColors(bg, deckDark.theme.foreground).sidebarBg).toBe(
-        "#272d31",
-      );
+      expect(deriveChromeColors(bg, deckDark.theme.foreground).sidebarBg).toBe("#272d31");
       // And it is the BACKGROUND that claims it, not the preset: one channel
       // away is a different theme, which derives its own sidebar.
-      expect(deriveChromeColors("#17181d", "#e7e7e7").sidebarBg).not.toBe(
-        "#272d31",
-      );
+      expect(deriveChromeColors("#17181d", "#e7e7e7").sidebarBg).not.toBe("#272d31");
     });
 
     it("preserves the distinction for light and pure-black overrides", () => {
@@ -180,9 +167,7 @@ describe("deriveChromeColors", () => {
      * (2026-08-19).
      */
     const towardTone = (bg: string, color: string): number =>
-      luminance(bg) < DARK_LUMINANCE_THRESHOLD
-        ? lum(color) - lum(bg)
-        : lum(bg) - lum(color);
+      luminance(bg) < DARK_LUMINANCE_THRESHOLD ? lum(color) - lum(bg) : lum(bg) - lum(color);
 
     it("puts a shell seam BELOW the surface it edges, on every preset", () => {
       for (const preset of THEME_PRESETS) {
@@ -217,9 +202,7 @@ describe("deriveChromeColors", () => {
     it("keeps the in-surface divider alpha, so it adapts to its ground", () => {
       const c = deriveChromeColors("#16161e", "#c0caf5");
       expect(c.seamDivider).toBe("rgba(255, 255, 255, 0.12)");
-      expect(deriveChromeColors("#ffffff", "#333333").seamDivider).toBe(
-        "rgba(0, 0, 0, 0.12)",
-      );
+      expect(deriveChromeColors("#ffffff", "#333333").seamDivider).toBe("rgba(0, 0, 0, 0.12)");
     });
   });
 
@@ -230,8 +213,7 @@ describe("deriveChromeColors", () => {
     it("keeps hover quieter than selection on every preset", () => {
       const pairs: readonly (readonly [string, string])[] = [
         ...THEME_PRESETS.map(
-          (preset) =>
-            [preset.theme.background, preset.theme.foreground] as const,
+          (preset) => [preset.theme.background, preset.theme.foreground] as const,
         ),
         ["#ffffff", "#333333"],
       ];
@@ -250,9 +232,7 @@ describe("deriveChromeColors", () => {
       expect(deriveChromeColors("#16161e", "#c0caf5").stateHoverBg).toBe(
         "rgba(255, 255, 255, 0.06)",
       );
-      expect(deriveChromeColors("#ffffff", "#333333").stateHoverBg).toBe(
-        "rgba(0, 0, 0, 0.06)",
-      );
+      expect(deriveChromeColors("#ffffff", "#333333").stateHoverBg).toBe("rgba(0, 0, 0, 0.06)");
     });
   });
 
@@ -292,12 +272,7 @@ describe("deriveChromeColors", () => {
       // inverse the ladder on a dim-foreground theme — textMuted came out
       // LOUDER than textPrimary. primary >= muted >= faint, on every surface.
       const c = deriveChromeColors(bg, fg);
-      for (const surface of [
-        c.sidebarBg,
-        c.chrome1,
-        c.chrome2,
-        c.tabActiveBg,
-      ]) {
+      for (const surface of [c.sidebarBg, c.chrome1, c.chrome2, c.tabActiveBg]) {
         const primary = contrastRatio(c.textPrimary, surface);
         const muted = contrastRatio(c.textMuted, surface);
         const faint = contrastRatio(c.textFaint, surface);
@@ -311,10 +286,7 @@ describe("deriveChromeColors", () => {
     // The floors are stacked (8 / 6 / 4.5) so the label/description
     // hierarchy in a config row survives; guard they never converge.
     for (const preset of THEME_PRESETS) {
-      const c = deriveChromeColors(
-        preset.theme.background,
-        preset.theme.foreground,
-      );
+      const c = deriveChromeColors(preset.theme.background, preset.theme.foreground);
       expect(new Set([c.textPrimary, c.textMuted, c.textFaint]).size).toBe(3);
     }
   });
@@ -327,9 +299,7 @@ describe("deriveChromeColors", () => {
     // white cannot reintroduce a hue. The literal rose from `#d9d9d9` on
     // 2026-08-19 with the raised sidebar: the active row is lighter than it
     // was, so the ink has to climb further to clear it.
-    expect(deriveChromeColors("#16161e", "#cbcbcb").textPrimary).toBe(
-      "#e0e0e0",
-    );
+    expect(deriveChromeColors("#16161e", "#cbcbcb").textPrimary).toBe("#e0e0e0");
   });
 
   it("keeps the built-in text ladder neutral", () => {
@@ -345,10 +315,7 @@ describe("deriveChromeColors", () => {
       return max === 0 ? 0 : (max - min) / max;
     };
     for (const preset of THEME_PRESETS) {
-      const c = deriveChromeColors(
-        preset.theme.background,
-        preset.theme.foreground,
-      );
+      const c = deriveChromeColors(preset.theme.background, preset.theme.foreground);
       for (const tone of [c.textPrimary, c.textMuted, c.textFaint]) {
         expect(saturation(tone)).toBeLessThan(0.06);
       }
@@ -359,12 +326,9 @@ describe("deriveChromeColors", () => {
 describe("checkChromeTextContrast", () => {
   it("accepts every built-in theme", () => {
     for (const preset of THEME_PRESETS) {
-      expect(
-        checkChromeTextContrast(
-          preset.theme.background,
-          preset.theme.foreground,
-        ),
-      ).toEqual({ ok: true });
+      expect(checkChromeTextContrast(preset.theme.background, preset.theme.foreground)).toEqual({
+        ok: true,
+      });
     }
   });
 

--- a/src/lib/derive-colors.ts
+++ b/src/lib/derive-colors.ts
@@ -168,8 +168,7 @@ const PINNED_SIDEBAR_BG: Readonly<Record<string, string>> = Object.freeze({
 });
 
 type ChromeTextToken = "textPrimary" | "textMuted" | "textFaint";
-type ChromeTextSurface =
-  "inputBg" | "sidebarBg" | "chrome1" | "chrome2" | "tabActiveBg";
+type ChromeTextSurface = "inputBg" | "sidebarBg" | "chrome1" | "chrome2" | "tabActiveBg";
 
 export interface ChromeContrastFailure {
   readonly token: ChromeTextToken;
@@ -274,8 +273,7 @@ export function deriveChromeColors(bg: string, fg: string): ChromeColors {
   // darker surface (DL-18.7). Neither direction can land back on `bg`: see
   // `recessedSidebar` for why the old rounding guard is gone.
   const sidebarBg = dark
-    ? (PINNED_SIDEBAR_BG[bg.toLowerCase()] ??
-      mixHex(bg, tone, DARK_SIDEBAR_LIFT))
+    ? (PINNED_SIDEBAR_BG[bg.toLowerCase()] ?? mixHex(bg, tone, DARK_SIDEBAR_LIFT))
     : recessedSidebar(bg);
   const sidebarSeam = mixHex(sidebarBg, bg, 0.5);
   // The chrome ladder stacks ON the sidebar on a dark theme, not on the stage.
@@ -285,21 +283,9 @@ export function deriveChromeColors(bg: string, fg: string): ChromeColors {
   // sidebar makes the separation structural: every chrome surface is above the
   // sidebar by construction, for every theme, including imports.
   const chromeBase = dark ? sidebarBg : bg;
-  const chrome1 = mixHex(
-    chromeBase,
-    tone,
-    dark ? DARK_CHROME_1_STEP : LIGHT_CHROME_1_STEP,
-  );
-  const chrome2 = mixHex(
-    chromeBase,
-    tone,
-    dark ? DARK_CHROME_2_STEP : LIGHT_CHROME_2_STEP,
-  );
-  const tabActiveBg = mixHex(
-    chromeBase,
-    tone,
-    dark ? DARK_TAB_ACTIVE_STEP : LIGHT_TAB_ACTIVE_STEP,
-  );
+  const chrome1 = mixHex(chromeBase, tone, dark ? DARK_CHROME_1_STEP : LIGHT_CHROME_1_STEP);
+  const chrome2 = mixHex(chromeBase, tone, dark ? DARK_CHROME_2_STEP : LIGHT_CHROME_2_STEP);
+  const tabActiveBg = mixHex(chromeBase, tone, dark ? DARK_TAB_ACTIVE_STEP : LIGHT_TAB_ACTIVE_STEP);
   // 6% against the active row's own step: far enough apart that hover cannot be
   // read as "already selected" (DL-21.2), close enough that the two belong to
   // one ladder. The percentage is the reviewed direction's; only its source
@@ -326,12 +312,7 @@ export function deriveChromeColors(bg: string, fg: string): ChromeColors {
   // up louder than the loud one. Mixing toward `bg` can only ever lower
   // contrast, so ordering holds by construction; the `ensureContrast` pass
   // after each mix only pulls a step back up if it undershot its floor.
-  const textPrimary = ensureContrast(
-    fg,
-    [inputBg, ...surfaces],
-    TEXT_PRIMARY_FLOOR,
-    tone,
-  );
+  const textPrimary = ensureContrast(fg, [inputBg, ...surfaces], TEXT_PRIMARY_FLOOR, tone);
   return {
     tone,
     sidebarBg,
@@ -354,11 +335,7 @@ export function deriveChromeColors(bg: string, fg: string): ChromeColors {
     // from `bg` it fell BELOW `chrome2` the moment the ladder moved onto the
     // sidebar (deck-dark: 0.0397 against 0.0409), which is a popover framed in
     // a line darker than its own body.
-    seamRaised: mixHex(
-      chromeBase,
-      tone,
-      dark ? DARK_SEAM_RAISED_STEP : LIGHT_SEAM_RAISED_STEP,
-    ),
+    seamRaised: mixHex(chromeBase, tone, dark ? DARK_SEAM_RAISED_STEP : LIGHT_SEAM_RAISED_STEP),
     // Alpha, because this one runs INSIDE a single surface and has to adapt to
     // whichever one that is — the stage on one pane, `chrome1` on another.
     //
@@ -369,21 +346,11 @@ export function deriveChromeColors(bg: string, fg: string): ChromeColors {
     // 12% is the same weight `hair` carries, one ladder step below `hairStrong`.
     seamDivider: alpha(tone, 0.12),
     textPrimary,
-    textMuted: ensureContrast(
-      mixHex(textPrimary, bg, 0.28),
-      surfaces,
-      TEXT_MUTED_FLOOR,
-      tone,
-    ),
+    textMuted: ensureContrast(mixHex(textPrimary, bg, 0.28), surfaces, TEXT_MUTED_FLOOR, tone),
     // 4.5, not 3: this token styles 10.5–11px text — config row descriptions,
     // workspace paths, the "off" value of every toggle — which WCAG AA rates
     // as normal text, where 3:1 is the non-text floor, not the text one.
-    textFaint: ensureContrast(
-      mixHex(textPrimary, bg, 0.5),
-      surfaces,
-      TEXT_FAINT_FLOOR,
-      tone,
-    ),
+    textFaint: ensureContrast(mixHex(textPrimary, bg, 0.5), surfaces, TEXT_FAINT_FLOOR, tone),
   };
 }
 
@@ -395,10 +362,7 @@ export function deriveChromeColors(bg: string, fg: string): ChromeColors {
  * fallback, while imported files call this boundary check and are rejected
  * before an unreadable theme can become selectable.
  */
-export function checkChromeTextContrast(
-  bg: string,
-  fg: string,
-): ChromeContrastCheck {
+export function checkChromeTextContrast(bg: string, fg: string): ChromeContrastCheck {
   const chrome = deriveChromeColors(bg, fg);
   const surfaces: Readonly<Record<ChromeTextSurface, string>> = {
     inputBg: chrome.inputBg,
@@ -408,21 +372,9 @@ export function checkChromeTextContrast(
     tabActiveBg: chrome.tabActiveBg,
   };
   const checks: readonly [ChromeTextToken, number, ChromeTextSurface[]][] = [
-    [
-      "textPrimary",
-      TEXT_PRIMARY_FLOOR,
-      Object.keys(surfaces) as ChromeTextSurface[],
-    ],
-    [
-      "textMuted",
-      TEXT_MUTED_FLOOR,
-      ["sidebarBg", "chrome1", "chrome2", "tabActiveBg"],
-    ],
-    [
-      "textFaint",
-      TEXT_FAINT_FLOOR,
-      ["sidebarBg", "chrome1", "chrome2", "tabActiveBg"],
-    ],
+    ["textPrimary", TEXT_PRIMARY_FLOOR, Object.keys(surfaces) as ChromeTextSurface[]],
+    ["textMuted", TEXT_MUTED_FLOOR, ["sidebarBg", "chrome1", "chrome2", "tabActiveBg"]],
+    ["textFaint", TEXT_FAINT_FLOOR, ["sidebarBg", "chrome1", "chrome2", "tabActiveBg"]],
   ];
   const failures = checks.flatMap(([token, required, names]) =>
     names.flatMap((surface) => {

--- a/src/lib/external-app-catalog.ts
+++ b/src/lib/external-app-catalog.ts
@@ -17,8 +17,12 @@
 /** The four kinds of app, in menu order; a hairline separates them (DL-23.5). */
 export type ExternalAppGroup = "editor" | "git" | "files" | "terminal";
 
-export const EXTERNAL_APP_GROUP_ORDER: readonly ExternalAppGroup[] =
-  Object.freeze(["editor", "git", "files", "terminal"]);
+export const EXTERNAL_APP_GROUP_ORDER: readonly ExternalAppGroup[] = Object.freeze([
+  "editor",
+  "git",
+  "files",
+  "terminal",
+]);
 
 /**
  * What an app is actually handed, for a target of a given kind.
@@ -120,9 +124,7 @@ export const EXTERNAL_APPS = [
 
 export type ExternalAppId = (typeof EXTERNAL_APPS)[number]["id"];
 
-export const EXTERNAL_APP_IDS: readonly ExternalAppId[] = EXTERNAL_APPS.map(
-  (app) => app.id,
-);
+export const EXTERNAL_APP_IDS: readonly ExternalAppId[] = EXTERNAL_APPS.map((app) => app.id);
 
 export function isExternalAppId(value: unknown): value is ExternalAppId {
   return EXTERNAL_APP_IDS.includes(value as ExternalAppId);
@@ -140,9 +142,7 @@ export function externalApp(id: ExternalAppId): ExternalApp {
  * `open -a` can name a file but never a position in it. Everything else goes
  * through `open_in_app`, which never claims to.
  */
-export function editorIdOf(
-  id: ExternalAppId,
-): "vscode" | "cursor" | "zed" | null {
+export function editorIdOf(id: ExternalAppId): "vscode" | "cursor" | "zed" | null {
   switch (id) {
     case "vscode":
       return "vscode";

--- a/src/lib/launch-command.test.ts
+++ b/src/lib/launch-command.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  applyResumeFlags,
-  defaultLaunchCommand,
-  resolveLaunchCommand,
-} from "./launch-command";
+import { applyResumeFlags, defaultLaunchCommand, resolveLaunchCommand } from "./launch-command";
 import type { LaunchProfile } from "./launch-profile";
 
 const plan: LaunchProfile = {
@@ -18,9 +14,7 @@ const sandboxed: LaunchProfile = {
 
 describe("resolveLaunchCommand", () => {
   it("returns the profile's command when the binary matches the agent", () => {
-    expect(resolveLaunchCommand("claude", "lp:plan", [plan])).toBe(
-      plan.command,
-    );
+    expect(resolveLaunchCommand("claude", "lp:plan", [plan])).toBe(plan.command);
   });
 
   it("refuses a command belonging to another agent", () => {
@@ -36,16 +30,12 @@ describe("resolveLaunchCommand", () => {
 
 describe("defaultLaunchCommand", () => {
   it("reads the agent's starred command", () => {
-    expect(defaultLaunchCommand("claude", [plan], { claude: "lp:plan" })).toBe(
-      plan.command,
-    );
+    expect(defaultLaunchCommand("claude", [plan], { claude: "lp:plan" })).toBe(plan.command);
   });
 
   it("returns null when the agent has no default", () => {
     expect(defaultLaunchCommand("claude", [plan], {})).toBeNull();
-    expect(
-      defaultLaunchCommand(null, [plan], { claude: "lp:plan" }),
-    ).toBeNull();
+    expect(defaultLaunchCommand(null, [plan], { claude: "lp:plan" })).toBeNull();
   });
 });
 
@@ -57,23 +47,15 @@ describe("applyResumeFlags", () => {
   });
 
   it("leaves every other agent's resume command alone", () => {
-    expect(applyResumeFlags("codex resume abc123", sandboxed.command)).toBe(
-      "codex resume abc123",
-    );
-    expect(applyResumeFlags("claude --continue", null)).toBe(
-      "claude --continue",
-    );
+    expect(applyResumeFlags("codex resume abc123", sandboxed.command)).toBe("codex resume abc123");
+    expect(applyResumeFlags("claude --continue", null)).toBe("claude --continue");
   });
 
   it("leaves a resume command that is not claude's own alone", () => {
-    expect(applyResumeFlags("review --resume x", plan.command)).toBe(
-      "review --resume x",
-    );
+    expect(applyResumeFlags("review --resume x", plan.command)).toBe("review --resume x");
   });
 
   it("adds nothing when the launch command was the bare binary", () => {
-    expect(applyResumeFlags("claude --resume abc", "claude")).toBe(
-      "claude --resume abc",
-    );
+    expect(applyResumeFlags("claude --resume abc", "claude")).toBe("claude --resume abc");
   });
 });

--- a/src/lib/launch-command.ts
+++ b/src/lib/launch-command.ts
@@ -97,10 +97,7 @@ export function agentLaunchCommand(
  * Not runtime-verified: the compatibility claim comes from `claude --help`,
  * not from an observed resume with both sets of flags present.
  */
-export function applyResumeFlags(
-  resumeCommand: string,
-  launchCommand: string | null,
-): string {
+export function applyResumeFlags(resumeCommand: string, launchCommand: string | null): string {
   if (launchCommand === null) {
     return resumeCommand;
   }

--- a/src/lib/launch-profile.test.ts
+++ b/src/lib/launch-profile.test.ts
@@ -26,13 +26,9 @@ describe("commandProblem", () => {
   it("accepts the commands the reference image shows", () => {
     expect(commandProblem("claude")).toBeNull();
     expect(commandProblem("claude --plan")).toBeNull();
-    expect(
-      commandProblem("codex --dangerously-bypass-approvals-and-sandbox"),
-    ).toBeNull();
+    expect(commandProblem("codex --dangerously-bypass-approvals-and-sandbox")).toBeNull();
     expect(commandProblem("cursor-agent --force")).toBeNull();
-    expect(
-      commandProblem("opencode --model anthropic/claude-sonnet-5"),
-    ).toBeNull();
+    expect(commandProblem("opencode --model anthropic/claude-sonnet-5")).toBeNull();
   });
 
   // This string is written VERBATIM into a live interactive shell, so every
@@ -67,9 +63,7 @@ describe("isLaunchCommand", () => {
 describe("commandAgentId / commandFlags", () => {
   it("splits a command into its binary and its flags", () => {
     expect(commandAgentId("claude --permission-mode plan")).toBe("claude");
-    expect(commandFlags("claude --permission-mode plan")).toBe(
-      "--permission-mode plan",
-    );
+    expect(commandFlags("claude --permission-mode plan")).toBe("--permission-mode plan");
     expect(commandAgentId("claude")).toBe("claude");
     expect(commandFlags("claude")).toBe("");
   });
@@ -79,9 +73,7 @@ describe("createLaunchProfileId", () => {
   it("mints a prefixed slug and never collides", () => {
     expect(createLaunchProfileId("claude --plan", [])).toBe("lp:claude-plan");
     expect(
-      createLaunchProfileId("claude --plan", [
-        { id: "lp:claude-plan", command: "claude --plan" },
-      ]),
+      createLaunchProfileId("claude --plan", [{ id: "lp:claude-plan", command: "claude --plan" }]),
     ).toBe("lp:claude-plan-2");
   });
 });
@@ -110,9 +102,7 @@ describe("validateLaunchProfiles", () => {
   it("drops a profile rather than repairing it", () => {
     expect(validateLaunchProfiles("nope")).toEqual([]);
     expect(validateLaunchProfiles([{ id: "lp:x" }])).toEqual([]);
-    expect(
-      validateLaunchProfiles([{ id: "lp:x", command: "claude; rm -rf /" }]),
-    ).toEqual([]);
+    expect(validateLaunchProfiles([{ id: "lp:x", command: "claude; rm -rf /" }])).toEqual([]);
     expect(validateLaunchProfiles([{ id: 7, command: "claude" }])).toEqual([]);
   });
 
@@ -124,18 +114,14 @@ describe("validateLaunchProfiles", () => {
 
 describe("validateDefaultLaunchProfiles", () => {
   it("keeps a mapping that points at a command for that agent", () => {
-    expect(validateDefaultLaunchProfiles({ claude: "lp:plan" }, [plan])).toEqual(
-      { claude: "lp:plan" },
-    );
+    expect(validateDefaultLaunchProfiles({ claude: "lp:plan" }, [plan])).toEqual({
+      claude: "lp:plan",
+    });
   });
 
   it("drops a dangling id and a cross-agent mapping", () => {
-    expect(validateDefaultLaunchProfiles({ claude: "lp:gone" }, [plan])).toEqual(
-      {},
-    );
-    expect(validateDefaultLaunchProfiles({ codex: "lp:plan" }, [plan])).toEqual(
-      {},
-    );
+    expect(validateDefaultLaunchProfiles({ claude: "lp:gone" }, [plan])).toEqual({});
+    expect(validateDefaultLaunchProfiles({ codex: "lp:plan" }, [plan])).toEqual({});
     expect(validateDefaultLaunchProfiles(null, [plan])).toEqual({});
   });
 });

--- a/src/lib/launch-profile.ts
+++ b/src/lib/launch-profile.ts
@@ -103,10 +103,7 @@ function slugify(command: string): string {
     .slice(0, 40);
 }
 
-export function createLaunchProfileId(
-  command: string,
-  existing: readonly LaunchProfile[],
-): string {
+export function createLaunchProfileId(command: string, existing: readonly LaunchProfile[]): string {
   const base = slugify(command) || "command";
   const taken = new Set(existing.map((profile) => profile.id));
   const first = `${LAUNCH_PROFILE_ID_PREFIX}${base}`;
@@ -126,9 +123,7 @@ export function profilesForAgent(
   agentId: string,
   profiles: readonly LaunchProfile[],
 ): readonly LaunchProfile[] {
-  return profiles.filter(
-    (profile) => commandAgentId(profile.command) === agentId,
-  );
+  return profiles.filter((profile) => commandAgentId(profile.command) === agentId);
 }
 
 export function findLaunchProfile(
@@ -182,9 +177,7 @@ export function validateDefaultLaunchProfiles(
     return {};
   }
   const result: Record<string, string> = {};
-  for (const [agentId, profileId] of Object.entries(
-    raw as Record<string, unknown>,
-  )) {
+  for (const [agentId, profileId] of Object.entries(raw as Record<string, unknown>)) {
     if (typeof profileId !== "string") {
       continue;
     }

--- a/src/lib/link-target.test.ts
+++ b/src/lib/link-target.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  decideLinkTarget,
-  externalAppLabel,
-  resolveExternalApp,
-} from "./link-target";
+import { decideLinkTarget, externalAppLabel, resolveExternalApp } from "./link-target";
 import {
   editorIdOf,
   EXTERNAL_APPS,
@@ -116,9 +112,7 @@ describe("resolveExternalApp", () => {
   it("falls back to the first installed app in catalog order", () => {
     // This is where a migrated `custom` editor command lands (design §5), and
     // where an app uninstalled while Deck runs lands too.
-    expect(resolveExternalApp("gitkraken", ["vscode", "finder"])).toBe(
-      "vscode",
-    );
+    expect(resolveExternalApp("gitkraken", ["vscode", "finder"])).toBe("vscode");
     expect(resolveExternalApp(null, ["finder"])).toBe("finder");
   });
 
@@ -171,8 +165,7 @@ describe("the catalog", () => {
 
   it("only the git group resolves a target to a repository", () => {
     for (const app of APPS) {
-      const usesRepo =
-        app.opensFile === "repository" || app.opensFolder === "repository";
+      const usesRepo = app.opensFile === "repository" || app.opensFolder === "repository";
       expect(usesRepo, app.id).toBe(app.group === "git");
     }
   });

--- a/src/lib/link-target.ts
+++ b/src/lib/link-target.ts
@@ -14,11 +14,7 @@
  * agreeing the moment a root is itself a symlink — `/tmp` on macOS is one.
  * This function is handed the ANSWER, not the roots.
  */
-import {
-  editorIdOf,
-  externalApp,
-  type ExternalAppId,
-} from "./external-app-catalog";
+import { editorIdOf, externalApp, type ExternalAppId } from "./external-app-catalog";
 
 export interface LinkDecision {
   /** Absolute, canonical, and already known to be a file. */
@@ -80,8 +76,7 @@ export function decideLinkTarget(decision: LinkDecision): LinkTarget {
   if (decision.appId === null) {
     return {
       kind: "unavailable",
-      reason:
-        "No app is available to open this file — pick one under Settings, in Links & editor.",
+      reason: "No app is available to open this file — pick one under Settings, in Links & editor.",
     };
   }
   const editor = editorIdOf(decision.appId);
@@ -123,9 +118,7 @@ export function resolveExternalApp(
   hostAnswered: boolean = true,
 ): ExternalAppId | null {
   if (!hostAnswered) {
-    return selected !== null && editorIdOf(selected) !== null
-      ? selected
-      : FALLBACK_EDITOR;
+    return selected !== null && editorIdOf(selected) !== null ? selected : FALLBACK_EDITOR;
   }
   if (selected !== null && installed.includes(selected)) {
     return selected;

--- a/src/lib/session-schema.test.ts
+++ b/src/lib/session-schema.test.ts
@@ -121,10 +121,9 @@ describe("SessionPane.launchCommand", () => {
   }
 
   it("keeps a pane's launch command", () => {
-    expect(
-      paneOf("claude --permission-mode plan")
-        ?.launchCommand,
-    ).toBe("claude --permission-mode plan");
+    expect(paneOf("claude --permission-mode plan")?.launchCommand).toBe(
+      "claude --permission-mode plan",
+    );
   });
 
   it("drops an unsafe command without dropping the pane", () => {

--- a/src/lib/session-schema.ts
+++ b/src/lib/session-schema.ts
@@ -71,9 +71,7 @@ function validateSessionPane(raw: unknown): SessionPane {
     // be typed into a live shell, but the pane's cwd and agent are still worth
     // restoring. No SESSION_VERSION bump — the field is optional and a file
     // written before it existed validates to null unchanged.
-    launchCommand: isLaunchCommand(source.launchCommand)
-      ? source.launchCommand
-      : null,
+    launchCommand: isLaunchCommand(source.launchCommand) ? source.launchCommand : null,
   };
 }
 

--- a/src/lib/terminal-links.test.ts
+++ b/src/lib/terminal-links.test.ts
@@ -172,9 +172,7 @@ describe("extractLinkCandidates", () => {
     it("leaves a Claude Code tool line alone", () => {
       // `Read(src/foo.ts)` — the parens are boundaries, not a position, and a
       // single parenthesised number is not one either.
-      expect(
-        extractLinkCandidates("Read(src/foo.ts)").map((c) => c.text),
-      ).toEqual(["src/foo.ts"]);
+      expect(extractLinkCandidates("Read(src/foo.ts)").map((c) => c.text)).toEqual(["src/foo.ts"]);
       expect(extractLinkCandidates("src/foo.ts(3)")[0].text).toBe("src/foo.ts");
     });
 
@@ -199,9 +197,7 @@ describe("extractLinkCandidates", () => {
       expect(file.target).toBe("src/my notes/todo.md");
       // Unquoted, the same text is two candidates and neither is the file.
       expect(
-        extractLinkCandidates("opened src/my notes/todo.md").map(
-          (c) => c.target,
-        ),
+        extractLinkCandidates("opened src/my notes/todo.md").map((c) => c.target),
       ).not.toContain("src/my notes/todo.md");
     });
 
@@ -218,12 +214,8 @@ describe("extractLinkCandidates", () => {
 
   describe("stripDiffPrefix", () => {
     it("strips git's diff prefixes", () => {
-      expect(stripDiffPrefix("a/src/terminal/tab-manager.ts")).toBe(
-        "src/terminal/tab-manager.ts",
-      );
-      expect(stripDiffPrefix("b/src/terminal/tab-manager.ts")).toBe(
-        "src/terminal/tab-manager.ts",
-      );
+      expect(stripDiffPrefix("a/src/terminal/tab-manager.ts")).toBe("src/terminal/tab-manager.ts");
+      expect(stripDiffPrefix("b/src/terminal/tab-manager.ts")).toBe("src/terminal/tab-manager.ts");
     });
 
     it("leaves anything else alone", () => {

--- a/src/lib/terminal-links.ts
+++ b/src/lib/terminal-links.ts
@@ -36,8 +36,7 @@ export const MAX_CANDIDATES_PER_LINE = 24;
 
 // http/https up to the first whitespace or quote, minus trailing punctuation.
 // Copied from @xterm/addon-web-links (strictUrlRegex) — battle-tested there.
-const URL_RE =
-  /(https?|HTTPS?):[/]{2}[^\s"'!*(){}|\\^<>`]*[^\s"':,.!?{}|\\^~[\]`()<>]/g;
+const URL_RE = /(https?|HTTPS?):[/]{2}[^\s"'!*(){}|\\^<>`]*[^\s"':,.!?{}|\\^~[\]`()<>]/g;
 
 /**
  * Whether a URI may be handed to the default browser.
@@ -143,11 +142,7 @@ const QUOTED_PATH_RE = new RegExp(
 
 /** A quoted token is only a candidate if it could be a path at all. */
 function looksLikePath(body: string): boolean {
-  return (
-    body.includes("/") ||
-    body.includes("\\") ||
-    /\.[A-Za-z][A-Za-z0-9]{0,9}$/u.test(body)
-  );
+  return body.includes("/") || body.includes("\\") || /\.[A-Za-z][A-Za-z0-9]{0,9}$/u.test(body);
 }
 
 /**
@@ -198,10 +193,7 @@ function matchUrls(source: string): LinkCandidate[] {
   return out;
 }
 
-function followsSpacedAbsoluteWindowsPath(
-  source: string,
-  start: number,
-): boolean {
+function followsSpacedAbsoluteWindowsPath(source: string, start: number): boolean {
   if (start === 0 || !/\s/u.test(source[start - 1] ?? "")) {
     return false;
   }
@@ -214,11 +206,7 @@ function followsSpacedAbsoluteWindowsPath(
   return isAbsoluteWindows && !looksComplete;
 }
 
-function startsSpacedAbsoluteWindowsPath(
-  source: string,
-  start: number,
-  end: number,
-): boolean {
+function startsSpacedAbsoluteWindowsPath(source: string, start: number, end: number): boolean {
   const candidate = source.slice(start, end);
   if (!/^(?:[A-Za-z]:[\\/]|\\\\)/u.test(candidate)) {
     return false;
@@ -250,10 +238,7 @@ function matchPathPattern(source: string, pattern: RegExp): LinkCandidate[] {
       continue;
     }
     const matched = m[0].slice(boundary.length);
-    const text = matched.slice(
-      0,
-      matched.length - (rawPath.length - path.length),
-    );
+    const text = matched.slice(0, matched.length - (rawPath.length - path.length));
     const start = m.index + boundary.length;
     const end = start + text.length;
     if (
@@ -278,11 +263,7 @@ function matchPathPattern(source: string, pattern: RegExp): LinkCandidate[] {
 function matchQuotedPaths(source: string): LinkCandidate[] {
   const out: LinkCandidate[] = [];
   QUOTED_PATH_RE.lastIndex = 0;
-  for (
-    let m = QUOTED_PATH_RE.exec(source);
-    m !== null;
-    m = QUOTED_PATH_RE.exec(source)
-  ) {
+  for (let m = QUOTED_PATH_RE.exec(source); m !== null; m = QUOTED_PATH_RE.exec(source)) {
     const body = m[1] ?? "";
     // A body padded with spaces is a phrase that ended in one, never a path
     // anybody typed — and trimming it would leave the range lying about which
@@ -334,8 +315,6 @@ export function extractLinkCandidates(
   max: number = MAX_CANDIDATES_PER_LINE,
 ): LinkCandidate[] {
   const urls = matchUrls(source);
-  const paths = matchPaths(source).filter(
-    (path) => !urls.some((url) => overlaps(path, url)),
-  );
+  const paths = matchPaths(source).filter((path) => !urls.some((url) => overlaps(path, url)));
   return [...urls, ...paths].sort((a, b) => a.start - b.start).slice(0, max);
 }

--- a/src/links/external-app-choices.test.ts
+++ b/src/links/external-app-choices.test.ts
@@ -39,9 +39,7 @@ describe("externalAppChoices", () => {
 describe("groupExternalApps", () => {
   it("keeps catalog group order and drops empty groups", () => {
     expect(
-      groupExternalApps(externalAppChoices(INSTALLED, true)).map(
-        (view) => view.group,
-      ),
+      groupExternalApps(externalAppChoices(INSTALLED, true)).map((view) => view.group),
     ).toEqual(["editor", "files"]);
   });
 

--- a/src/links/external-apps-store.ts
+++ b/src/links/external-apps-store.ts
@@ -13,15 +13,10 @@
  * not rendered, and Settings falls back to printing the catalog.
  */
 import { signal } from "@preact/signals";
-import {
-  listExternalApps,
-  type InstalledExternalApp,
-} from "../host/external-apps-host";
+import { listExternalApps, type InstalledExternalApp } from "../host/external-apps-host";
 import type { ExternalAppId } from "../lib/external-app-catalog";
 
-export const installedExternalApps = signal<readonly InstalledExternalApp[]>(
-  [],
-);
+export const installedExternalApps = signal<readonly InstalledExternalApp[]>([]);
 
 /** True once a scan has answered — an empty list before and after look the
  * same, and the menu must not say "nothing installed" before it has asked. */

--- a/src/repositories/worktree-destinations.test.ts
+++ b/src/repositories/worktree-destinations.test.ts
@@ -184,8 +184,6 @@ describe("plainFolderDestination", () => {
   });
 
   it("prints as the folder alone, with no branch half", () => {
-    expect(destinationLabel(plainFolderDestination("/dev/notes"))).toBe(
-      "notes",
-    );
+    expect(destinationLabel(plainFolderDestination("/dev/notes"))).toBe("notes");
   });
 });

--- a/src/settings/themes.test.ts
+++ b/src/settings/themes.test.ts
@@ -85,40 +85,26 @@ describe("the two canonical modes", () => {
     expect(getPreset("does-not-exist").id).toBe(DECK_DARK_ID);
   });
 
-  it.each([DECK_DARK_ID, DECK_LIGHT_ID])(
-    "derives chrome that clears DL-3.5 on %s",
-    (id) => {
-      const preset = getPreset(id);
-      const check = checkChromeTextContrast(
-        preset.theme.background,
-        preset.theme.foreground,
-      );
+  it.each([DECK_DARK_ID, DECK_LIGHT_ID])("derives chrome that clears DL-3.5 on %s", (id) => {
+    const preset = getPreset(id);
+    const check = checkChromeTextContrast(preset.theme.background, preset.theme.foreground);
 
-      expect(check.ok ? null : check.reason).toBeNull();
-    },
-  );
+    expect(check.ok ? null : check.reason).toBeNull();
+  });
 
-  it.each([DECK_DARK_ID, DECK_LIGHT_ID])(
-    "keeps terminal text and cursor legible on %s",
-    (id) => {
-      const { theme } = getPreset(id);
+  it.each([DECK_DARK_ID, DECK_LIGHT_ID])("keeps terminal text and cursor legible on %s", (id) => {
+    const { theme } = getPreset(id);
 
-      expect(
-        contrastRatio(theme.foreground, theme.background),
-      ).toBeGreaterThanOrEqual(TERMINAL_TEXT_FLOOR);
-      expect(
-        contrastRatio(theme.cursor, theme.background),
-      ).toBeGreaterThanOrEqual(TERMINAL_CURSOR_FLOOR);
-    },
-  );
+    expect(contrastRatio(theme.foreground, theme.background)).toBeGreaterThanOrEqual(
+      TERMINAL_TEXT_FLOOR,
+    );
+    expect(contrastRatio(theme.cursor, theme.background)).toBeGreaterThanOrEqual(
+      TERMINAL_CURSOR_FLOOR,
+    );
+  });
 
   it("keeps every legacy built-in id resolvable", () => {
-    for (const id of [
-      "tokyo-night",
-      "dracula",
-      "one-dark",
-      "catppuccin-mocha",
-    ]) {
+    for (const id of ["tokyo-night", "dracula", "one-dark", "catppuccin-mocha"]) {
       expect(getPreset(id).id).toBe(id);
     }
   });
@@ -126,18 +112,12 @@ describe("the two canonical modes", () => {
 
 describe("themeModeOf", () => {
   it("reports each canonical mode as itself", () => {
-    expect(themeModeOf({ ...DEFAULT_SETTINGS, themeId: DECK_LIGHT_ID })).toBe(
-      "light",
-    );
-    expect(themeModeOf({ ...DEFAULT_SETTINGS, themeId: DECK_DARK_ID })).toBe(
-      "dark",
-    );
+    expect(themeModeOf({ ...DEFAULT_SETTINGS, themeId: DECK_LIGHT_ID })).toBe("light");
+    expect(themeModeOf({ ...DEFAULT_SETTINGS, themeId: DECK_DARK_ID })).toBe("dark");
   });
 
   it("classifies a legacy theme by the background it resolves to", () => {
-    expect(themeModeOf({ ...DEFAULT_SETTINGS, themeId: "tokyo-night" })).toBe(
-      "dark",
-    );
+    expect(themeModeOf({ ...DEFAULT_SETTINGS, themeId: "tokyo-night" })).toBe("dark");
   });
 
   // The selected segment must describe what the user is LOOKING at. An
@@ -153,17 +133,13 @@ describe("themeModeOf", () => {
   });
 
   it("classifies an unknown id through the fallback preset", () => {
-    expect(
-      themeModeOf({ ...DEFAULT_SETTINGS, themeId: "file:gone.json" }),
-    ).toBe("dark");
+    expect(themeModeOf({ ...DEFAULT_SETTINGS, themeId: "file:gone.json" })).toBe("dark");
   });
 });
 
 describe("conversionDiscardsData", () => {
   it("is false for a legacy built-in with nothing overridden", () => {
-    expect(
-      conversionDiscardsData({ ...DEFAULT_SETTINGS, themeId: "gruvbox" }),
-    ).toBe(false);
+    expect(conversionDiscardsData({ ...DEFAULT_SETTINGS, themeId: "gruvbox" })).toBe(false);
   });
 
   it("is true while any colour override is set", () => {

--- a/src/settings/themes.ts
+++ b/src/settings/themes.ts
@@ -18,8 +18,10 @@ export const DECK_LIGHT_ID = "deck-light";
 
 export type ThemeMode = "light" | "dark";
 
-export const CANONICAL_THEME_IDS: Readonly<Record<ThemeMode, string>> =
-  Object.freeze({ light: DECK_LIGHT_ID, dark: DECK_DARK_ID });
+export const CANONICAL_THEME_IDS: Readonly<Record<ThemeMode, string>> = Object.freeze({
+  light: DECK_LIGHT_ID,
+  dark: DECK_DARK_ID,
+});
 
 export interface ThemePreset {
   id: string;

--- a/src/terminal/eslint-positions.test.ts
+++ b/src/terminal/eslint-positions.test.ts
@@ -39,9 +39,10 @@ describe("matchPositionRow", () => {
   });
 
   it("reads a warning row too", () => {
-    expect(
-      matchPositionRow("   3:1  warning  Missing semicolon  semi"),
-    ).toMatchObject({ line: 3, col: 1 });
+    expect(matchPositionRow("   3:1  warning  Missing semicolon  semi")).toMatchObject({
+      line: 3,
+      col: 1,
+    });
   });
 
   it("refuses a bare position with no severity", () => {
@@ -79,11 +80,7 @@ describe("eslintHeaderText", () => {
   });
 
   it("stops at a blank line rather than crossing into the block above", () => {
-    const { buffer, cols } = fakeBuffer([
-      "src/foo.ts",
-      "",
-      "  12:5   error  x  rule",
-    ]);
+    const { buffer, cols } = fakeBuffer(["src/foo.ts", "", "  12:5   error  x  rule"]);
     expect(eslintHeaderText(buffer, cols, 2)).toBeNull();
   });
 
@@ -93,10 +90,7 @@ describe("eslintHeaderText", () => {
   });
 
   it("gives up rather than scanning forever", () => {
-    const rows = [
-      "src/foo.ts",
-      ...Array.from({ length: 60 }, () => "  1:1  error  x  rule"),
-    ];
+    const rows = ["src/foo.ts", ...Array.from({ length: 60 }, () => "  1:1  error  x  rule")];
     const { buffer, cols } = fakeBuffer(rows);
     expect(eslintHeaderText(buffer, cols, rows.length - 1, 5)).toBeNull();
   });

--- a/src/terminal/link-provider.test.ts
+++ b/src/terminal/link-provider.test.ts
@@ -5,10 +5,7 @@ import { createMemoryLinkClient } from "./link-client";
 import { settings } from "../settings/settings-store";
 import { DEFAULT_SETTINGS } from "../settings/settings-schema";
 import { pathOpenRequest, persistError } from "../chrome/events";
-import {
-  initializeDesktopEnvironment,
-  resetDesktopEnvironmentForTests,
-} from "../lib/platform";
+import { initializeDesktopEnvironment, resetDesktopEnvironmentForTests } from "../lib/platform";
 
 const CWD = "/repo";
 
@@ -48,10 +45,7 @@ function fakeTerminal(text: string): Terminal {
   return fakeTerminalRows([text]);
 }
 
-function provide(
-  term: Terminal,
-  client: ReturnType<typeof createMemoryLinkClient>,
-) {
+function provide(term: Terminal, client: ReturnType<typeof createMemoryLinkClient>) {
   const provider = createLinkProvider(term, {
     getCwd: () => CWD,
     client,
@@ -62,10 +56,7 @@ function provide(
 }
 
 /** One provider, many rows — the shape the cross-line cases need. */
-function providerFor(
-  term: Terminal,
-  client: ReturnType<typeof createMemoryLinkClient>,
-) {
+function providerFor(term: Terminal, client: ReturnType<typeof createMemoryLinkClient>) {
   const provider = createLinkProvider(term, { getCwd: () => CWD, client });
   return (row: number) =>
     new Promise<ILink[] | undefined>((resolve) => {
@@ -90,10 +81,7 @@ describe("createLinkProvider", () => {
 
   it("links a url and opens it in the browser on ⌘+click", async () => {
     const client = createMemoryLinkClient();
-    const links = await provide(
-      fakeTerminal("see https://example.com now"),
-      client,
-    );
+    const links = await provide(fakeTerminal("see https://example.com now"), client);
 
     expect(links).toHaveLength(1);
     expect(links?.[0].text).toBe("https://example.com");
@@ -104,10 +92,7 @@ describe("createLinkProvider", () => {
 
   it("ignores a plain click so the terminal keeps it", async () => {
     const client = createMemoryLinkClient();
-    const links = await provide(
-      fakeTerminal("see https://example.com now"),
-      client,
-    );
+    const links = await provide(fakeTerminal("see https://example.com now"), client);
 
     click(links![0], false);
     expect(client.openedUrls).toEqual([]);
@@ -120,10 +105,7 @@ describe("createLinkProvider", () => {
       homeDir: String.raw`C:\Users\dev`,
     });
     const client = createMemoryLinkClient();
-    const links = await provide(
-      fakeTerminal("see https://example.com now"),
-      client,
-    );
+    const links = await provide(fakeTerminal("see https://example.com now"), client);
 
     click(links![0], true);
     click(links![0], false, true);
@@ -133,10 +115,7 @@ describe("createLinkProvider", () => {
 
   it("links only the paths that resolve to a real file", async () => {
     const client = createMemoryLinkClient({ files: [`${CWD}/src/foo.ts`] });
-    const links = await provide(
-      fakeTerminal("src/foo.ts and src/gone.ts"),
-      client,
-    );
+    const links = await provide(fakeTerminal("src/foo.ts and src/gone.ts"), client);
 
     expect(links?.map((link) => link.text)).toEqual(["src/foo.ts"]);
   });
@@ -147,10 +126,7 @@ describe("createLinkProvider", () => {
   // itself is covered by `link-target.test.ts`.
   it("raises an open request carrying the line and column", async () => {
     const client = createMemoryLinkClient({ files: [`${CWD}/src/foo.ts`] });
-    const links = await provide(
-      fakeTerminal("at src/foo.ts:12:5 boom"),
-      client,
-    );
+    const links = await provide(fakeTerminal("at src/foo.ts:12:5 boom"), client);
 
     click(links![0], true);
     expect(pathOpenRequest.value).toMatchObject({
@@ -194,10 +170,7 @@ describe("createLinkProvider", () => {
     // `a/src/foo.ts` is not a file; `src/foo.ts` is. Both go into one batch
     // and the candidate keeps the hit (design §2.2).
     const client = createMemoryLinkClient({ files: [`${CWD}/src/foo.ts`] });
-    const links = await provide(
-      fakeTerminal("--- a/src/foo.ts"),
-      client,
-    );
+    const links = await provide(fakeTerminal("--- a/src/foo.ts"), client);
 
     expect(links).toHaveLength(1);
     click(links![0], true);
@@ -256,9 +229,7 @@ describe("createLinkProvider", () => {
     vi.useFakeTimers();
     try {
       const client = createMemoryLinkClient();
-      const spy = vi
-        .spyOn(client, "resolvePaths")
-        .mockResolvedValue([null] as (string | null)[]);
+      const spy = vi.spyOn(client, "resolvePaths").mockResolvedValue([null] as (string | null)[]);
       const term = fakeTerminal("xx a.ts");
       const provider = createLinkProvider(term, { getCwd: () => CWD, client });
       const hover = (): Promise<ILink[] | undefined> =>

--- a/src/terminal/link-provider.ts
+++ b/src/terminal/link-provider.ts
@@ -1,9 +1,5 @@
 import type { ILink, ILinkProvider, Terminal } from "@xterm/xterm";
-import {
-  extractLinkCandidates,
-  stripDiffPrefix,
-  type LinkCandidate,
-} from "../lib/terminal-links";
+import { extractLinkCandidates, stripDiffPrefix, type LinkCandidate } from "../lib/terminal-links";
 import { reportPersistError, requestPathOpen } from "../chrome/events";
 import { hasPrimaryModifier } from "../lib/platform";
 import { defaultLinkClient, type LinkClient } from "./link-client";
@@ -74,10 +70,7 @@ function openCandidate(link: ResolvedLink, client: LinkClient): void {
  * click has to stay a plain click, because an agent TUI (Claude Code, Codex)
  * turns on mouse tracking and needs those clicks itself.
  */
-export function createLinkProvider(
-  term: Terminal,
-  deps: LinkProviderDeps,
-): ILinkProvider {
+export function createLinkProvider(term: Terminal, deps: LinkProviderDeps): ILinkProvider {
   const client = deps.client ?? defaultLinkClient;
   const cache = new Map<string, CacheEntry>();
   // Bumped by every request; a reply carrying a stale id is dropped rather than
@@ -164,10 +157,7 @@ export function createLinkProvider(
     return link;
   }
 
-  function toLinks(
-    resolved: readonly ResolvedLink[],
-    logical: LogicalLine,
-  ): ILink[] | undefined {
+  function toLinks(resolved: readonly ResolvedLink[], logical: LogicalLine): ILink[] | undefined {
     const links = resolved
       // The cache is keyed by line text, but the same text can sit at a
       // different row after a scroll — drop anything the spans no longer cover.
@@ -183,11 +173,7 @@ export function createLinkProvider(
   return {
     provideLinks(bufferLineNumber, callback) {
       const requestId = (generation += 1);
-      const logical = readLogicalLine(
-        term.buffer.active,
-        term.cols,
-        bufferLineNumber - 1,
-      );
+      const logical = readLogicalLine(term.buffer.active, term.cols, bufferLineNumber - 1);
       if (logical === null || logical.text.trim() === "") {
         callback(undefined);
         return;
@@ -205,9 +191,8 @@ export function createLinkProvider(
       const headerPath =
         headerText === null
           ? null
-          : (extractLinkCandidates(headerText).find(
-              (candidate) => candidate.kind === "path",
-            ) ?? null);
+          : (extractLinkCandidates(headerText).find((candidate) => candidate.kind === "path") ??
+            null);
       const crossLine: LinkCandidate | null =
         position !== null && headerPath !== null
           ? {
@@ -220,8 +205,7 @@ export function createLinkProvider(
               end: position.end,
             }
           : null;
-      const candidates =
-        crossLine === null ? onLine : [...onLine, crossLine];
+      const candidates = crossLine === null ? onLine : [...onLine, crossLine];
       if (candidates.length === 0) {
         callback(undefined);
         return;
@@ -313,9 +297,7 @@ export function createLinkProvider(
           // being clickable while URLs keep working — which reads like a
           // detection bug. Say so instead of dropping it.
           if (requestId === generation) {
-            reportPersistError(
-              `Couldn't check the file paths on this line: ${String(err)}`,
-            );
+            reportPersistError(`Couldn't check the file paths on this line: ${String(err)}`);
           }
           callback(undefined);
         });

--- a/src/terminal/pane-ping.test.ts
+++ b/src/terminal/pane-ping.test.ts
@@ -14,9 +14,7 @@ function grid(...paneIds: readonly number[]): HTMLElement {
 }
 
 function slot(root: ParentNode, paneId: number): HTMLElement {
-  const found = root.querySelector<HTMLElement>(
-    `.pane-slot[data-pane-id="${paneId}"]`,
-  );
+  const found = root.querySelector<HTMLElement>(`.pane-slot[data-pane-id="${paneId}"]`);
   if (found === null) {
     throw new Error(`no slot for pane ${paneId}`);
   }

--- a/src/terminal/pane-ping.ts
+++ b/src/terminal/pane-ping.ts
@@ -9,9 +9,7 @@
 const PING_CLASS = "pane-ping";
 
 export function pingPane(paneId: number, root: ParentNode = document): void {
-  const slot = root.querySelector(
-    `.pane-slot[data-pane-id="${paneId}"]`,
-  );
+  const slot = root.querySelector(`.pane-slot[data-pane-id="${paneId}"]`);
   if (slot === null) {
     return;
   }

--- a/src/terminal/pane-renderer.test.ts
+++ b/src/terminal/pane-renderer.test.ts
@@ -178,9 +178,7 @@ describe("createPane OpenCode glyph rendering", () => {
     webgl.instances[0].emitContextLoss();
     expect(webgl.instances[0].disposed).toBe(1);
     expect(warn).toHaveBeenCalledOnce();
-    expect(warn).toHaveBeenCalledWith(
-      "WebGL terminal renderer context lost; falling back to DOM.",
-    );
+    expect(warn).toHaveBeenCalledWith("WebGL terminal renderer context lost; falling back to DOM.");
   });
 
   it("does not change the renderer when settings are applied", () => {

--- a/src/ui/agent-quick-picker.test.tsx
+++ b/src/ui/agent-quick-picker.test.tsx
@@ -144,9 +144,7 @@ describe("AgentQuickPicker", () => {
 
     const aider = host.querySelectorAll<HTMLButtonElement>(".achip")[2];
     expect(aider.className).toContain("is-missing");
-    expect(aider.title).toBe(
-      "aider --model gpt-4 — not on $PATH; opens Settings",
-    );
+    expect(aider.title).toBe("aider --model gpt-4 — not on $PATH; opens Settings");
   });
 
   it("does not mark a detected built-in as missing", () => {
@@ -377,9 +375,7 @@ describe("AgentQuickPicker destination", () => {
 
 describe("AgentQuickPicker launch profiles", () => {
   function profileSelect(label: string): HTMLSelectElement | null {
-    return host.querySelector<HTMLSelectElement>(
-      `[aria-label="${label} launch profile"]`,
-    );
+    return host.querySelector<HTMLSelectElement>(`[aria-label="${label} launch profile"]`);
   }
 
   it("offers a profile select only for agents that have profiles", () => {
@@ -454,9 +450,7 @@ describe("AgentQuickPicker launch profiles", () => {
     const { onSelect } = mount();
 
     act(() => {
-      profileSelect("Claude Code")!.dispatchEvent(
-        new MouseEvent("click", { bubbles: true }),
-      );
+      profileSelect("Claude Code")!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
     expect(onSelect).not.toHaveBeenCalled();
@@ -506,11 +500,15 @@ describe("AgentQuickPicker keyboard and unreachable rows (DL-29.8)", () => {
 
     const keys = host.querySelector(".agent-quick-picker__keys");
     expect(keys?.textContent).toContain("pick");
-    expect(
-      Array.from(keys?.querySelectorAll("kbd") ?? []).map(
-        (key) => key.textContent,
-      ),
-    ).toEqual(["1", "9", "0", "↑", "↓", "Enter", "Esc"]);
+    expect(Array.from(keys?.querySelectorAll("kbd") ?? []).map((key) => key.textContent)).toEqual([
+      "1",
+      "9",
+      "0",
+      "↑",
+      "↓",
+      "Enter",
+      "Esc",
+    ]);
   });
 
   it("routes a missing agent to Settings instead of launching it", () => {

--- a/src/ui/agent-quick-picker.tsx
+++ b/src/ui/agent-quick-picker.tsx
@@ -4,10 +4,7 @@ import { agentOptions, type CustomAgent } from "../lib/agent-catalog";
 import { AGENT_LOGOS } from "../lib/agent-logos";
 import { letterAvatar } from "../lib/letter-avatar";
 import type { AgentChoice } from "../lib/workspace-recents";
-import {
-  destinationLabel,
-  type QuickDestination,
-} from "../repositories/worktree-destinations";
+import { destinationLabel, type QuickDestination } from "../repositories/worktree-destinations";
 import { ConfigRow } from "./controls/config-row";
 import { DeckIcon, ROW_ICON } from "./controls/deck-icon";
 import { Modal } from "./modal";
@@ -66,11 +63,7 @@ export interface AgentQuickPickerProps {
    * agent has none, or when its "No profile" option is selected, which is an
    * explicit request for the bare command even if the agent has a default.
    */
-  onSelect(
-    agentId: AgentChoice,
-    destination: string | null,
-    profileId: string | null,
-  ): void;
+  onSelect(agentId: AgentChoice, destination: string | null, profileId: string | null): void;
   onCancel(): void;
   /**
    * Open Settings, for a row whose binary is gone. Settings takes no initial
@@ -98,12 +91,10 @@ export function AgentQuickPicker({
   onCancel,
   onManageAgents,
 }: AgentQuickPickerProps) {
-  const chips = agentOptions(detected, customAgents, disabledAgents).map(
-    (option) => ({
-      ...option,
-      logo: AGENT_LOGOS[option.id],
-    }),
-  );
+  const chips = agentOptions(detected, customAgents, disabledAgents).map((option) => ({
+    ...option,
+    logo: AGENT_LOGOS[option.id],
+  }));
 
   /**
    * The user's explicit pick, or null for "whatever the default resolves to".
@@ -148,10 +139,7 @@ export function AgentQuickPicker({
    * it were omitted than inert): it does something, and the something is
    * useful.
    */
-  function activate(chip: {
-    readonly id: string;
-    readonly missing: boolean;
-  }): void {
+  function activate(chip: { readonly id: string; readonly missing: boolean }): void {
     if (chip.missing) {
       onManageAgents();
       return;
@@ -167,9 +155,7 @@ export function AgentQuickPicker({
    */
   function moveFocus(event: KeyboardEvent, key: string): boolean {
     const from = event.target instanceof HTMLElement ? event.target : null;
-    const chips = chipsOf(
-      from === null ? null : from.closest(".agent-quick-picker"),
-    );
+    const chips = chipsOf(from === null ? null : from.closest(".agent-quick-picker"));
     if (chips.length === 0) {
       return false;
     }
@@ -191,11 +177,7 @@ export function AgentQuickPicker({
 
   function pick(agentId: AgentChoice): void {
     const profileId = agentId === null ? "" : profileFor(agentId);
-    onSelect(
-      agentId,
-      current?.path ?? null,
-      profileId === "" ? null : profileId,
-    );
+    onSelect(agentId, current?.path ?? null, profileId === "" ? null : profileId);
   }
 
   function handleKeyDown(event: KeyboardEvent): void {
@@ -248,9 +230,7 @@ export function AgentQuickPicker({
           {/* menu value kind (DL-6, DL-1.4): a native select overlaid
               invisibly on the styled pill. */}
           <span class="cfg-btn cfg-btn--overlay">
-            <span class="cfg-btn__text">
-              {current === null ? "—" : destinationLabel(current)}
-            </span>
+            <span class="cfg-btn__text">{current === null ? "—" : destinationLabel(current)}</span>
             <span class="cfg-btn__hint">
               <DeckIcon icon={CaretDown} size={ROW_ICON} />
             </span>
@@ -277,34 +257,24 @@ export function AgentQuickPicker({
           <span class="cfg-readout">{destinationLabel(current)}</span>
         </ConfigRow>
       ) : (
-        <p class="agent-quick-picker__hint">
-          Runs in this workspace — pick an agent to launch it
-        </p>
+        <p class="agent-quick-picker__hint">Runs in this workspace — pick an agent to launch it</p>
       )}
       <div class="agents">
         {chips.map((chip) => {
-          const avatar =
-            chip.logo === undefined ? letterAvatar(chip.label, chip.id) : null;
+          const avatar = chip.logo === undefined ? letterAvatar(chip.label, chip.id) : null;
           const profiles = profilesForAgent(chip.id, launchProfiles);
           const button = (
             <button
               key={chip.id}
               type="button"
               class={`achip ${chip.missing ? "is-missing" : ""}`}
-              title={
-                chip.missing
-                  ? `${chip.detail} — not on $PATH; opens Settings`
-                  : chip.detail
-              }
+              title={chip.missing ? `${chip.detail} — not on $PATH; opens Settings` : chip.detail}
               onClick={() => activate(chip)}
             >
               {chip.logo !== undefined ? (
                 <img class="achip__logo" src={chip.logo} alt="" />
               ) : (
-                <span
-                  class="achip__letter"
-                  style={{ color: `var(--${avatar?.color})` }}
-                >
+                <span class="achip__letter" style={{ color: `var(--${avatar?.color})` }}>
                   {avatar?.letter}
                 </span>
               )}

--- a/src/ui/desktop-chrome.test.tsx
+++ b/src/ui/desktop-chrome.test.tsx
@@ -4,10 +4,7 @@ import { act } from "preact/test-utils";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { DesktopChrome } from "./desktop-chrome";
-import {
-  initializeDesktopEnvironment,
-  resetDesktopEnvironmentForTests,
-} from "../lib/platform";
+import { initializeDesktopEnvironment, resetDesktopEnvironmentForTests } from "../lib/platform";
 
 let host: HTMLDivElement;
 

--- a/src/ui/desktop-chrome.tsx
+++ b/src/ui/desktop-chrome.tsx
@@ -87,9 +87,7 @@ export function DesktopChrome(props: DesktopChromeProps) {
           class="deck-frame"
           onDblClick={windows ? undefined : props.onMacTitlebarDoubleClick}
         >
-          {!windows ? (
-            <div class="deck-frame__lights" aria-hidden="true" />
-          ) : null}
+          {!windows ? <div class="deck-frame__lights" aria-hidden="true" /> : null}
           {/* Beside the OS buttons, before anything else: the sidebar's hide
               control and `New` launcher form its leading frame cluster
               (DL-18.9). */}

--- a/src/ui/dock/dock-panel.tsx
+++ b/src/ui/dock/dock-panel.tsx
@@ -17,10 +17,7 @@
  * `src/ui/sessions` — three imports that would make the host depend on
  * everything it hosts.
  */
-import {
-  dockCollapseArmed,
-  dockWidthLive,
-} from "../../files/file-surface-store";
+import { dockCollapseArmed, dockWidthLive } from "../../files/file-surface-store";
 import type { DockTab } from "../../settings/settings-schema";
 import { DOCK_DRAG_BOUNDS, resolvePanelDrag } from "../panel-resize";
 import { FEATURE_ICON } from "../controls/deck-icon";
@@ -74,10 +71,7 @@ export function DockPanel(props: DockPanelProps) {
       // The RAW width goes to `resolvePanelDrag`, not a clamped one: clamping
       // maps every overdrag onto the floor, and "past the floor" is exactly
       // what the collapse gesture is made of (DL-19.4).
-      const outcome = resolvePanelDrag(
-        startWidth + (startX - moveEvent.clientX),
-        DOCK_DRAG_BOUNDS,
-      );
+      const outcome = resolvePanelDrag(startWidth + (startX - moveEvent.clientX), DOCK_DRAG_BOUNDS);
       dockWidthLive.value = outcome.width;
       dockCollapseArmed.value = outcome.collapsed;
     };
@@ -134,9 +128,7 @@ export function DockPanel(props: DockPanelProps) {
         // Lit for the whole gesture, the sidebar seam's reason exactly: the
         // pointer leaves this 9px target almost immediately once the drag is
         // captured (DL-19.4, amended 2026-08-19).
-        class={`dock-panel__grip ${
-          dockWidthLive.value === null ? "" : "is-dragging"
-        }`}
+        class={`dock-panel__grip ${dockWidthLive.value === null ? "" : "is-dragging"}`}
         onPointerDown={startResize}
         role="separator"
         aria-orientation="vertical"
@@ -160,11 +152,7 @@ export function DockPanel(props: DockPanelProps) {
           drag-past-the-floor gesture goes there: `App` routes it into the
           `toggle-dock` action, which owns the focus guard. */}
       <div class="dock-panel__header">
-        <DockTabs
-          items={props.tabs}
-          active={props.activeTab}
-          onSelect={props.onSelectTab}
-        />
+        <DockTabs items={props.tabs} active={props.activeTab} onSelect={props.onSelectTab} />
         {/* DL-14.2, 2026-08-19: the header's controls draw at
             `FEATURE_ICON`, one rung up from chrome. The stage-strip mount of
             this same component keeps `CHROME_ICON`, where it stands beside

--- a/src/ui/dock/dock-presence.test.tsx
+++ b/src/ui/dock/dock-presence.test.tsx
@@ -10,13 +10,7 @@ import { DOCK_SLIDE_MS, useDockPresence } from "./dock-presence";
  * hook exists — this repo has no hook-testing harness and does not need one
  * for a probe that prints its own two booleans.
  */
-function Probe({
-  visible,
-  hold = false,
-}: {
-  readonly visible: boolean;
-  readonly hold?: boolean;
-}) {
+function Probe({ visible, hold = false }: { readonly visible: boolean; readonly hold?: boolean }) {
   const presence = useDockPresence(visible, hold);
   return (
     <div

--- a/src/ui/dock/dock-presence.ts
+++ b/src/ui/dock/dock-presence.ts
@@ -47,10 +47,7 @@ export interface DockPresence {
  * navigation sidebar always has, instead of dimming it and waiting for the
  * pointer to come up.
  */
-export function useDockPresence(
-  visible: boolean,
-  hold: boolean = false,
-): DockPresence {
+export function useDockPresence(visible: boolean, hold: boolean = false): DockPresence {
   const [mounted, setMounted] = useState(visible);
   const [entered, setEntered] = useState(visible);
 

--- a/src/ui/dock/dock-tabs.test.tsx
+++ b/src/ui/dock/dock-tabs.test.tsx
@@ -19,16 +19,10 @@ describe("DockTabs", () => {
     host.remove();
   });
 
-  const getTabs = (): HTMLButtonElement[] =>
-    Array.from(host.querySelectorAll('[role="tab"]'));
+  const getTabs = (): HTMLButtonElement[] => Array.from(host.querySelectorAll('[role="tab"]'));
 
   it("renders one tab per item, in order, inside a labelled tablist", () => {
-    act(() =>
-      render(
-        <DockTabs items={DOCK_TABS} active="explorer" onSelect={vi.fn()} />,
-        host,
-      ),
-    );
+    act(() => render(<DockTabs items={DOCK_TABS} active="explorer" onSelect={vi.fn()} />, host));
 
     const tablist = host.querySelector('[role="tablist"]');
     expect(tablist).not.toBeNull();
@@ -46,12 +40,7 @@ describe("DockTabs", () => {
   });
 
   it("marks only the active chip with is-active and aria-selected", () => {
-    act(() =>
-      render(
-        <DockTabs items={DOCK_TABS} active="usage" onSelect={vi.fn()} />,
-        host,
-      ),
-    );
+    act(() => render(<DockTabs items={DOCK_TABS} active="usage" onSelect={vi.fn()} />, host));
 
     getTabs().forEach((tab, index) => {
       const shouldBeActive = DOCK_TABS[index].id === "usage";
@@ -62,12 +51,7 @@ describe("DockTabs", () => {
 
   it("reports the clicked id and keeps no state of its own", () => {
     const onSelect = vi.fn();
-    act(() =>
-      render(
-        <DockTabs items={DOCK_TABS} active="explorer" onSelect={onSelect} />,
-        host,
-      ),
-    );
+    act(() => render(<DockTabs items={DOCK_TABS} active="explorer" onSelect={onSelect} />, host));
 
     const tabs = getTabs();
     act(() => {
@@ -82,12 +66,7 @@ describe("DockTabs", () => {
 
   it("renders exactly the items it is given — a caller narrowing to two tabs sees two", () => {
     const narrowed = availableDockTabs(false);
-    act(() =>
-      render(
-        <DockTabs items={narrowed} active="explorer" onSelect={vi.fn()} />,
-        host,
-      ),
-    );
+    act(() => render(<DockTabs items={narrowed} active="explorer" onSelect={vi.fn()} />, host));
 
     const tabs = getTabs();
     expect(tabs).toHaveLength(2);
@@ -98,12 +77,7 @@ describe("DockTabs", () => {
   });
 
   it("draws each chip's icon through DeckIcon, never a raw glyph", () => {
-    act(() =>
-      render(
-        <DockTabs items={DOCK_TABS} active="explorer" onSelect={vi.fn()} />,
-        host,
-      ),
-    );
+    act(() => render(<DockTabs items={DOCK_TABS} active="explorer" onSelect={vi.fn()} />, host));
 
     getTabs().forEach((tab) => {
       const icon = tab.querySelector("svg.deck-icon");
@@ -118,12 +92,7 @@ describe("DockTabs", () => {
   // place its name and chord are ever printed. It opens on hover AND on focus
   // — the native `title` it replaced did neither for a keyboard.
   it("says the tab's name and its chord on hover, and again on focus", () => {
-    act(() =>
-      render(
-        <DockTabs items={DOCK_TABS} active="explorer" onSelect={vi.fn()} />,
-        host,
-      ),
-    );
+    act(() => render(<DockTabs items={DOCK_TABS} active="explorer" onSelect={vi.fn()} />, host));
 
     const explorer = getTabs()[0];
     expect(document.querySelector('[role="tooltip"]')).toBeNull();
@@ -136,9 +105,7 @@ describe("DockTabs", () => {
     expect(tip?.textContent).toContain("File explorer");
     // The chord comes from the keymap through `shortcutLabel`, never from a
     // literal here: a rebind has to reach this text.
-    expect(tip?.querySelector("kbd")?.textContent).toBe(
-      shortcutLabel("toggle-explorer", "macos"),
-    );
+    expect(tip?.querySelector("kbd")?.textContent).toBe(shortcutLabel("toggle-explorer", "macos"));
     expect(explorer.getAttribute("aria-describedby")).toBe(tip?.id);
 
     act(() => {
@@ -161,12 +128,7 @@ describe("DockTabs", () => {
   });
 
   it("draws all three dock icons with Phosphor's fill weight", () => {
-    act(() =>
-      render(
-        <DockTabs items={DOCK_TABS} active="explorer" onSelect={vi.fn()} />,
-        host,
-      ),
-    );
+    act(() => render(<DockTabs items={DOCK_TABS} active="explorer" onSelect={vi.fn()} />, host));
 
     getTabs().forEach((tab, index) => {
       const reference = document.createElement("div");

--- a/src/ui/dock/dock-tabs.tsx
+++ b/src/ui/dock/dock-tabs.tsx
@@ -89,12 +89,7 @@ export function DockTabs({ items, active, onSelect }: DockTabsProps) {
   return (
     <div class="dock-tabs" role="tablist" aria-label="Side panel">
       {items.map((item) => (
-        <DockTabChip
-          key={item.id}
-          item={item}
-          active={item.id === active}
-          onSelect={onSelect}
-        />
+        <DockTabChip key={item.id} item={item} active={item.id === active} onSelect={onSelect} />
       ))}
     </div>
   );

--- a/src/ui/dock/dock-toggle.test.tsx
+++ b/src/ui/dock/dock-toggle.test.tsx
@@ -69,9 +69,7 @@ describe("DockToggle", () => {
 
     const tip = document.querySelector('[role="tooltip"]');
     expect(tip?.textContent).toContain("Show the side panel");
-    expect(tip?.querySelector("kbd")?.textContent).toBe(
-      shortcutLabel("toggle-dock", "macos"),
-    );
+    expect(tip?.querySelector("kbd")?.textContent).toBe(shortcutLabel("toggle-dock", "macos"));
     expect(control().getAttribute("aria-describedby")).toBe(tip?.id);
   });
 
@@ -80,19 +78,10 @@ describe("DockToggle", () => {
   // a PROP, not a read of `open` — the two only happen to correlate today.
   it("draws chrome-sized by default and larger when a mount asks", () => {
     act(() => render(<DockToggle open={false} onToggle={vi.fn()} />, host));
-    expect(control().querySelector("svg.deck-icon")?.getAttribute("width")).toBe(
-      "13",
-    );
+    expect(control().querySelector("svg.deck-icon")?.getAttribute("width")).toBe("13");
 
-    act(() =>
-      render(
-        <DockToggle open={false} size={FEATURE_ICON} onToggle={vi.fn()} />,
-        host,
-      ),
-    );
-    expect(control().querySelector("svg.deck-icon")?.getAttribute("width")).toBe(
-      "15",
-    );
+    act(() => render(<DockToggle open={false} size={FEATURE_ICON} onToggle={vi.fn()} />, host));
+    expect(control().querySelector("svg.deck-icon")?.getAttribute("width")).toBe("15");
   });
 
   it("reports a click and keeps no state of its own", () => {

--- a/src/ui/dock/dock-toggle.tsx
+++ b/src/ui/dock/dock-toggle.tsx
@@ -6,11 +6,7 @@ import {
   useTooltipVisibility,
   tooltipTriggerProps,
 } from "../controls/action-tooltip";
-import {
-  CHROME_ICON,
-  DeckIcon,
-  type DeckIconSize,
-} from "../controls/deck-icon";
+import { CHROME_ICON, DeckIcon, type DeckIconSize } from "../controls/deck-icon";
 
 interface DockToggleProps {
   readonly open: boolean;
@@ -48,11 +44,7 @@ interface DockToggleProps {
  * from settings. `shortcutLabel` reads the keymap during render, which is how
  * a rebind reaches the tooltip.
  */
-export function DockToggle({
-  open,
-  size = CHROME_ICON,
-  onToggle,
-}: DockToggleProps) {
+export function DockToggle({ open, size = CHROME_ICON, onToggle }: DockToggleProps) {
   const ref = useRef<HTMLButtonElement>(null);
   const tooltip = useTooltipVisibility();
   const label = open ? "Hide the side panel" : "Show the side panel";

--- a/src/ui/focus-trap.ts
+++ b/src/ui/focus-trap.ts
@@ -76,8 +76,7 @@ export function trapTab(
   const first = items[0];
   const last = items[items.length - 1];
   const active = document.activeElement;
-  const inside =
-    active instanceof HTMLElement && root.contains(active) && active !== root;
+  const inside = active instanceof HTMLElement && root.contains(active) && active !== root;
   if (!inside) {
     event.preventDefault();
     (event.shiftKey ? last : first).focus();

--- a/src/ui/migration-banner.tsx
+++ b/src/ui/migration-banner.tsx
@@ -27,9 +27,8 @@ export function MigrationBanner({ onDismiss }: MigrationBannerProps) {
     // interrupt whatever a screen-reader user was doing at launch.
     <div class="migration-banner" role="status">
       <p class="migration-banner__message">
-        <strong>SpaceVibe Deck 1.0 is out.</strong> This build no longer
-        updates itself — the new Deck must be downloaded by hand, and settings
-        do not carry over.
+        <strong>SpaceVibe Deck 1.0 is out.</strong> This build no longer updates itself — the new
+        Deck must be downloaded by hand, and settings do not carry over.
       </p>
       {/* DL-8: a control says what happens, and what happens is that a browser
           tab opens. The download is a decision made on the page. */}

--- a/src/ui/settings/launch-profile-editor.test.tsx
+++ b/src/ui/settings/launch-profile-editor.test.tsx
@@ -16,9 +16,9 @@ vi.mock("../../host/store-host", () => ({
 }));
 
 vi.mock("../../settings/settings-store", async () => {
-  const actual = await vi.importActual<
-    typeof import("../../settings/settings-store")
-  >("../../settings/settings-store");
+  const actual = await vi.importActual<typeof import("../../settings/settings-store")>(
+    "../../settings/settings-store",
+  );
   return { ...actual, updateSettings: vi.fn() };
 });
 
@@ -104,9 +104,7 @@ describe("LaunchProfileEditor", () => {
     // The catalog's recommendation, not a bare binary and not something the
     // user had to type — this is what a fresh install shows.
     expect(host.textContent).toContain("--dangerously-skip-permissions");
-    expect(host.textContent).toContain(
-      "--dangerously-bypass-approvals-and-sandbox",
-    );
+    expect(host.textContent).toContain("--dangerously-bypass-approvals-and-sandbox");
     expect(updateSettings).not.toHaveBeenCalled();
   });
 
@@ -135,9 +133,7 @@ describe("LaunchProfileEditor", () => {
   it("says so when nothing is installed", () => {
     mount();
 
-    expect(host.querySelector('[role="status"]')?.textContent).toContain(
-      "No agent CLI found",
-    );
+    expect(host.querySelector('[role="status"]')?.textContent).toContain("No agent CLI found");
   });
 
   it("a user preset replaces the shipped command for that agent", () => {
@@ -148,9 +144,7 @@ describe("LaunchProfileEditor", () => {
     expect(host.textContent).toContain("claude --permission-mode plan");
     // The shipped claude command is gone; agy's, which shares that flag, is
     // not — so the assertion names the binary rather than the flag alone.
-    expect(host.textContent).not.toContain(
-      "claude --dangerously-skip-permissions",
-    );
+    expect(host.textContent).not.toContain("claude --dangerously-skip-permissions");
   });
 
   it("disables an agent without deleting it", () => {
@@ -165,8 +159,6 @@ describe("LaunchProfileEditor", () => {
       disabledAgents: ["claude"],
     });
   });
-
-
 
   it("adds a typed command and stars it for its agent", () => {
     install("claude");
@@ -187,9 +179,7 @@ describe("LaunchProfileEditor", () => {
     type("claude; rm -rf /");
     click(byLabel("Add"));
 
-    expect(host.querySelector('[role="alert"]')?.textContent).toContain(
-      "letters, digits",
-    );
+    expect(host.querySelector('[role="alert"]')?.textContent).toContain("letters, digits");
     expect(updateSettings).not.toHaveBeenCalled();
   });
 });

--- a/src/ui/settings/launch-profile-editor.tsx
+++ b/src/ui/settings/launch-profile-editor.tsx
@@ -5,10 +5,7 @@ import { settings, updateSettings } from "../../settings/settings-store";
 import { BUILTIN_AGENTS, type BuiltinAgent } from "../../lib/agent-catalog";
 import { AGENT_LOGOS } from "../../lib/agent-logos";
 import { letterAvatar } from "../../lib/letter-avatar";
-import {
-  detectedAgents,
-  ensureAgentsDetected,
-} from "../../terminal/agent-detection-store";
+import { detectedAgents, ensureAgentsDetected } from "../../terminal/agent-detection-store";
 import {
   commandAgentId,
   commandFlags,
@@ -54,10 +51,7 @@ function AgentMark({ id, label }: { id: string; label: string }) {
   }
   const avatar = letterAvatar(label, id);
   return (
-    <span
-      class="lp-mark lp-mark--letter"
-      style={{ color: `var(--${avatar.color})` }}
-    >
+    <span class="lp-mark lp-mark--letter" style={{ color: `var(--${avatar.color})` }}>
       {avatar.letter}
     </span>
   );
@@ -104,11 +98,7 @@ function EnabledToggle({
   onChange: (next: boolean) => void;
 }) {
   return (
-    <div
-      class="segmented lp-enabled"
-      role="radiogroup"
-      aria-label={`${agent.label} availability`}
-    >
+    <div class="segmented lp-enabled" role="radiogroup" aria-label={`${agent.label} availability`}>
       {[true, false].map((value) => (
         <button
           key={String(value)}
@@ -160,12 +150,8 @@ export function LaunchProfileEditor() {
   const refreshing = useSignal(false);
 
   const installedIds = new Set(detectedAgents.value.map((agent) => agent.name));
-  const installed = BUILTIN_AGENTS.filter((agent) =>
-    installedIds.has(agent.id),
-  );
-  const available = BUILTIN_AGENTS.filter(
-    (agent) => !installedIds.has(agent.id),
-  );
+  const installed = BUILTIN_AGENTS.filter((agent) => installedIds.has(agent.id));
+  const available = BUILTIN_AGENTS.filter((agent) => !installedIds.has(agent.id));
 
   const setEnabled = (agentId: string, next: boolean): void => {
     updateSettings({
@@ -183,11 +169,9 @@ export function LaunchProfileEditor() {
     // `ensureAgentsDetected` has no force flag: a warm cache answers instantly
     // and revalidates behind. That is the right behaviour here too — the
     // button's job is to start a scan, not to block on one.
-    void ensureAgentsDetected(BUILTIN_AGENTS.map((agent) => agent.id)).finally(
-      () => {
-        refreshing.value = false;
-      },
-    );
+    void ensureAgentsDetected(BUILTIN_AGENTS.map((agent) => agent.id)).finally(() => {
+      refreshing.value = false;
+    });
   };
 
   const add = (): void => {

--- a/src/ui/settings/sections/agents-section.test.tsx
+++ b/src/ui/settings/sections/agents-section.test.tsx
@@ -75,8 +75,7 @@ describe("AgentsSection", () => {
   // link row landed after it. Scoping by label is positional-drift-proof.
   const addButton = (): HTMLButtonElement => {
     const row = Array.from(host.querySelectorAll(".cfg-row")).find(
-      (candidate) =>
-        candidate.querySelector(".cfg-row__label")?.textContent === "Add agent",
+      (candidate) => candidate.querySelector(".cfg-row__label")?.textContent === "Add agent",
     )!;
     return row.querySelector<HTMLButtonElement>(".cfg-btn")!;
   };
@@ -104,9 +103,7 @@ describe("AgentsSection", () => {
     mount();
     declare("codex nightly", "codex --nightly");
 
-    const remove = host.querySelector(
-      '[aria-label="Remove codex nightly"] svg',
-    );
+    const remove = host.querySelector('[aria-label="Remove codex nightly"] svg');
     // Trash removes something the user declared and persisted; the draft's
     // X only dismisses a row that never existed.
     expect(remove?.classList.contains("deck-icon--trash")).toBe(true);
@@ -115,9 +112,7 @@ describe("AgentsSection", () => {
     expect(addButton().querySelector(".deck-icon--plus")).not.toBeNull();
 
     click(addButton());
-    const discard = host.querySelector(
-      '[aria-label="Discard the new agent"] svg',
-    );
+    const discard = host.querySelector('[aria-label="Discard the new agent"] svg');
     expect(discard?.classList.contains("deck-icon--x")).toBe(true);
     expect(addButton().textContent?.trim()).toBe("add");
   });
@@ -130,9 +125,7 @@ describe("AgentsSection", () => {
   it("hands the agent catalog to the launch profile editor", () => {
     mount();
     expect(host.querySelector(".lp-head")).not.toBeNull();
-    expect(host.querySelectorAll(".lp-agent")).toHaveLength(
-      BUILTIN_AGENTS.length,
-    );
+    expect(host.querySelectorAll(".lp-agent")).toHaveLength(BUILTIN_AGENTS.length);
     // Every remove control on this screen belongs to a DECLARED agent; none
     // was seeded here, so there are none.
     expect(host.querySelectorAll(".cfg-row__remove")).toHaveLength(0);
@@ -152,9 +145,7 @@ describe("AgentsSection", () => {
     declare("Evil", "x; rm -rf ~");
 
     expect(settings.value.customAgents).toEqual([]);
-    expect(host.querySelector(".cfg-custom--error")?.textContent).toContain(
-      "letters, digits",
-    );
+    expect(host.querySelector(".cfg-custom--error")?.textContent).toContain("letters, digits");
   });
 
   it("refuses a name already taken by a built-in", () => {
@@ -162,9 +153,7 @@ describe("AgentsSection", () => {
     declare("Claude Code", "aider");
 
     expect(settings.value.customAgents).toEqual([]);
-    expect(host.querySelector(".cfg-custom--error")?.textContent).toContain(
-      "already used",
-    );
+    expect(host.querySelector(".cfg-custom--error")?.textContent).toContain("already used");
   });
 
   it("refuses a name spelled like a built-in's id", () => {
@@ -247,9 +236,9 @@ describe("AgentsSection", () => {
     });
 
     const usageButton = (): HTMLButtonElement => {
-      const found = Array.from(
-        host.querySelectorAll<HTMLButtonElement>(".cfg-btn"),
-      ).find((candidate) => candidate.textContent?.trim() === "open …");
+      const found = Array.from(host.querySelectorAll<HTMLButtonElement>(".cfg-btn")).find(
+        (candidate) => candidate.textContent?.trim() === "open …",
+      );
       if (found === undefined) {
         throw new Error("no token usage link row");
       }
@@ -303,11 +292,7 @@ describe("AgentsSection — refusals and cleanup", () => {
     settings.value = DEFAULT_SETTINGS;
   });
 
-  const openAndCommit = (
-    trigger: string,
-    aria: string,
-    value: string,
-  ): void => {
+  const openAndCommit = (trigger: string, aria: string, value: string): void => {
     const button = Array.from(
       host.querySelectorAll<HTMLButtonElement>(
         ".cfg-row--item .cfg-row__label--edit, .cfg-row--item .cfg-btn",
@@ -316,9 +301,7 @@ describe("AgentsSection — refusals and cleanup", () => {
     act(() => {
       button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
-    const input = host.querySelector<HTMLInputElement>(
-      `[aria-label="${aria}"]`,
-    )!;
+    const input = host.querySelector<HTMLInputElement>(`[aria-label="${aria}"]`)!;
     act(() => {
       input.value = value;
       input.dispatchEvent(new Event("input", { bubbles: true }));
@@ -339,18 +322,14 @@ describe("AgentsSection — refusals and cleanup", () => {
     openAndCommit("aider", "Command for Aider", "$(id)");
 
     expect(settings.value.customAgents[0].command).toBe("aider");
-    expect(host.querySelector(".cfg-custom--error")?.textContent).toContain(
-      "letters, digits",
-    );
+    expect(host.querySelector(".cfg-custom--error")?.textContent).toContain("letters, digits");
   });
 
   it("says why an in-place rename was refused", () => {
     openAndCommit("Aider", "Name for Aider", "Claude Code");
 
     expect(settings.value.customAgents[0].label).toBe("Aider");
-    expect(host.querySelector(".cfg-custom--error")?.textContent).toContain(
-      "already used",
-    );
+    expect(host.querySelector(".cfg-custom--error")?.textContent).toContain("already used");
   });
 
   it("clears the refusal once a valid value is committed", () => {

--- a/src/ui/settings/sections/links-editor-section.tsx
+++ b/src/ui/settings/sections/links-editor-section.tsx
@@ -4,14 +4,8 @@ import { settings, updateSettings } from "../../../settings/settings-store";
 import { ConfigRow } from "../../controls/config-row";
 import { DeckIcon, ROW_ICON } from "../../controls/deck-icon";
 import { primaryModifierName } from "../../../lib/shortcut-label";
-import {
-  externalApp,
-  isExternalAppId,
-} from "../../../lib/external-app-catalog";
-import {
-  externalAppChoices,
-  groupExternalApps,
-} from "../../../links/external-app-choices";
+import { externalApp, isExternalAppId } from "../../../lib/external-app-catalog";
+import { externalAppChoices, groupExternalApps } from "../../../links/external-app-choices";
 import {
   ensureExternalAppsScanned,
   externalAppsScanned,
@@ -41,18 +35,13 @@ const GROUP_LABELS: Record<string, string> = {
  */
 export function LinksEditorSection() {
   const selected = settings.value.externalAppId;
-  const choices = externalAppChoices(
-    installedExternalApps.value,
-    externalAppsScanned.value,
-  );
+  const choices = externalAppChoices(installedExternalApps.value, externalAppsScanned.value);
   const groups = groupExternalApps(choices);
   // A stored selection whose app has left the machine still has to be visible,
   // or the row would silently read as the first installed app while the click
   // path falls back to it for a different reason. Named, not hidden.
   const missing =
-    choices.some((choice) => choice.id === selected) === false
-      ? externalApp(selected)
-      : null;
+    choices.some((choice) => choice.id === selected) === false ? externalApp(selected) : null;
 
   useEffect(() => {
     void ensureExternalAppsScanned();
@@ -65,9 +54,7 @@ export function LinksEditorSection() {
     >
       <span class="cfg-btn cfg-btn--overlay">
         <span class="cfg-btn__text">
-          {choices.find((choice) => choice.id === selected)?.label ??
-            missing?.label ??
-            selected}
+          {choices.find((choice) => choice.id === selected)?.label ?? missing?.label ?? selected}
         </span>
         <span class="cfg-btn__hint">
           <DeckIcon icon={CaretDown} size={ROW_ICON} />

--- a/src/ui/settings/settings-nav.tsx
+++ b/src/ui/settings/settings-nav.tsx
@@ -1,10 +1,6 @@
 import { useRef } from "preact/hooks";
 import { activeCategory } from "./active-category-store";
-import {
-  categoryTabId,
-  SECTION_PANEL_ID,
-  SETTINGS_CATEGORIES,
-} from "./settings-categories";
+import { categoryTabId, SECTION_PANEL_ID, SETTINGS_CATEGORIES } from "./settings-categories";
 
 /**
  * The settings rail: one vertical list of category tabs, and nothing else.

--- a/src/ui/settings/theme-mode-selector.test.tsx
+++ b/src/ui/settings/theme-mode-selector.test.tsx
@@ -78,10 +78,7 @@ describe("ThemeModeSelector", () => {
     mount();
 
     expect(host.querySelector('[role="radiogroup"]')).not.toBeNull();
-    expect(options().map((option) => option.textContent?.trim())).toEqual([
-      "Light",
-      "Dark",
-    ]);
+    expect(options().map((option) => option.textContent?.trim())).toEqual(["Light", "Dark"]);
   });
 
   it("names the selected value without relying on colour alone", () => {
@@ -91,10 +88,7 @@ describe("ThemeModeSelector", () => {
     expect(selected()).toBe("Light");
     // One tab stop for the pair, on the selected segment (radiogroup roving
     // tabindex) — Tab enters the control, arrows move within it.
-    expect(options().map((option) => option.getAttribute("tabindex"))).toEqual([
-      "0",
-      "-1",
-    ]);
+    expect(options().map((option) => option.getAttribute("tabindex"))).toEqual(["0", "-1"]);
   });
 
   it("shows a legacy theme as the mode its background belongs to, and writes nothing", () => {
@@ -219,9 +213,7 @@ describe("ThemeModeSelector", () => {
     mount();
 
     act(() => {
-      options()[1].dispatchEvent(
-        new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }),
-      );
+      options()[1].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
     });
     await settle();
 

--- a/src/ui/settings/theme-mode-selector.tsx
+++ b/src/ui/settings/theme-mode-selector.tsx
@@ -82,9 +82,7 @@ export function ThemeModeSelector() {
     } catch {
       // Fail safe, exactly like the reset row: a prompt that could not be
       // shown must not be treated as an answer.
-      reportPersistError(
-        "Couldn't confirm the appearance change — nothing was changed.",
-      );
+      reportPersistError("Couldn't confirm the appearance change — nothing was changed.");
     } finally {
       converting.value = false;
     }
@@ -96,14 +94,7 @@ export function ThemeModeSelector() {
    * leaves the pair as one control rather than walking through it.
    */
   const onKeyDown = (event: KeyboardEvent): void => {
-    const keys = [
-      "ArrowLeft",
-      "ArrowRight",
-      "ArrowUp",
-      "ArrowDown",
-      "Home",
-      "End",
-    ];
+    const keys = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End"];
     if (!keys.includes(event.key)) {
       return;
     }
@@ -115,20 +106,14 @@ export function ThemeModeSelector() {
         ? 0
         : event.key === "End"
           ? MODE_OPTIONS.length - 1
-          : (index + (forward ? 1 : -1) + MODE_OPTIONS.length) %
-            MODE_OPTIONS.length;
+          : (index + (forward ? 1 : -1) + MODE_OPTIONS.length) % MODE_OPTIONS.length;
     const next = MODE_OPTIONS[nextIndex];
-    groupRef.current
-      ?.querySelectorAll<HTMLButtonElement>("button")
-      [nextIndex]?.focus();
+    groupRef.current?.querySelectorAll<HTMLButtonElement>("button")[nextIndex]?.focus();
     void select(next.value);
   };
 
   return (
-    <ConfigRow
-      label="Appearance"
-      desc="Use a light or dark surface across Deck"
-    >
+    <ConfigRow label="Appearance" desc="Use a light or dark surface across Deck">
       <div
         ref={groupRef}
         class="segmented"

--- a/src/ui/sidebar-grip.test.tsx
+++ b/src/ui/sidebar-grip.test.tsx
@@ -139,14 +139,12 @@ describe("SidebarGrip", () => {
     expect(grip.className).not.toContain("is-dragging");
 
     drag(grip, 275, [330]);
-    expect(
-      host.querySelector<HTMLElement>(".sidebar-grip")!.className,
-    ).toContain("is-dragging");
+    expect(host.querySelector<HTMLElement>(".sidebar-grip")!.className).toContain("is-dragging");
 
     release(grip);
-    expect(
-      host.querySelector<HTMLElement>(".sidebar-grip")!.className,
-    ).not.toContain("is-dragging");
+    expect(host.querySelector<HTMLElement>(".sidebar-grip")!.className).not.toContain(
+      "is-dragging",
+    );
   });
 
   it("abandons the drag on pointercancel the same way it ends on pointerup", () => {

--- a/src/ui/sidebar-toggle.test.tsx
+++ b/src/ui/sidebar-toggle.test.tsx
@@ -78,11 +78,10 @@ describe("SidebarToggle", () => {
     );
 
     const actions = host.querySelector(".sidebar-frame-actions")!;
-    expect(
-      Array.from(actions.children).map((child) =>
-        child.getAttribute("aria-label"),
-      ),
-    ).toEqual(["Collapse the sidebar", "New"]);
+    expect(Array.from(actions.children).map((child) => child.getAttribute("aria-label"))).toEqual([
+      "Collapse the sidebar",
+      "New",
+    ]);
 
     act(() => {
       host.querySelector<HTMLButtonElement>(".sidebar-new")!.click();

--- a/src/ui/sidebar-toggle.tsx
+++ b/src/ui/sidebar-toggle.tsx
@@ -1,10 +1,7 @@
 import { Plus, SidebarSimple } from "@phosphor-icons/react";
 import { useEffect, useRef } from "preact/hooks";
 import { CHROME_ICON, DeckIcon } from "./controls/deck-icon";
-import {
-  createNewPaneDragController,
-  type NewPaneDropDeps,
-} from "./new-pane-drag";
+import { createNewPaneDragController, type NewPaneDropDeps } from "./new-pane-drag";
 
 interface SidebarToggleProps {
   /** Painted state, not the setting: a live drag arms this before it writes. */
@@ -51,10 +48,7 @@ interface SidebarNewButtonProps {
 }
 
 /** The sidebar's `New` launcher, now in the frame beside its hide control. */
-function SidebarNewButton({
-  onOpenWorkspace,
-  newPaneDrop,
-}: SidebarNewButtonProps) {
+function SidebarNewButton({ onOpenWorkspace, newPaneDrop }: SidebarNewButtonProps) {
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const dropRef = useRef<NewPaneDropDeps | undefined>(newPaneDrop);
   dropRef.current = newPaneDrop;
@@ -100,10 +94,7 @@ export function SidebarFrameActions(props: SidebarFrameActionsProps) {
   return (
     <div class="sidebar-frame-actions">
       <SidebarToggle collapsed={props.collapsed} onToggle={props.onToggle} />
-      <SidebarNewButton
-        onOpenWorkspace={props.onOpenWorkspace}
-        newPaneDrop={props.newPaneDrop}
-      />
+      <SidebarNewButton onOpenWorkspace={props.onOpenWorkspace} newPaneDrop={props.newPaneDrop} />
     </div>
   );
 }

--- a/src/ui/toolbar/external-app-button.tsx
+++ b/src/ui/toolbar/external-app-button.tsx
@@ -1,14 +1,8 @@
 import { CaretDown } from "@phosphor-icons/react";
 import { useEffect, useRef, useState } from "preact/hooks";
-import {
-  ActionTooltip,
-  useTooltipVisibility,
-} from "../controls/action-tooltip";
+import { ActionTooltip, useTooltipVisibility } from "../controls/action-tooltip";
 import { CHROME_ICON, DeckIcon } from "../controls/deck-icon";
-import {
-  groupExternalApps,
-  type ExternalAppChoice,
-} from "../../links/external-app-choices";
+import { groupExternalApps, type ExternalAppChoice } from "../../links/external-app-choices";
 import type { ExternalAppId } from "../../lib/external-app-catalog";
 import type { MenuAnchor } from "./toolbar-overflow-menu";
 
@@ -48,9 +42,7 @@ function AppMark({ choice }: { readonly choice: ExternalAppChoice }) {
     // No authored stand-in (DL-14.6): the label is the identity here.
     return <span class="extapp__initial">{choice.label.slice(0, 1)}</span>;
   }
-  return (
-    <img class="extapp__icon" src={choice.iconDataUrl} alt="" aria-hidden />
-  );
+  return <img class="extapp__icon" src={choice.iconDataUrl} alt="" aria-hidden />;
 }
 
 export function ExternalAppButton({
@@ -66,8 +58,7 @@ export function ExternalAppButton({
   const [menu, setMenu] = useState<MenuAnchor | null>(null);
   const tooltip = useTooltipVisibility();
 
-  const current =
-    choices.find((choice) => choice.id === selected) ?? choices[0] ?? null;
+  const current = choices.find((choice) => choice.id === selected) ?? choices[0] ?? null;
 
   useEffect(() => {
     if (menu === null) {
@@ -103,8 +94,7 @@ export function ExternalAppButton({
     return null;
   }
 
-  const reason =
-    workspacePath === null ? "No workspace is open on this tab" : null;
+  const reason = workspacePath === null ? "No workspace is open on this tab" : null;
   const label = `Open in ${current.label}`;
   const tooltipId = "action-tip-external-app";
   const showTooltip = tooltip.anchor !== null && menu === null;
@@ -180,18 +170,14 @@ export function ExternalAppButton({
         >
           {groupExternalApps(choices).map((view, index) => (
             <div key={view.group} class="toolbar-menu__group">
-              {index > 0 && (
-                <span class="toolbar-menu__sep" aria-hidden="true" />
-              )}
+              {index > 0 && <span class="toolbar-menu__sep" aria-hidden="true" />}
               {view.items.map((choice) => (
                 <button
                   key={choice.id}
                   type="button"
                   role="menuitemradio"
                   aria-checked={choice.id === current.id}
-                  class={`toolbar-menu__row ${
-                    choice.id === current.id ? "is-active" : ""
-                  }`}
+                  class={`toolbar-menu__row ${choice.id === current.id ? "is-active" : ""}`}
                   onClick={() => {
                     onSelect(choice.id);
                     setMenu(null);

--- a/src/ui/toolbar/feature-toolbar.tsx
+++ b/src/ui/toolbar/feature-toolbar.tsx
@@ -6,17 +6,8 @@ import {
   useTooltipVisibility,
   tooltipTriggerProps,
 } from "../controls/action-tooltip";
-import {
-  CHROME_ICON,
-  DeckIcon,
-  FEATURE_ICON,
-  type DeckIconSize,
-} from "../controls/deck-icon";
-import {
-  isUnavailable,
-  unavailableReason,
-  type ToolbarItem,
-} from "./toolbar-item";
+import { CHROME_ICON, DeckIcon, FEATURE_ICON, type DeckIconSize } from "../controls/deck-icon";
+import { isUnavailable, unavailableReason, type ToolbarItem } from "./toolbar-item";
 import { TOOLBAR_GAP, fitToolbarItems } from "./toolbar-overflow";
 import { ToolbarOverflowMenu, type MenuAnchor } from "./toolbar-overflow-menu";
 
@@ -94,9 +85,7 @@ function ToolbarControl({
       <button
         ref={ref}
         type="button"
-        class={`iconbtn ${item.controlClass ?? ""} ${
-          reason !== null ? "is-unavailable" : ""
-        }`}
+        class={`iconbtn ${item.controlClass ?? ""} ${reason !== null ? "is-unavailable" : ""}`}
         aria-label={item.label}
         aria-disabled={reason !== null}
         aria-describedby={showTooltip ? tooltipId : undefined}
@@ -220,10 +209,7 @@ export function FeatureToolbar({
 
   // Pinned first, then whatever the width pushed out: the menu reads as
   // "the things that live here" followed by "the things that had to move".
-  const menuItems: readonly ToolbarItem[] = [
-    ...(pinnedMenu ?? []),
-    ...fit.overflow,
-  ];
+  const menuItems: readonly ToolbarItem[] = [...(pinnedMenu ?? []), ...fit.overflow];
 
   // `DotsThreeOutline` solid, never `DotsThree` at `fill` — the latter is the
   // bare-glyph case DL-14.1 records: its fill variant becomes a knocked-out
@@ -263,12 +249,7 @@ export function FeatureToolbar({
           strip's trailing end, so it draws at 15 like the dock header — the
           glyph grew, the 24px `.iconbtn` box did not. */}
       {menuItems.length > 0 && (
-        <ToolbarControl
-          item={moreItem}
-          controlRef={moreRef}
-          iconSize={FEATURE_ICON}
-          iconFilled
-        />
+        <ToolbarControl item={moreItem} controlRef={moreRef} iconSize={FEATURE_ICON} iconFilled />
       )}
     </>
   );
@@ -286,9 +267,7 @@ export function FeatureToolbar({
         // before it, which is why this group renders in two halves.
         const trailing = index === lastGroup;
         const lead = trailing ? view.items.slice(0, -1) : view.items;
-        const anchorItem = trailing
-          ? view.items[view.items.length - 1]
-          : undefined;
+        const anchorItem = trailing ? view.items[view.items.length - 1] : undefined;
         return (
           <Fragment key={view.group}>
             {index > 0 && <span class="tabbar__sep" aria-hidden="true" />}
@@ -296,9 +275,7 @@ export function FeatureToolbar({
               <ToolbarControl key={item.id} item={item} />
             ))}
             {trailing && trailingExtras}
-            {anchorItem !== undefined && (
-              <ToolbarControl key={anchorItem.id} item={anchorItem} />
-            )}
+            {anchorItem !== undefined && <ToolbarControl key={anchorItem.id} item={anchorItem} />}
           </Fragment>
         );
       })}

--- a/src/ui/workspace-spinner.tsx
+++ b/src/ui/workspace-spinner.tsx
@@ -37,13 +37,7 @@ const DOTS: readonly Dot[] = Array.from({ length: COUNT }, (_, i) => {
 
 export function WorkspaceSpinner() {
   return (
-    <svg
-      class="wsitem__spinner"
-      viewBox="0 0 26 26"
-      width="26"
-      height="26"
-      aria-hidden="true"
-    >
+    <svg class="wsitem__spinner" viewBox="0 0 26 26" width="26" height="26" aria-hidden="true">
       {DOTS.map((dot, i) => (
         <circle
           key={i}

--- a/src/updater/update-controller.test.ts
+++ b/src/updater/update-controller.test.ts
@@ -329,10 +329,7 @@ describe("the background recheck", () => {
     vi.useFakeTimers();
     try {
       const update = pending();
-      const check = vi
-        .fn()
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce(update);
+      const check = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(update);
       const { controller } = setup(null, { check });
 
       await controller.start();

--- a/src/updater/update-controller.ts
+++ b/src/updater/update-controller.ts
@@ -91,8 +91,7 @@ export interface UpdateController {
   relaunch(): Promise<void>;
 }
 
-export type UpdateCheckResult =
-  "available" | "current" | "unsupported" | "failed";
+export type UpdateCheckResult = "available" | "current" | "unsupported" | "failed";
 
 const HIDDEN_VIEW = Object.freeze<UpdateView>({
   phase: "hidden",
@@ -121,9 +120,7 @@ function updateView(update: PendingUpdate, phase: UpdatePhase): UpdateView {
   });
 }
 
-export function createUpdateController(
-  deps: UpdateControllerDependencies,
-): UpdateController {
+export function createUpdateController(deps: UpdateControllerDependencies): UpdateController {
   const view = signal<UpdateView>(HIDDEN_VIEW);
   let update: PendingUpdate | null = null;
   let started = false;
@@ -157,8 +154,7 @@ export function createUpdateController(
           return "unsupported";
         }
         update = result;
-        view.value =
-          update === null ? HIDDEN_VIEW : updateView(update, "available");
+        view.value = update === null ? HIDDEN_VIEW : updateView(update, "available");
         return update === null ? "current" : "available";
       } catch (error: unknown) {
         deps.report("Update check failed", error);
@@ -271,16 +267,13 @@ export function createUpdateController(
   };
 
   const checkNow = (): Promise<UpdateCheckResult> =>
-    view.value.phase === "hidden"
-      ? checkForAvailableUpdate()
-      : Promise.resolve("available");
+    view.value.phase === "hidden" ? checkForAvailableUpdate() : Promise.resolve("available");
 
   const download = (): Promise<void> =>
     singleFlight(async () => {
       if (
         update === null ||
-        (view.value.phase !== "available" &&
-          view.value.phase !== "download-failed")
+        (view.value.phase !== "available" && view.value.phase !== "download-failed")
       ) {
         return;
       }
@@ -312,8 +305,7 @@ export function createUpdateController(
     singleFlight(async () => {
       if (
         update === null ||
-        (view.value.phase !== "downloaded" &&
-          view.value.phase !== "install-failed")
+        (view.value.phase !== "downloaded" && view.value.phase !== "install-failed")
       ) {
         return;
       }


### PR DESCRIPTION
Closes MXR-34.

`main` has had no green CI run since 2026-08-24. Both jobs died at **step 7**, so every step after it — Test, Build frontend, Typecheck Electron, Rust fmt, Rust tests — was skipped for twelve days. `npm test` and `npm run build` had never run in CI over that window; the numbers quoted in PRs were local runs, not a gate.

This is an infrastructure fix. **No shipped logic changes** — see the file table at the bottom.

## The 30 lint errors, by rule

Enumerated with `oxlint --format=json` before touching anything:

| Count | Rule | Verdict |
| -- | -- | -- |
| 25 | `jest/valid-expect` + `vitest/valid-expect` | false positive |
| 2 | `react-hooks/exhaustive-deps` | deliberate, silenced with reason |
| 2 | `jest/require-to-throw-message` + vitest twin | real, fixed in code |

Both plugins are enabled, so **26 of the 30 are one finding counted twice**.

**`valid-expect` is a false positive.** `expect(value, message)` is Vitest's own two-argument form, and every one of the 13 sites uses it to name which row of a table-driven loop failed. `maxArgs: 2` in the test override states that, which is narrower than switching the rule off — a third argument still fails, and the rule keeps its other checks everywhere.

**`require-to-throw-message` was a real gap.** The packaged-smoke test asserted that a nested pid is gone via a bare `.toThrow()`, which also passes on `EPERM` — a process that is still alive but owned by another user. It now asserts `ESRCH`.

**`exhaustive-deps` is deliberate in both cases**, and each effect already said so in its own comment. The mount effect *writes* `ready.value`, so listing it would re-run the effect that set it and re-create Monaco forever; it also holds `props.controller`, whose identity must not tear the editor down. The model effect reads only `document.text` and `document.file`, and lists both. oxlint 1.78 ignores per-line disables for this rule (measured — `eslint-disable-next-line` and `oxlint-disable-next-line` both no-op), so the scope is one file-level pragma naming that one rule, with the reasoning kept at each call site.

Nothing was downgraded to a warning and no rule was switched off. `max-lines` stays the warning it already was.

## The prettier half, which had never run

`npm run lint` is `oxlint && prettier --check .`, so oxlint's exit 1 short-circuited before prettier for the whole twelve days. **Prettier was red too:** 69 files were written at 80 columns against the config's 100. They are reformatted to the repo's own declared style — formatting only, no behaviour.

## The Windows failure: line endings, confirmed from the log

The hypothesis in the issue is right, and the full `windows-check` log **proves** it rather than merely suggesting it: every "Received" line in the CSS diffs ends in a literal `\r`. The repo had no `.gitattributes`, so Git for Windows' default `core.autocrlf=true` rewrote every LF to CRLF in the working tree, and suites that read a source file and assert it *contains* an LF-spelled snippet compared LF needles against CRLF haystacks.

`* text=auto eol=lf` overrides that for the working tree, so a test reads the bytes that were committed on every platform. **No assertion was widened.** The change is inert in the index: `git add --renormalize .` moved nothing, because no tracked text file in this repo contains a CR today. Byte-exact fixtures and binaries are marked so git leaves them alone in both directions.

Two more Windows failures are platform bugs rather than line endings, and are fixed here because both are unambiguous:

- **`security-regressions.test.ts`** used `URL.pathname`, which yields `/D:/a/…` on Windows; `readdirSync` resolved that against the current drive and looked for `D:\D:\a\…`. It uses `fileURLToPath` now — the same note two sibling tests already carry.
- **Two `write.test.ts` cases** assert POSIX permission bits, which Windows does not have (`stat().mode & 0o777` answers `0o666` there whatever was asked for). They are gated with `it.runIf(process.platform !== "win32")`, following `spawn-helper-permissions.test.ts`. The assertions stay exact where the bits exist rather than being widened to pass everywhere.

## Verified

Every step of the `check` job, run locally on this branch:

| Step | Result |
| -- | -- |
| `npm run generate:menu:check` | pass |
| `npm run lint` | pass (0 errors; warnings only) |
| `npm test` | **3870 passed, 0 failed** (3 skipped) |
| `npm run build` | pass |
| `npm run electron:build` | pass |
| `cargo fmt --check` | pass |
| `cargo test` | **297 passed, 0 failed** |

## Not verified

**Anything on Windows.** There was no Windows hardware in the session, so the `.gitattributes` fix is reasoned from the log's `\r` bytes and from `git check-attr`, not observed. **This PR's own `windows-check` run is the first real evidence** — read it before merging.

`windows-check` also carries a **separate pre-existing backlog this does not close**:

- `electron/pty/info.test.ts` — 6 failures, process classification (AGENTS.md lists this as a fork; it needs an owner decision, not a drive-by patch)
- `electron/pty/manager.test.ts` — 1
- `electron/fs/read.test.ts` — readdir ordering
- three spawned-process `SyntaxError`s

That job has been red since well before 2026-08-24, as `ci.yml`'s own comment on `windows-electron-package` records ("17 failures, all of them pre-existing"). So MXR-34's third acceptance bullet closes **only for `check`** with this PR; `windows-check` needs a follow-up once the fork above is decided.

## Files

| Change | Kind |
| -- | -- |
| `.oxlintrc.json` (`maxArgs: 2`) | lint config |
| `.gitattributes` (new) | git config |
| 69 files reformatted | whitespace only |
| `src/files/ui/file-editor.tsx` | comments + one pragma, **no logic changed** |
| 3 `*.test.ts` files | tests only |

No runtime behaviour of the app changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StiWXFeq9pa2iPHESv9Ltn

---
_Generated by [Claude Code](https://claude.ai/code/session_01StiWXFeq9pa2iPHESv9Ltn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Maintenance**
  - Standardized line-ending handling and binary-file treatment for more consistent repository behavior.
  - Updated development checks and formatting across the application without changing functionality or user-facing behavior.
  - Added clarifying comments around intentionally limited effect dependencies and platform-specific behavior.

- **Bug Fixes**
  - Improved Windows compatibility for path handling in automated checks.
  - Restricted permission-related tests to supported POSIX environments.
  - Strengthened process-cleanup verification to detect incomplete shutdowns more precisely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->