### PR TITLE
feat(landing): ship the quick-install command and keep the privacy page

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -21,6 +21,10 @@
 # The tour panels import the shared brand marks from here.
 !/marketing/stage
 
+# Vite's publicDir for the landing build (root = marketing/): the privacy page
+# is copied verbatim into the output root and served by the /privacy rewrites.
+!/marketing/public
+
 # The landing's agent logos live with the app's own assets.
 !/src
 /src/*

--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ replacing the CLI's own workflow
 
 ## Install
 
+Quick install:
+
+```sh
+curl -fsSL https://deck.spacevibe.dev/install.sh | sh
+```
+
+```powershell
+irm https://deck.spacevibe.dev/install.ps1 | iex
+```
+
 - **[macOS — Apple Silicon (arm64)](https://github.com/mxrsv/spacevibe-deck/releases/latest):** signed and notarized. Intel Macs are not served by V1.
 - **[Windows — x64](https://github.com/mxrsv/spacevibe-deck/releases/latest):** unsigned; SmartScreen will warn. Windows ARM is not served, and V1 remains runtime-unverified on Windows hardware.
 

--- a/marketing/landing-prototype/install.ps1
+++ b/marketing/landing-prototype/install.ps1
@@ -204,7 +204,23 @@ try {
 
   Receive-TrustedAsset $InstallerUri $Tag $InstallerName $InstallerPath
   $ExpectedHash = [BitConverter]::ToString($ExpectedHashBytes).Replace("-", "")
-  $ActualHash = (Get-FileHash -Algorithm SHA512 -LiteralPath $InstallerPath).Hash
+
+  # .NET rather than Get-FileHash: in Windows PowerShell 5.1 that cmdlet is a
+  # script function auto-loaded through PSModulePath, and a powershell.exe
+  # started from PowerShell 7 inherits pwsh's module path, where the lookup
+  # resolves to the Core edition of Microsoft.PowerShell.Utility and fails
+  # with "Get-FileHash is not recognized" (PowerShell/PowerShell#24630).
+  $Sha512 = [Security.Cryptography.SHA512]::Create()
+  $InstallerStream = [IO.File]::OpenRead($InstallerPath)
+
+  try {
+    $ActualHashBytes = $Sha512.ComputeHash($InstallerStream)
+  } finally {
+    $InstallerStream.Dispose()
+    $Sha512.Dispose()
+  }
+
+  $ActualHash = [BitConverter]::ToString($ActualHashBytes).Replace("-", "")
 
   if (-not [string]::Equals($ExpectedHash, $ActualHash, [StringComparison]::OrdinalIgnoreCase)) {
     Stop-Install "Installer SHA-512 verification failed."

--- a/marketing/landing-prototype/install.ps1
+++ b/marketing/landing-prototype/install.ps1
@@ -1,0 +1,226 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$ReleaseApi = "https://api.github.com/repos/mxrsv/spacevibe-deck/releases/latest"
+$ReleasesPage = "https://github.com/mxrsv/spacevibe-deck/releases"
+$RepositoryPath = "/mxrsv/spacevibe-deck/releases/download"
+$ReleaseAssetPath = "/github-production-release-asset/1287332937/"
+$Headers = @{ Accept = "application/vnd.github+json" }
+$TempDirectory = $null
+
+function Stop-Install([string]$Message) {
+  throw "${Message} Download manually: $ReleasesPage"
+}
+
+function Get-TrustedReleaseUri(
+  [object]$Asset,
+  [string]$Tag,
+  [string]$ExpectedName
+) {
+  if ($null -eq $Asset -or $Asset.name -isnot [string] -or $Asset.name -ne $ExpectedName) {
+    Stop-Install "Release asset metadata is malformed."
+  }
+
+  if ($Asset.browser_download_url -isnot [string]) {
+    Stop-Install "Release asset URL is missing."
+  }
+
+  $Uri = $null
+
+  if (-not [Uri]::TryCreate($Asset.browser_download_url, [UriKind]::Absolute, [ref]$Uri)) {
+    Stop-Install "Release asset URL is malformed."
+  }
+
+  $DecodedPath = [Uri]::UnescapeDataString($Uri.AbsolutePath)
+  $ExpectedPath = "$RepositoryPath/$Tag/$ExpectedName"
+
+  if (
+    $Uri.Scheme -ne "https" -or
+    $Uri.Host -ne "github.com" -or
+    $DecodedPath -ne $ExpectedPath
+  ) {
+    Stop-Install "Release asset is outside the trusted GitHub release origin."
+  }
+
+  return $Uri
+}
+
+function Test-TrustedFinalUri(
+  [Uri]$Uri,
+  [string]$ExpectedPath,
+  [string]$ExpectedName
+) {
+  if ($Uri.Scheme -ne "https") {
+    return $false
+  }
+
+  if (
+    $Uri.Host -eq "github.com" -and
+    [Uri]::UnescapeDataString($Uri.AbsolutePath) -eq $ExpectedPath
+  ) {
+    return $true
+  }
+
+  if (
+    $Uri.Host -ne "release-assets.githubusercontent.com" -or
+    -not $Uri.AbsolutePath.StartsWith($ReleaseAssetPath, [StringComparison]::Ordinal)
+  ) {
+    return $false
+  }
+
+  $DecodedQuery = [Uri]::UnescapeDataString($Uri.Query)
+  return $DecodedQuery -match ("filename=" + [regex]::Escape($ExpectedName) + "(?:&|$)")
+}
+
+function Receive-TrustedAsset(
+  [Uri]$Uri,
+  [string]$Tag,
+  [string]$Name,
+  [string]$OutFile
+) {
+  Add-Type -AssemblyName System.Net.Http
+  $Handler = [Net.Http.HttpClientHandler]::new()
+  $Handler.AllowAutoRedirect = $true
+  $Handler.MaxAutomaticRedirections = 5
+  $Client = [Net.Http.HttpClient]::new($Handler)
+  $Response = $null
+  $InputStream = $null
+  $OutputStream = $null
+
+  try {
+    $Client.DefaultRequestHeaders.UserAgent.ParseAdd("SpaceVibe-Deck-Installer/1")
+    $Response = $Client.GetAsync(
+      $Uri.AbsoluteUri,
+      [Net.Http.HttpCompletionOption]::ResponseHeadersRead
+    ).GetAwaiter().GetResult()
+    $Response.EnsureSuccessStatusCode() | Out-Null
+    $FinalUri = $Response.RequestMessage.RequestUri
+    $ExpectedPath = "$RepositoryPath/$Tag/$Name"
+
+    if (-not (Test-TrustedFinalUri $FinalUri $ExpectedPath $Name)) {
+      Stop-Install "Download redirected outside the trusted GitHub release asset."
+    }
+
+    $InputStream = $Response.Content.ReadAsStreamAsync().GetAwaiter().GetResult()
+    $OutputStream = [IO.File]::Create($OutFile)
+    $InputStream.CopyTo($OutputStream)
+  } finally {
+    if ($null -ne $OutputStream) {
+      $OutputStream.Dispose()
+    }
+
+    if ($null -ne $InputStream) {
+      $InputStream.Dispose()
+    }
+
+    if ($null -ne $Response) {
+      $Response.Dispose()
+    }
+
+    $Client.Dispose()
+    $Handler.Dispose()
+  }
+}
+
+try {
+  if ([Environment]::OSVersion.Platform -ne [PlatformID]::Win32NT) {
+    Stop-Install "64-bit Windows is required."
+  }
+
+  $ProcessorArchitecture = if ($env:PROCESSOR_ARCHITEW6432) {
+    $env:PROCESSOR_ARCHITEW6432
+  } else {
+    $env:PROCESSOR_ARCHITECTURE
+  }
+
+  if (-not [Environment]::Is64BitOperatingSystem -or $ProcessorArchitecture -ne "AMD64") {
+    Stop-Install "Windows x64 is required; Windows ARM is not supported."
+  }
+
+  $Release = Invoke-RestMethod -Uri $ReleaseApi -Headers $Headers -MaximumRedirection 5
+
+  if (
+    $null -eq $Release -or
+    $Release.draft -ne $false -or
+    $Release.prerelease -ne $false -or
+    $Release.tag_name -isnot [string] -or
+    $Release.tag_name -notmatch '^v?\d+\.\d+\.\d+$' -or
+    $null -eq $Release.assets
+  ) {
+    Stop-Install "GitHub did not return a published stable release."
+  }
+
+  $InstallerAssets = @(
+    $Release.assets | Where-Object {
+      $_.name -is [string] -and $_.name -match '^[A-Za-z0-9._-]+-win-x64-setup\.exe$'
+    }
+  )
+  $ManifestAssets = @(
+    $Release.assets | Where-Object { $_.name -eq "latest.yml" }
+  )
+
+  if ($InstallerAssets.Count -ne 1) {
+    Stop-Install "The stable release must contain exactly one Windows x64 installer."
+  }
+
+  if ($ManifestAssets.Count -ne 1) {
+    Stop-Install "The stable release must contain exactly one latest.yml manifest."
+  }
+
+  $InstallerName = [string]$InstallerAssets[0].name
+  $Tag = [string]$Release.tag_name
+  $InstallerUri = Get-TrustedReleaseUri $InstallerAssets[0] $Tag $InstallerName
+  $ManifestUri = Get-TrustedReleaseUri $ManifestAssets[0] $Tag "latest.yml"
+
+  $TempDirectory = Join-Path ([IO.Path]::GetTempPath()) ("spacevibe-deck-" + [Guid]::NewGuid())
+  [IO.Directory]::CreateDirectory($TempDirectory) | Out-Null
+  $ManifestPath = Join-Path $TempDirectory "latest.yml"
+  $InstallerPath = Join-Path $TempDirectory $InstallerName
+
+  Write-Host "Installing SpaceVibe Deck $Tag for Windows x64..."
+  Receive-TrustedAsset $ManifestUri $Tag "latest.yml" $ManifestPath
+
+  $Manifest = [IO.File]::ReadAllText($ManifestPath)
+  $PathMatch = [regex]::Match($Manifest, '(?m)^path:\s*([^\r\n]+)\s*$')
+  $HashMatch = [regex]::Match($Manifest, '(?m)^sha512:\s*([^\r\n]+)\s*$')
+
+  if (-not $PathMatch.Success -or $PathMatch.Groups[1].Value.Trim() -ne $InstallerName) {
+    Stop-Install "latest.yml does not name the resolved installer."
+  }
+
+  if (-not $HashMatch.Success) {
+    Stop-Install "latest.yml does not contain a SHA-512 value."
+  }
+
+  try {
+    $ExpectedHashBytes = [Convert]::FromBase64String($HashMatch.Groups[1].Value.Trim())
+  } catch {
+    Stop-Install "latest.yml contains an invalid SHA-512 value."
+  }
+
+  if ($ExpectedHashBytes.Length -ne 64) {
+    Stop-Install "latest.yml SHA-512 value has the wrong length."
+  }
+
+  Receive-TrustedAsset $InstallerUri $Tag $InstallerName $InstallerPath
+  $ExpectedHash = [BitConverter]::ToString($ExpectedHashBytes).Replace("-", "")
+  $ActualHash = (Get-FileHash -Algorithm SHA512 -LiteralPath $InstallerPath).Hash
+
+  if (-not [string]::Equals($ExpectedHash, $ActualHash, [StringComparison]::OrdinalIgnoreCase)) {
+    Stop-Install "Installer SHA-512 verification failed."
+  }
+
+  $Process = Start-Process -FilePath $InstallerPath -Wait -PassThru
+
+  if ($Process.ExitCode -ne 0) {
+    Stop-Install "The installer was cancelled or exited with code $($Process.ExitCode)."
+  }
+
+  Write-Host "SpaceVibe Deck $Tag installation completed."
+} catch {
+  throw "SpaceVibe Deck install failed: $($_.Exception.Message)"
+} finally {
+  if ($null -ne $TempDirectory -and [IO.Directory]::Exists($TempDirectory)) {
+    Remove-Item -LiteralPath $TempDirectory -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}

--- a/marketing/landing-prototype/install.sh
+++ b/marketing/landing-prototype/install.sh
@@ -1,0 +1,168 @@
+#!/bin/sh
+
+set -eu
+
+RELEASE_API="https://api.github.com/repos/mxrsv/spacevibe-deck/releases/latest"
+RELEASES_PAGE="https://github.com/mxrsv/spacevibe-deck/releases"
+APP_NAME="SpaceVibe Deck.app"
+
+fail() {
+  printf 'SpaceVibe Deck install failed: %s\n' "$1" >&2
+  printf 'Download manually: %s\n' "$RELEASES_PAGE" >&2
+  exit 1
+}
+
+[ "$(uname -s)" = "Darwin" ] || fail "macOS is required."
+[ "$(uname -m)" = "arm64" ] || fail "Apple Silicon (arm64) is required."
+
+command -v curl >/dev/null 2>&1 || fail "curl is required."
+command -v osascript >/dev/null 2>&1 || fail "osascript is required."
+command -v hdiutil >/dev/null 2>&1 || fail "hdiutil is required."
+command -v codesign >/dev/null 2>&1 || fail "codesign is required."
+command -v spctl >/dev/null 2>&1 || fail "spctl is required."
+command -v ditto >/dev/null 2>&1 || fail "ditto is required."
+
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/spacevibe-deck.XXXXXX") || fail "Could not create a temporary directory."
+mount_dir="$work_dir/mount"
+release_json="$work_dir/release.json"
+dmg_path="$work_dir/SpaceVibe-Deck.dmg"
+mounted=0
+
+cleanup() {
+  if [ "$mounted" -eq 1 ]; then
+    hdiutil detach "$mount_dir" >/dev/null 2>&1 || true
+  fi
+
+  rm -rf "$work_dir"
+}
+
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+mkdir -p "$mount_dir"
+
+curl \
+  --fail \
+  --silent \
+  --show-error \
+  --location \
+  --proto '=https' \
+  --proto-redir '=https' \
+  --tlsv1.2 \
+  --retry 2 \
+  --header 'Accept: application/vnd.github+json' \
+  --output "$release_json" \
+  "$RELEASE_API" || fail "Could not resolve the latest stable release."
+
+release_data=$(
+  osascript -l JavaScript - "$release_json" <<'JXA'
+ObjC.import("Foundation");
+
+function abort(message) {
+  throw new Error(message);
+}
+
+function run(argv) {
+  const path = argv[0];
+  const source = ObjC.unwrap(
+    $.NSString.stringWithContentsOfFileEncodingError(
+      path,
+      $.NSUTF8StringEncoding,
+      null,
+    ),
+  );
+
+  if (typeof source !== "string") {
+    abort("Release response could not be read.");
+  }
+
+  const release = JSON.parse(source);
+
+  if (
+    !release ||
+    typeof release !== "object" ||
+    release.draft !== false ||
+    release.prerelease !== false ||
+    typeof release.tag_name !== "string" ||
+    !/^v?\d+\.\d+\.\d+$/.test(release.tag_name) ||
+    !Array.isArray(release.assets)
+  ) {
+    abort("Release response is not a published stable release.");
+  }
+
+  const matches = release.assets.filter((asset) => {
+    if (
+      !asset ||
+      typeof asset.name !== "string" ||
+      typeof asset.browser_download_url !== "string" ||
+      !/^[A-Za-z0-9._-]+-arm64\.dmg$/.test(asset.name)
+    ) {
+      return false;
+    }
+
+    const expected =
+      "https://github.com/mxrsv/spacevibe-deck/releases/download/" +
+      encodeURIComponent(release.tag_name) +
+      "/" +
+      encodeURIComponent(asset.name);
+
+    return asset.browser_download_url === expected;
+  });
+
+  if (matches.length !== 1) {
+    abort("Release must contain exactly one trusted Apple Silicon DMG.");
+  }
+
+  return release.tag_name + "\n" + matches[0].browser_download_url;
+}
+JXA
+) || fail "Release metadata validation failed."
+
+release_version=$(printf '%s\n' "$release_data" | sed -n '1p')
+dmg_url=$(printf '%s\n' "$release_data" | sed -n '2p')
+
+[ -n "$release_version" ] || fail "Release version is missing."
+[ -n "$dmg_url" ] || fail "Release asset URL is missing."
+
+printf 'Installing SpaceVibe Deck %s for Apple Silicon...\n' "$release_version"
+
+curl \
+  --fail \
+  --silent \
+  --show-error \
+  --location \
+  --proto '=https' \
+  --proto-redir '=https' \
+  --tlsv1.2 \
+  --retry 2 \
+  --output "$dmg_path" \
+  "$dmg_url" || fail "Could not download the signed DMG."
+
+hdiutil attach \
+  -nobrowse \
+  -readonly \
+  -mountpoint "$mount_dir" \
+  "$dmg_path" >/dev/null || fail "Could not mount the DMG."
+mounted=1
+
+app_paths=$(find "$mount_dir" -type d -name "$APP_NAME" -prune -print)
+app_count=$(printf '%s\n' "$app_paths" | awk 'NF { count += 1 } END { print count + 0 }')
+
+[ "$app_count" -eq 1 ] || fail "The DMG must contain exactly one $APP_NAME."
+app_path=$(printf '%s\n' "$app_paths" | sed -n '1p')
+
+codesign --verify --deep --strict "$app_path" || fail "Code signature verification failed."
+spctl --assess --type execute "$app_path" || fail "Gatekeeper rejected the application."
+
+if [ -d /Applications ] && [ -w /Applications ]; then
+  install_root="/Applications"
+else
+  install_root="$HOME/Applications"
+  mkdir -p "$install_root" || fail "Could not create $install_root."
+fi
+
+install_path="$install_root/$APP_NAME"
+ditto "$app_path" "$install_path" || fail "Could not copy the application to $install_root."
+
+printf 'Installed SpaceVibe Deck %s at %s\n' "$release_version" "$install_path"

--- a/marketing/landing-prototype/src/directions/a.js
+++ b/marketing/landing-prototype/src/directions/a.js
@@ -1,7 +1,7 @@
 import { renderAgentStrip } from "../agent-strip.js";
 import { BRAND_ICON_SRC, renderStagePane, renderStageRail, renderStageStrip } from "../appwin.js";
-import { renderAppleIcon, renderWindowsIcon } from "../os-icons.js";
-import { RELEASES_URL, REPO_URL, WINDOWS_FALLBACK_URL } from "../download-links.js";
+import { REPO_URL } from "../download-links.js";
+import { renderQuickInstall } from "../install-command.js";
 import { CHANGELOG_URL } from "../release-data.js";
 import {
   STAGE_ARIA_LABEL,
@@ -66,16 +66,6 @@ function renderDiscordIcon() {
   return `
     <svg class="a-discord-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true">
       <path d="M19.5 5.34A17.4 17.4 0 0 0 15.44 4l-.5 1.03a16.2 16.2 0 0 0-5.88 0L8.56 4A17.4 17.4 0 0 0 4.5 5.34C1.93 9.18 1.23 12.93 1.58 16.63a16.6 16.6 0 0 0 4.98 2.5l1.2-1.64c-.66-.25-1.3-.56-1.9-.92l.47-.36c3.67 1.7 7.65 1.7 11.28 0l.48.36c-.6.36-1.24.67-1.9.92l1.2 1.64a16.5 16.5 0 0 0 4.98-2.5c.42-4.29-.72-8-2.87-11.29ZM8.52 14.36c-1.1 0-2-1.02-2-2.28s.88-2.28 2-2.28c1.12 0 2.02 1.03 2 2.28 0 1.26-.88 2.28-2 2.28Zm6.96 0c-1.1 0-2-1.02-2-2.28s.88-2.28 2-2.28c1.12 0 2.02 1.03 2 2.28 0 1.26-.88 2.28-2 2.28Z" />
-    </svg>
-  `;
-}
-
-function renderInstallIcon() {
-  return `
-    <svg class="a-install-icon" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-      <path d="M12 3v11" />
-      <path d="m8 10 4 4 4-4" />
-      <path d="M5 18v2h14v-2" />
     </svg>
   `;
 }
@@ -147,41 +137,7 @@ export function renderDirectionA(copy) {
               <p class="a-subhead" data-copy="subhead">${copy.subhead}</p>
             </div>
 
-            <div class="a-actions">
-              <!-- Both installs wear the same outline variant (owner,
-                   2026-08-20): with two stable platforms there is no primary
-                   one, and the white fill went with the hierarchy. -->
-              <a
-                class="a-quiet-cta"
-                href="${WINDOWS_FALLBACK_URL}"
-                target="_blank"
-                rel="noreferrer"
-              >
-                <span class="a-cta-lead">
-                  ${renderWindowsIcon()}
-                  <span data-copy="installWin">${copy.installWin}</span>
-                </span>
-                <span class="a-cta-trail"> ${renderInstallIcon()} </span>
-              </a>
-
-              <!-- An anchor again since 1.0.0 shipped stable for both
-                   platforms (2026-08-20): the server-rendered href is the
-                   releases page, and upgradeReleaseLinks retargets it at the
-                   newest stable .dmg — see download-links.js. The preview and
-                   coming-soon tags went with the preview era. -->
-              <a
-                class="a-quiet-cta"
-                href="${RELEASES_URL}"
-                target="_blank"
-                rel="noreferrer"
-              >
-                <span class="a-cta-lead">
-                  ${renderAppleIcon()}
-                  <span data-copy="installMac">${copy.installMac}</span>
-                </span>
-                <span class="a-cta-trail"> ${renderInstallIcon()} </span>
-              </a>
-            </div>
+            ${renderQuickInstall()}
 
             <div class="a-hero__support">
               <!-- Pointed at the feature panels since 2026-08-19. It used to

--- a/marketing/landing-prototype/src/directions/a.test.js
+++ b/marketing/landing-prototype/src/directions/a.test.js
@@ -343,3 +343,14 @@ describe("the English-only header", () => {
     expect(root.querySelector("[data-release-version]")).toBeNull();
   });
 });
+
+describe("the public install action", () => {
+  it("renders the selected quick-install prompt instead of legacy download buttons", () => {
+    const root = renderHero();
+
+    expect(root.querySelector("[data-quick-install]")).not.toBeNull();
+    expect(root.querySelectorAll("[data-install-platform]")).toHaveLength(2);
+    expect(root.querySelector(".a-actions")).toBeNull();
+    expect(root.querySelector(".a-quiet-cta")).toBeNull();
+  });
+});

--- a/marketing/landing-prototype/src/download-links.js
+++ b/marketing/landing-prototype/src/download-links.js
@@ -3,20 +3,13 @@
  *
  * The download anchors are server-rendered with releases *pages* — URLs that
  * never rot — and upgraded in place at load time: one call to the releases
- * API finds the newest macOS .dmg on a stable release and the newest Windows
- * installer on any published release. The Windows engineering preview ships
- * as a prerelease, which `releases/latest` never returns, hence the list
- * endpoint.
+ * API finds the newest Apple Silicon .dmg and Windows x64 installer on stable
+ * releases. The list endpoint remains shared with the changelog and download
+ * proof, while platform selection rejects prerelease installers.
  *
  * Decided 2026-08-01: the Windows link follows the API like macOS, replacing
  * the hand-bumped WINDOWS_TAG pin — publishing a release is the act that
  * points the landing at it, so an unpublished build can never be served.
- *
- * 2026-08-17, for the Windows Electron release: the page carries no macOS
- * ANCHOR right now — the macOS control is a disabled button until the Electron
- * macOS build ships, so nothing matches the `downloadMac` retarget and the old
- * Tauri .dmg is never handed out. The call below stays because restoring macOS
- * is then a markup change alone: turn the button back into an anchor.
  *
  * Failure contract: on any miss (offline, rate limit, no matching asset) the
  * anchors keep their server-rendered page hrefs — a releases page, never a
@@ -70,6 +63,25 @@ function setDownloadProofState(root, state, count = null) {
   }
 }
 
+function retargetInstallManualLinks(root, urls) {
+  for (const link of root.querySelectorAll("[data-install-manual]")) {
+    if (urls.mac) {
+      link.dataset.installMacUrl = urls.mac;
+    }
+
+    if (urls.win) {
+      link.dataset.installWinUrl = urls.win;
+    }
+
+    const selectedUrl = link.dataset.installManual === "win" ? urls.win : urls.mac;
+
+    if (selectedUrl) {
+      link.href = selectedUrl;
+      link.removeAttribute("target");
+    }
+  }
+}
+
 export async function upgradeReleaseLinks(root) {
   let releases;
 
@@ -84,6 +96,7 @@ export async function upgradeReleaseLinks(root) {
 
   retargetAnchors(root, ["downloadMac", "installMac"], urls.mac);
   retargetAnchors(root, ["downloadWin", "installWin"], urls.win);
+  retargetInstallManualLinks(root, urls);
   setDownloadProofState(root, "ready", totalInstallerDownloads(releases));
 
   const stableTag = latestStableTag(releases);

--- a/marketing/landing-prototype/src/download-links.test.js
+++ b/marketing/landing-prototype/src/download-links.test.js
@@ -7,12 +7,12 @@ import {
 } from "./download-links.js";
 
 const DMG_URL =
-  "https://github.com/mxrsv/spacevibe-deck/releases/download/v0.9.0/SpaceVibe.Deck_0.9.0_universal.dmg";
+  "https://github.com/mxrsv/spacevibe-deck/releases/download/v0.9.0/SpaceVibe-Deck-0.9.0-arm64.dmg";
 const EXE_URL =
-  "https://github.com/mxrsv/spacevibe-deck/releases/download/v0.9.0-windows-preview/SpaceVibe.Deck_0.9.0_x64-setup.exe";
+  "https://github.com/mxrsv/spacevibe-deck/releases/download/v0.9.0/SpaceVibe-Deck-0.9.0-win-x64-setup.exe";
 
-// Newest-first, like the API: the Windows preview prerelease sits above the
-// stable macOS release.
+// Newest-first, like the API: the preview sits above the stable release, but
+// both platform links resolve from stable assets only.
 const RELEASES = [
   {
     tag_name: "v0.9.0-windows-preview",
@@ -44,9 +44,14 @@ const RELEASES = [
         browser_download_url: "x",
       },
       {
-        name: "SpaceVibe.Deck_0.9.0_universal.dmg",
+        name: "SpaceVibe-Deck-0.9.0-arm64.dmg",
         download_count: 5,
         browser_download_url: DMG_URL,
+      },
+      {
+        name: "SpaceVibe-Deck-0.9.0-win-x64-setup.exe",
+        download_count: 6,
+        browser_download_url: EXE_URL,
       },
     ],
   },
@@ -54,8 +59,6 @@ const RELEASES = [
 
 // Mirrors the page: the hero uses install copy, while the finale/footer retain
 // download copy. The footer Releases link must stay untouched.
-// The macOS control is a disabled button while the Electron macOS build is
-// unreleased — it carries `downloadMac` but is deliberately not an anchor.
 function renderFixture() {
   const root = document.createElement("main");
   root.innerHTML = `
@@ -63,16 +66,17 @@ function renderFixture() {
       <span data-copy="installWin">Install for Windows</span>
       <span data-copy="winPreviewTag">preview</span>
     </a>
-    <button class="hero-mac" type="button" disabled>
+    <a class="hero-mac" href="${RELEASES_URL}" target="_blank" rel="noreferrer">
       <span data-copy="installMac">Install for macOS</span>
-      <span data-copy="comingSoon">coming soon</span>
-    </button>
+    </a>
     <a class="footer-win" href="${WINDOWS_FALLBACK_URL}" target="_blank" rel="noreferrer"
       data-copy="downloadWin">Download for Windows</a>
     <a class="releases" href="${RELEASES_URL}" target="_blank"
       data-copy="footerReleases">Releases</a>
     <a class="release-version" href="/landing-prototype/changelog/"
       data-release-version>v0.8.0</a>
+    <a class="quick-manual" href="${WINDOWS_FALLBACK_URL}"
+      data-install-manual="win">Download manually</a>
     <aside data-download-proof data-download-state="loading">
       <strong data-download-count>—</strong>
       <span>downloads</span>
@@ -110,7 +114,10 @@ describe("upgradeReleaseLinks", () => {
     expect(
       root.querySelector("[data-download-proof]").dataset.downloadState,
     ).toBe("ready");
-    expect(root.querySelector("[data-download-count]").textContent).toBe("17");
+    expect(root.querySelector("[data-download-count]").textContent).toBe("23");
+    expect(root.querySelector(".quick-manual").href).toBe(EXE_URL);
+    expect(root.querySelector(".quick-manual").dataset.installMacUrl).toBe(DMG_URL);
+    expect(root.querySelector(".quick-manual").dataset.installWinUrl).toBe(EXE_URL);
   });
 
   it("leaves non-download anchors alone", async () => {
@@ -122,19 +129,16 @@ describe("upgradeReleaseLinks", () => {
     expect(root.querySelector("a.releases").href).toBe(RELEASES_URL);
   });
 
-  // The whole point of the coming-soon control being a <button>: a live .dmg
-  // exists on a stable release, and nothing may quietly turn it into a link.
-  it("never turns the coming-soon macOS control into a download", async () => {
+  it("points the macOS anchor at the stable Apple Silicon DMG", async () => {
     stubFetch(RELEASES);
     const root = renderFixture();
 
     await upgradeReleaseLinks(root);
 
     const mac = root.querySelector(".hero-mac");
-    expect(mac.tagName).toBe("BUTTON");
-    expect(mac.hasAttribute("href")).toBe(false);
-    expect(mac.disabled).toBe(true);
-    expect(root.querySelector("a.hero-mac")).toBeNull();
+    expect(mac.tagName).toBe("A");
+    expect(mac.href).toBe(DMG_URL);
+    expect(mac.hasAttribute("target")).toBe(false);
   });
 
   it("keeps the page hrefs when the API call fails", async () => {
@@ -169,7 +173,12 @@ describe("upgradeReleaseLinks", () => {
   });
 
   it("keeps the releases page when no release carries an .exe", async () => {
-    stubFetch([RELEASES[1]]);
+    stubFetch([
+      {
+        ...RELEASES[1],
+        assets: RELEASES[1].assets.filter((asset) => !asset.name.endsWith(".exe")),
+      },
+    ]);
     const root = renderFixture();
 
     await upgradeReleaseLinks(root);

--- a/marketing/landing-prototype/src/install-bootstrap.test.js
+++ b/marketing/landing-prototype/src/install-bootstrap.test.js
@@ -1,0 +1,255 @@
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../../..");
+const MAC_INSTALLER = resolve(REPO_ROOT, "marketing/landing-prototype/install.sh");
+const WINDOWS_INSTALLER = resolve(REPO_ROOT, "marketing/landing-prototype/install.ps1");
+const scratchDirectories = [];
+
+function scratch(prefix) {
+  const directory = mkdtempSync(join(tmpdir(), prefix));
+  scratchDirectories.push(directory);
+  return directory;
+}
+
+function executable(path, source) {
+  writeFileSync(path, source);
+  chmodSync(path, 0o755);
+}
+
+function macFixture({ failCodesign = false } = {}) {
+  const directory = scratch("deck-install-mac-");
+  const bin = join(directory, "bin");
+  const releaseJson = join(directory, "release.json");
+  const copyLog = join(directory, "copy.log");
+  mkdirSync(bin);
+
+  writeFileSync(
+    releaseJson,
+    JSON.stringify({
+      draft: false,
+      prerelease: false,
+      tag_name: "v1.2.3",
+      assets: [
+        {
+          name: "SpaceVibe-Deck-1.2.3-arm64.dmg",
+          browser_download_url:
+            "https://github.com/mxrsv/spacevibe-deck/releases/download/v1.2.3/SpaceVibe-Deck-1.2.3-arm64.dmg",
+        },
+      ],
+    }),
+  );
+
+  executable(
+    join(bin, "curl"),
+    `#!/bin/sh
+output=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) shift; output="$1" ;;
+    http*) url="$1" ;;
+  esac
+  shift
+done
+case "$url" in
+  *api.github.com*) cp "$DECK_TEST_RELEASE_JSON" "$output" ;;
+  *github.com*) printf 'fixture-dmg' > "$output" ;;
+  *) exit 2 ;;
+esac
+`,
+  );
+  executable(
+    join(bin, "hdiutil"),
+    `#!/bin/sh
+if [ "$1" = "attach" ]; then
+  mount=""
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-mountpoint" ]; then shift; mount="$1"; fi
+    shift
+  done
+  mkdir -p "$mount/SpaceVibe Deck.app"
+fi
+exit 0
+`,
+  );
+  executable(
+    join(bin, "codesign"),
+    `#!/bin/sh
+[ "${failCodesign ? "1" : "0"}" -eq 0 ]
+`,
+  );
+  executable(join(bin, "spctl"), "#!/bin/sh\nexit 0\n");
+  executable(
+    join(bin, "ditto"),
+    "#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$DECK_TEST_COPY_LOG\"\n",
+  );
+
+  const result = spawnSync("/bin/sh", [MAC_INSTALLER], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      DECK_TEST_COPY_LOG: copyLog,
+      DECK_TEST_RELEASE_JSON: releaseJson,
+      PATH: `${bin}${delimiter}${process.env.PATH}`,
+    },
+  });
+
+  return { copyLog, result };
+}
+
+function powershellPath() {
+  if (process.platform !== "win32") {
+    return null;
+  }
+
+  return join(
+    process.env.SystemRoot ?? "C:\\Windows",
+    "System32/WindowsPowerShell/v1.0/powershell.exe",
+  );
+}
+
+function runWindowsFixture({ validHash }) {
+  const directory = scratch("deck-install-win-");
+  const wrapper = join(directory, "wrapper.ps1");
+  const patchedInstaller = join(directory, "install-fixture.ps1");
+  const marker = join(directory, "started.txt");
+  const installerBytes = Buffer.from("trusted installer fixture");
+  const expectedHash = createHash("sha512").update(installerBytes).digest("base64");
+  const manifestHash = validHash ? expectedHash : Buffer.alloc(64, 7).toString("base64");
+  const installerSource = readFileSync(WINDOWS_INSTALLER, "utf8");
+  const patchedSource = installerSource.replace(
+    "function Receive-TrustedAsset(",
+    "function Receive-TrustedAssetReal(",
+  );
+
+  if (patchedSource === installerSource) {
+    throw new Error("Windows fixture could not isolate the download function.");
+  }
+
+  writeFileSync(patchedInstaller, patchedSource);
+  const escapedInstaller = patchedInstaller.replaceAll("'", "''");
+  const escapedMarker = marker.replaceAll("'", "''");
+  const bytes = [...installerBytes].join(",");
+
+  writeFileSync(
+    wrapper,
+    `$global:MockRelease = [pscustomobject]@{
+  draft = $false
+  prerelease = $false
+  tag_name = 'v1.2.3'
+  assets = @(
+    [pscustomobject]@{
+      name = 'SpaceVibe-Deck-1.2.3-win-x64-setup.exe'
+      browser_download_url = 'https://github.com/mxrsv/spacevibe-deck/releases/download/v1.2.3/SpaceVibe-Deck-1.2.3-win-x64-setup.exe'
+    },
+    [pscustomobject]@{
+      name = 'latest.yml'
+      browser_download_url = 'https://github.com/mxrsv/spacevibe-deck/releases/download/v1.2.3/latest.yml'
+    }
+  )
+}
+function Invoke-RestMethod { return $global:MockRelease }
+function Receive-TrustedAsset {
+  param([Uri]$Uri, [string]$Tag, [string]$Name, [string]$OutFile)
+  if ($Name -eq 'latest.yml') {
+    $NewLine = [Environment]::NewLine
+    [IO.File]::WriteAllText($OutFile, "version: 1.2.3" + $NewLine + "path: SpaceVibe-Deck-1.2.3-win-x64-setup.exe" + $NewLine + "sha512: ${manifestHash}" + $NewLine)
+  } else {
+    [IO.File]::WriteAllBytes($OutFile, [byte[]]@(${bytes}))
+  }
+}
+function Start-Process {
+  [IO.File]::WriteAllText('${escapedMarker}', 'started')
+  return [pscustomobject]@{ ExitCode = 0 }
+}
+. '${escapedInstaller}'
+`,
+  );
+
+  const result = spawnSync(
+    powershellPath(),
+    ["-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", wrapper],
+    { encoding: "utf8" },
+  );
+
+  return { marker, result };
+}
+
+afterEach(() => {
+  for (const directory of scratchDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe("macOS bootstrap", () => {
+  it.runIf(process.platform === "darwin" && process.arch === "arm64")(
+    "validates a mocked stable release and signed app before copying",
+    () => {
+      const { copyLog, result } = macFixture();
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain("SpaceVibe Deck v1.2.3");
+      expect(readFileSync(copyLog, "utf8")).toContain("SpaceVibe Deck.app");
+    },
+  );
+
+  it.runIf(process.platform === "darwin" && process.arch === "arm64")(
+    "stops before copying when signature validation fails",
+    () => {
+      const { copyLog, result } = macFixture({ failCodesign: true });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("Code signature verification failed");
+      expect(existsSync(copyLog)).toBe(false);
+    },
+  );
+});
+
+describe("Windows bootstrap", () => {
+  it.runIf(process.platform === "win32")(
+    "starts a mocked installer only after its latest.yml SHA-512 matches",
+    () => {
+      const { marker, result } = runWindowsFixture({ validHash: true });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(existsSync(marker)).toBe(true);
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "does not start a mocked installer when its SHA-512 differs",
+    () => {
+      const { marker, result } = runWindowsFixture({ validHash: false });
+
+      expect(result.status).toBe(1);
+      expect(existsSync(marker)).toBe(false);
+      expect(result.stderr).toContain("SHA-512 verification failed");
+    },
+  );
+});
+
+describe("bootstrap security contract", () => {
+  it("keeps silent install and platform-security bypass flags out of both endpoints", () => {
+    const sources = [MAC_INSTALLER, WINDOWS_INSTALLER].map((path) =>
+      readFileSync(path, "utf8"),
+    );
+
+    for (const source of sources) {
+      expect(source).not.toMatch(/--silent-install|\/S\b|smartscreen.*disable|spctl.*disable/i);
+      expect(source).toContain("https://github.com/mxrsv/spacevibe-deck/releases");
+    }
+  });
+});

--- a/marketing/landing-prototype/src/install-command.js
+++ b/marketing/landing-prototype/src/install-command.js
@@ -1,0 +1,244 @@
+import { RELEASES_URL, WINDOWS_FALLBACK_URL } from "./release-data.js";
+
+export const INSTALL_PLATFORMS = {
+  mac: {
+    command: "curl -fsSL https://deck.spacevibe.dev/install.sh | sh",
+    label: "macOS",
+    manualUrl: RELEASES_URL,
+    prefix: "$",
+    status: "Apple Silicon",
+  },
+  win: {
+    command: "irm https://deck.spacevibe.dev/install.ps1 | iex",
+    label: "Windows",
+    manualUrl: WINDOWS_FALLBACK_URL,
+    prefix: "PS›",
+    status: "x64 · unsigned installer",
+  },
+};
+
+const COPY_RESET_MS = 1800;
+const PLATFORM_KEYS = Object.keys(INSTALL_PLATFORMS);
+
+export function initialInstallPlatform(navigatorLike = globalThis.navigator) {
+  const platform = [
+    navigatorLike?.userAgentData?.platform,
+    navigatorLike?.platform,
+    navigatorLike?.userAgent,
+  ]
+    .filter((value) => typeof value === "string")
+    .join(" ")
+    .toLowerCase();
+
+  return platform.includes("win") ? "win" : "mac";
+}
+
+function renderPlatformControl(key) {
+  const platform = INSTALL_PLATFORMS[key];
+
+  return `
+    <button
+      class="quick-install__platform"
+      type="button"
+      role="tab"
+      id="quick-install-${key}-tab"
+      aria-controls="quick-install-command"
+      aria-selected="false"
+      data-install-platform="${key}"
+      tabindex="-1"
+    >
+      <span>${platform.label}</span>
+    </button>
+  `;
+}
+
+export function renderQuickInstall() {
+  return `
+    <section
+      class="quick-install"
+      data-quick-install
+      data-install-state="idle"
+      aria-labelledby="quick-install-title"
+    >
+      <h2 class="quick-install__title" id="quick-install-title">Quick install</h2>
+
+      <div class="quick-install__selector" role="tablist" aria-label="Install platform">
+        <span class="quick-install__recommended">Recommended</span>
+        ${PLATFORM_KEYS.map(renderPlatformControl).join("")}
+      </div>
+
+      <div class="quick-install__status">
+        <span data-install-status></span>
+      </div>
+
+      <div
+        class="quick-install__command"
+        id="quick-install-command"
+        role="tabpanel"
+        aria-live="off"
+      >
+        <span class="quick-install__prefix" data-install-prefix aria-hidden="true"></span>
+        <code data-install-command></code>
+        <button
+          class="quick-install__copy"
+          type="button"
+          aria-label="Copy install command"
+          data-install-copy
+        >
+          <svg viewBox="0 0 20 20" width="16" height="16" fill="none" aria-hidden="true">
+            <rect x="6.5" y="6.5" width="9" height="9" rx="1.5" />
+            <path d="M13.5 6.5V5A1.5 1.5 0 0 0 12 3.5H5A1.5 1.5 0 0 0 3.5 5v7A1.5 1.5 0 0 0 5 13.5h1.5" />
+          </svg>
+          <span data-install-copy-label>Copy</span>
+        </button>
+      </div>
+
+      <div class="quick-install__footer">
+        <span class="quick-install__feedback" role="status" aria-live="polite" data-install-feedback></span>
+        <a
+          class="quick-install__manual"
+          href="${RELEASES_URL}"
+          target="_blank"
+          rel="noreferrer"
+          data-install-manual
+        >Download manually <span aria-hidden="true">↗</span></a>
+      </div>
+    </section>
+  `;
+}
+
+export function mountQuickInstall(
+  root,
+  { navigatorLike = globalThis.navigator, clipboard = navigatorLike?.clipboard } = {},
+) {
+  const shell = root.matches?.("[data-quick-install]")
+    ? root
+    : root.querySelector("[data-quick-install]");
+
+  if (!shell) {
+    throw new Error("Quick install root is missing.");
+  }
+
+  const controls = [...shell.querySelectorAll("[data-install-platform]")];
+  const command = shell.querySelector("[data-install-command]");
+  const prefix = shell.querySelector("[data-install-prefix]");
+  const status = shell.querySelector("[data-install-status]");
+  const manual = shell.querySelector("[data-install-manual]");
+  const copyButton = shell.querySelector("[data-install-copy]");
+  const copyLabel = shell.querySelector("[data-install-copy-label]");
+  const feedback = shell.querySelector("[data-install-feedback]");
+
+  if (!command || !prefix || !status || !manual || !copyButton || !copyLabel || !feedback) {
+    throw new Error("Quick install controls are incomplete.");
+  }
+
+  let selected = initialInstallPlatform(navigatorLike);
+  let resetTimer = null;
+  const clickHandlers = new Map();
+
+  function manualUrl(platformKey) {
+    const datasetKey = platformKey === "mac" ? "installMacUrl" : "installWinUrl";
+    return manual.dataset[datasetKey] || INSTALL_PLATFORMS[platformKey].manualUrl;
+  }
+
+  function renderPlatform(nextPlatform, { focus = false } = {}) {
+    const platform = INSTALL_PLATFORMS[nextPlatform];
+
+    if (!platform) {
+      return;
+    }
+
+    selected = nextPlatform;
+    shell.dataset.platform = selected;
+    shell.dataset.installState = "idle";
+    command.textContent = platform.command;
+    prefix.textContent = platform.prefix;
+    status.textContent = platform.status;
+    manual.href = manualUrl(selected);
+    manual.dataset.installManual = selected;
+    copyLabel.textContent = "Copy";
+    feedback.textContent = "";
+
+    for (const control of controls) {
+      const active = control.dataset.installPlatform === selected;
+      control.setAttribute("aria-selected", String(active));
+      control.tabIndex = active ? 0 : -1;
+
+      if (active) {
+        shell.querySelector("[role=tabpanel]")?.setAttribute("aria-labelledby", control.id);
+
+        if (focus) {
+          control.focus();
+        }
+      }
+    }
+  }
+
+  function moveSelection(event) {
+    const index = controls.indexOf(event.currentTarget);
+    let nextIndex = index;
+
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      nextIndex = (index + 1) % controls.length;
+    } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      nextIndex = (index - 1 + controls.length) % controls.length;
+    } else if (event.key === "Home") {
+      nextIndex = 0;
+    } else if (event.key === "End") {
+      nextIndex = controls.length - 1;
+    } else {
+      return;
+    }
+
+    event.preventDefault();
+    renderPlatform(controls[nextIndex].dataset.installPlatform, { focus: true });
+  }
+
+  async function copyCommand() {
+    clearTimeout(resetTimer);
+
+    try {
+      if (typeof clipboard?.writeText !== "function") {
+        throw new Error("Clipboard API unavailable.");
+      }
+
+      await clipboard.writeText(INSTALL_PLATFORMS[selected].command);
+      shell.dataset.installState = "copied";
+      copyLabel.textContent = "Copied";
+      feedback.textContent = "Command copied.";
+    } catch {
+      shell.dataset.installState = "copy-failed";
+      copyLabel.textContent = "Copy failed";
+      feedback.textContent = "Automatic copy failed. Select the command and copy it manually.";
+    }
+
+    resetTimer = setTimeout(() => {
+      shell.dataset.installState = "idle";
+      copyLabel.textContent = "Copy";
+      feedback.textContent = "";
+    }, COPY_RESET_MS);
+  }
+
+  for (const control of controls) {
+    const selectPlatform = () => {
+      renderPlatform(control.dataset.installPlatform);
+    };
+
+    clickHandlers.set(control, selectPlatform);
+    control.addEventListener("click", selectPlatform);
+    control.addEventListener("keydown", moveSelection);
+  }
+
+  copyButton.addEventListener("click", copyCommand);
+  renderPlatform(selected);
+
+  return () => {
+    clearTimeout(resetTimer);
+    copyButton.removeEventListener("click", copyCommand);
+
+    for (const control of controls) {
+      control.removeEventListener("click", clickHandlers.get(control));
+      control.removeEventListener("keydown", moveSelection);
+    }
+  };
+}

--- a/marketing/landing-prototype/src/install-command.test.js
+++ b/marketing/landing-prototype/src/install-command.test.js
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  INSTALL_PLATFORMS,
+  initialInstallPlatform,
+  mountQuickInstall,
+  renderQuickInstall,
+} from "./install-command.js";
+
+function fixture(navigatorLike = { platform: "MacIntel" }) {
+  const root = document.createElement("div");
+  root.innerHTML = renderQuickInstall();
+  document.body.append(root);
+  const dispose = mountQuickInstall(root, { navigatorLike });
+  return { dispose, root, shell: root.querySelector("[data-quick-install]") };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.body.innerHTML = "";
+});
+
+describe("initialInstallPlatform", () => {
+  it("uses Windows only as an initial hint and otherwise falls back to macOS", () => {
+    expect(initialInstallPlatform({ userAgentData: { platform: "Windows" } })).toBe("win");
+    expect(initialInstallPlatform({ userAgent: "Linux x86_64" })).toBe("mac");
+    expect(initialInstallPlatform({})).toBe("mac");
+  });
+});
+
+describe("quick install command", () => {
+  it("keeps the visible copy focused on the install action", () => {
+    const { dispose, root } = fixture();
+
+    expect(root.querySelector("[data-release-version]")).toBeNull();
+    expect(root.querySelector(".quick-install__platform-index")).toBeNull();
+    expect(root.querySelector(".quick-install__title").textContent).toBe("Quick install");
+    expect(root.querySelector("[data-install-status]").textContent).toBe("Apple Silicon");
+    expect(root.querySelector(".quick-install__selector > .quick-install__recommended").textContent).toBe(
+      "Recommended",
+    );
+    expect(root.querySelector('[data-install-platform="mac"] .quick-install__recommended')).toBeNull();
+
+    dispose();
+  });
+
+  it("keeps both platform controls visible and exposes selected tab state", () => {
+    const { dispose, root, shell } = fixture({
+      platform: "Win32",
+    });
+    const controls = [...root.querySelectorAll("[data-install-platform]")];
+
+    expect(shell.dataset.platform).toBe("win");
+    expect(controls).toHaveLength(2);
+    expect(controls.map((control) => control.getAttribute("aria-selected"))).toEqual([
+      "false",
+      "true",
+    ]);
+    expect(root.querySelector("[data-install-command]").textContent).toBe(
+      INSTALL_PLATFORMS.win.command,
+    );
+
+    dispose();
+  });
+
+  it("changes the command and manual fallback only after an explicit choice", () => {
+    const { dispose, root, shell } = fixture();
+    root.querySelector('[data-install-platform="win"]').click();
+
+    expect(shell.dataset.platform).toBe("win");
+    expect(root.querySelector("[data-install-command]").textContent).toBe(
+      INSTALL_PLATFORMS.win.command,
+    );
+    expect(root.querySelector("[data-install-manual]").href).toBe(
+      INSTALL_PLATFORMS.win.manualUrl,
+    );
+
+    dispose();
+  });
+
+  it("supports roving keyboard selection", () => {
+    const { dispose, root, shell } = fixture();
+    const mac = root.querySelector('[data-install-platform="mac"]');
+    mac.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+
+    expect(shell.dataset.platform).toBe("win");
+    expect(document.activeElement).toBe(root.querySelector('[data-install-platform="win"]'));
+
+    dispose();
+  });
+
+  it("announces copy success without replacing selectable command text", async () => {
+    vi.useFakeTimers();
+    const clipboard = { writeText: vi.fn().mockResolvedValue(undefined) };
+    const root = document.createElement("div");
+    root.innerHTML = renderQuickInstall();
+    const dispose = mountQuickInstall(root, {
+      clipboard,
+      navigatorLike: { platform: "MacIntel" },
+    });
+
+    root.querySelector("[data-install-copy]").click();
+    await vi.runAllTicks();
+
+    expect(clipboard.writeText).toHaveBeenCalledWith(INSTALL_PLATFORMS.mac.command);
+    expect(root.querySelector("[data-install-command]").textContent).toBe(
+      INSTALL_PLATFORMS.mac.command,
+    );
+    expect(root.querySelector("[data-install-feedback]").textContent).toBe(
+      "Command copied.",
+    );
+
+    dispose();
+  });
+
+  it("keeps the command selectable and reports clipboard failure", async () => {
+    const clipboard = { writeText: vi.fn().mockRejectedValue(new Error("denied")) };
+    const root = document.createElement("div");
+    root.innerHTML = renderQuickInstall();
+    const dispose = mountQuickInstall(root, {
+      clipboard,
+      navigatorLike: { platform: "MacIntel" },
+    });
+
+    root.querySelector("[data-install-copy]").click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(root.querySelector("[data-install-command]").textContent).toBe(
+      INSTALL_PLATFORMS.mac.command,
+    );
+    expect(root.querySelector("[data-install-feedback]").textContent).toContain(
+      "Select the command",
+    );
+
+    dispose();
+  });
+});

--- a/marketing/landing-prototype/src/main.js
+++ b/marketing/landing-prototype/src/main.js
@@ -2,12 +2,14 @@ import "../styles/tokens.css";
 import "../styles/appwin.css";
 import "../styles/frame.css";
 import "../styles/direction-a.css";
+import "../styles/install-command.css";
 import "../styles/tour.css";
 import "../styles/scenes.css";
 
 import { messages } from "./copy.js";
 import { renderDirectionA } from "./directions/a.js";
 import { upgradeReleaseLinks } from "./download-links.js";
+import { mountQuickInstall } from "./install-command.js";
 import { renderTour } from "./tour/index.js";
 
 const specimenRoot = document.querySelector("#specimen-root");
@@ -25,9 +27,11 @@ function render() {
   const tour = renderTour(messages.en);
   specimenRoot.innerHTML = page.markup + tour.markup;
   const disposeRenderer = page.mount(specimenRoot);
+  const disposeInstall = mountQuickInstall(specimenRoot);
   const disposeTour = tour.mount(specimenRoot);
   disposePage = () => {
     disposeTour();
+    disposeInstall();
     disposeRenderer();
   };
 

--- a/marketing/landing-prototype/src/release-data.js
+++ b/marketing/landing-prototype/src/release-data.js
@@ -120,21 +120,23 @@ export function latestStableTag(releases) {
   return releases.find((release) => !release.prerelease)?.tag ?? null;
 }
 
-function assetUrl(release, suffix) {
+function assetUrl(release, matches) {
   return (
-    release.assets.find((asset) => asset.name.endsWith(suffix))
+    release.assets.find((asset) => matches(asset.name.toLowerCase()))
       ?.browser_download_url ?? null
   );
 }
 
 export function selectDownloadUrls(releases) {
-  const mac =
-    releases
-      .filter((release) => !release.prerelease)
-      .map((release) => assetUrl(release, ".dmg"))
-      .find(Boolean) ?? null;
-  const win =
-    releases.map((release) => assetUrl(release, ".exe")).find(Boolean) ?? null;
+  const stableReleases = releases.filter((release) => !release.prerelease);
+  const mac = stableReleases
+    .map((release) => assetUrl(release, (name) => name.endsWith("-arm64.dmg")))
+    .find(Boolean) ?? null;
+  const win = stableReleases
+    .map((release) =>
+      assetUrl(release, (name) => name.endsWith("-win-x64-setup.exe")),
+    )
+    .find(Boolean) ?? null;
 
   return { mac, win };
 }

--- a/marketing/landing-prototype/src/release-data.test.js
+++ b/marketing/landing-prototype/src/release-data.test.js
@@ -35,10 +35,16 @@ const RELEASES = [
     prerelease: false,
     assets: [
       {
-        name: "SpaceVibe.Deck_0.9.0_universal.dmg",
+        name: "SpaceVibe-Deck-0.9.0-arm64.dmg",
         download_count: 5,
         browser_download_url:
-          "https://github.com/mxrsv/spacevibe-deck/releases/download/v0.9.0/SpaceVibe.Deck_0.9.0_universal.dmg",
+          "https://github.com/mxrsv/spacevibe-deck/releases/download/v0.9.0/SpaceVibe-Deck-0.9.0-arm64.dmg",
+      },
+      {
+        name: "SpaceVibe-Deck-0.9.0-win-x64-setup.exe",
+        download_count: 6,
+        browser_download_url:
+          "https://github.com/mxrsv/spacevibe-deck/releases/download/v0.9.0/SpaceVibe-Deck-0.9.0-win-x64-setup.exe",
       },
     ],
   },
@@ -79,13 +85,13 @@ describe("normalizeReleases", () => {
     ]);
 
     expect(normalized).toHaveLength(1);
-    expect(normalized[0].assets).toEqual([
-      {
-        name: RELEASES[1].assets[0].name,
-        browser_download_url: RELEASES[1].assets[0].browser_download_url,
-        downloadCount: 5,
-      },
-    ]);
+    expect(normalized[0].assets).toEqual(
+      RELEASES[1].assets.map((asset) => ({
+        name: asset.name,
+        browser_download_url: asset.browser_download_url,
+        downloadCount: asset.download_count,
+      })),
+    );
   });
 });
 
@@ -96,9 +102,9 @@ describe("release selection", () => {
     expect(latestStableTag(releases)).toBe("v0.9.0");
     expect(selectDownloadUrls(releases)).toEqual({
       mac: RELEASES[1].assets[0].browser_download_url,
-      win: RELEASES[0].assets[0].browser_download_url,
+      win: RELEASES[1].assets[1].browser_download_url,
     });
-    expect(totalInstallerDownloads(releases)).toBe(17);
+    expect(totalInstallerDownloads(releases)).toBe(23);
   });
 
   it("counts only validated macOS and Windows installer downloads", () => {
@@ -123,7 +129,7 @@ describe("release selection", () => {
       },
     ]);
 
-    expect(totalInstallerDownloads(releases)).toBe(5);
+    expect(totalInstallerDownloads(releases)).toBe(11);
   });
 });
 

--- a/marketing/landing-prototype/styles/install-command.css
+++ b/marketing/landing-prototype/styles/install-command.css
@@ -1,0 +1,292 @@
+/* Production quick install: the owner selected the Embedded Prompt treatment. */
+
+.quick-install {
+  --install-edge: rgb(255 255 255 / 16%);
+  --install-edge-soft: rgb(255 255 255 / 8%);
+  --install-signal: var(--a-release-cyan);
+  --install-signal-rgb: var(--a-release-cyan-rgb);
+  --install-command-width: 24.5rem;
+  --install-shell-width: 33.25rem;
+  position: relative;
+  z-index: 4;
+  width: min(100%, var(--install-shell-width));
+  min-width: 0;
+  margin-top: clamp(1.35rem, 2.6vh, 1.75rem);
+  margin-inline: auto;
+  color: var(--a-ink);
+  text-align: left;
+}
+
+.quick-install button,
+.quick-install a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+.quick-install__title {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.quick-install__selector {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: 1fr auto auto 1fr;
+  align-items: center;
+}
+
+.quick-install__platform {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border: 0;
+  background: transparent;
+  color: var(--a-ink-faint);
+  cursor: pointer;
+  font: 600 0.66rem/1 var(--a-font-display);
+}
+
+.quick-install__recommended {
+  justify-self: start;
+  margin-left: 0.85rem;
+  padding: 0.25rem 0.45rem;
+  border: 1px solid rgb(var(--install-signal-rgb) / 38%);
+  border-radius: 4px;
+  background: rgb(var(--install-signal-rgb) / 7%);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 4%);
+  color: rgb(var(--install-signal-rgb) / 82%);
+  font: 500 0.47rem/1 var(--a-font-mono);
+  letter-spacing: 0.02em;
+}
+
+.quick-install__platform[aria-selected="true"] {
+  color: rgb(255 255 255 / 95%);
+}
+
+.quick-install__platform:focus-visible,
+.quick-install__copy:focus-visible,
+.quick-install__manual:focus-visible {
+  outline: 2px solid var(--install-signal);
+  outline-offset: 3px;
+}
+
+.quick-install__command {
+  position: relative;
+  display: grid;
+  min-width: 0;
+  grid-template-columns: auto minmax(0, var(--install-command-width)) auto;
+  align-items: center;
+  justify-content: center;
+}
+
+.quick-install__prefix {
+  width: 1.5rem;
+  color: var(--install-signal);
+  font: 600 0.72rem/1 var(--a-font-mono);
+  text-align: center;
+}
+
+.quick-install__command code {
+  min-width: 0;
+  overflow-x: auto;
+  color: rgb(255 255 255 / 88%);
+  font: 500 clamp(0.66rem, 0.9vw, 0.76rem) / 1.3 var(--a-font-mono);
+  letter-spacing: -0.012em;
+  scrollbar-width: none;
+  user-select: text;
+  white-space: nowrap;
+}
+
+.quick-install__command code::-webkit-scrollbar {
+  display: none;
+}
+
+.quick-install__copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  border: 0;
+  color: var(--a-ink-soft);
+  cursor: pointer;
+  font: 600 0.61rem/1 var(--a-font-display);
+}
+
+.quick-install__copy svg {
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.35;
+}
+
+.quick-install[data-install-state="copied"] .quick-install__copy,
+.quick-install__feedback {
+  color: var(--install-signal);
+}
+
+.quick-install[data-install-state="copy-failed"] .quick-install__copy,
+.quick-install[data-install-state="copy-failed"] .quick-install__feedback {
+  color: #ff9d8f;
+}
+
+.quick-install__status,
+.quick-install__footer {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  color: var(--a-ink-faint);
+  font: 500 0.55rem/1.25 var(--a-font-mono);
+}
+
+.quick-install__footer {
+  justify-content: flex-end;
+  gap: 0.8rem;
+}
+
+.quick-install__feedback {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.quick-install__manual {
+  flex: 0 0 auto;
+  color: var(--a-ink-faint);
+  font: 520 0.57rem/1 var(--a-font-display);
+  text-decoration: none;
+  transition: color 180ms var(--a-ease-lock);
+}
+
+.quick-install__manual:hover,
+.quick-install__manual:focus-visible {
+  color: var(--a-ink);
+}
+
+.quick-install {
+  display: grid;
+  grid-template-areas:
+    "selector selector"
+    "command command"
+    "status footer";
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.quick-install .quick-install__selector {
+  grid-area: selector;
+  padding: 0 0.15rem 0.6rem;
+}
+
+.quick-install .quick-install__recommended {
+  margin-left: 0;
+}
+
+.quick-install .quick-install__platform {
+  padding: 0.25rem 0;
+}
+
+.quick-install .quick-install__platform + .quick-install__platform {
+  margin-left: 1.1rem;
+}
+
+.quick-install .quick-install__platform[aria-selected="true"]::after {
+  display: block;
+  width: 100%;
+  height: 1px;
+  margin-top: 0.32rem;
+  background: var(--install-signal);
+  content: "";
+}
+
+.quick-install .quick-install__command {
+  grid-area: command;
+  min-height: 3.25rem;
+  gap: 0.8rem;
+  padding-left: 0.15rem;
+  border-block: 1px solid var(--install-edge);
+}
+
+.quick-install .quick-install__copy {
+  min-width: 5.5rem;
+  background: transparent;
+}
+
+.quick-install .quick-install__copy:hover {
+  color: var(--install-signal);
+}
+
+.quick-install .quick-install__status {
+  grid-area: status;
+  padding: 0.55rem 0.15rem;
+}
+
+.quick-install .quick-install__footer {
+  grid-area: footer;
+  padding: 0.55rem 0.15rem;
+}
+
+.quick-install[data-platform="mac"] .quick-install__command code,
+.quick-install[data-platform="mac"] .quick-install__prefix {
+  animation: quick-install-command-in-mac 220ms var(--a-ease-lock) both;
+}
+
+.quick-install[data-platform="win"] .quick-install__command code,
+.quick-install[data-platform="win"] .quick-install__prefix {
+  animation: quick-install-command-in-win 220ms var(--a-ease-lock) both;
+}
+
+@keyframes quick-install-command-in-mac {
+  from {
+    opacity: 0;
+    transform: translateY(0.18rem);
+  }
+}
+
+@keyframes quick-install-command-in-win {
+  from {
+    opacity: 0;
+    transform: translateY(-0.18rem);
+  }
+}
+
+@media (max-width: 680px) {
+  .quick-install {
+    margin-top: 1.15rem;
+  }
+
+  .quick-install__command code {
+    font-size: 0.64rem;
+  }
+
+  .quick-install .quick-install__copy {
+    min-width: 3.4rem;
+  }
+
+  .quick-install__copy span {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  .quick-install__feedback {
+    max-width: 7rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .quick-install__platform,
+  .quick-install__copy,
+  .quick-install__manual,
+  .quick-install[data-platform] .quick-install__command code,
+  .quick-install[data-platform] .quick-install__prefix {
+    animation: none;
+    transition: none;
+  }
+}

--- a/marketing/landing-prototype/vite.build.mjs
+++ b/marketing/landing-prototype/vite.build.mjs
@@ -14,6 +14,10 @@ const outDir = resolve(import.meta.dirname, "dist");
 // still produces them (marketing/video/README.md) — they are simply no longer
 // shipped, which is several megabytes the landing stopped carrying.
 const RUNTIME_ASSETS = ["landing-prototype/assets"];
+const BOOTSTRAP_ENDPOINTS = [
+  "landing-prototype/install.sh",
+  "landing-prototype/install.ps1",
+];
 
 function copyRuntimeAssets() {
   return {
@@ -30,6 +34,16 @@ function copyRuntimeAssets() {
         }
 
         cpSync(source, resolve(outDir, path), { recursive: true });
+      }
+
+      for (const path of BOOTSTRAP_ENDPOINTS) {
+        const source = resolve(marketingRoot, path);
+
+        if (!existsSync(source)) {
+          throw new Error(`Landing build: bootstrap endpoint "${path}" is missing.`);
+        }
+
+        cpSync(source, resolve(outDir, path.split("/").at(-1)));
       }
     },
   };

--- a/marketing/public/privacy/2026-09-07/index.html
+++ b/marketing/public/privacy/2026-09-07/index.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="What SpaceVibe Deck sends, why it sends it, and how long usage data is kept." />
+    <title>Privacy — SpaceVibe Deck</title>
+    <style>
+      :root { color-scheme: dark; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #0a0c0b; color: #e7eae8; font-size: 16px; }
+      * { box-sizing: border-box; }
+      body { margin: 0; }
+      a { color: inherit; text-underline-offset: .22em; }
+      a:hover { color: #fff; }
+      a:focus-visible { outline: 2px solid #9de0b7; outline-offset: 5px; }
+      .skip { position: absolute; left: 24px; top: -80px; background: #0a0c0b; padding: 12px; }
+      .skip:focus { top: 12px; }
+      header, footer { max-width: 1120px; margin: auto; padding: 28px 32px; display: flex; justify-content: space-between; gap: 24px; }
+      header { border-bottom: 1px solid #303733; }
+      .brand { font-weight: 650; letter-spacing: -.03em; text-decoration: none; }
+      .label, nav, dt, footer { font-family: "SF Mono", Consolas, monospace; font-size: 12px; }
+      .label { color: #abb6ae; letter-spacing: .08em; text-transform: uppercase; }
+      .layout { max-width: 1120px; margin: 0 auto; display: grid; grid-template-columns: 200px minmax(0, 1fr); gap: 64px; padding: 72px 32px 100px; }
+      nav { align-self: start; position: sticky; top: 32px; line-height: 2.8; }
+      nav a { display: block; color: #abb6ae; text-decoration: none; }
+      main { min-width: 0; max-width: 70ch; }
+      h1 { font-size: clamp(40px, 5vw, 64px); line-height: 1.05; font-weight: 550; letter-spacing: -.055em; margin: 22px 0; }
+      .intro { font-size: 21px; line-height: 1.5; color: #c1cac4; margin: 0 0 24px; }
+      .meta { color: #abb6ae; font-size: 13px; }
+      section { border-top: 1px solid #303733; padding-top: 28px; margin-top: 48px; scroll-margin-top: 28px; }
+      h2 { font-size: 23px; font-weight: 550; letter-spacing: -.025em; margin: 0 0 20px; }
+      p, li, dd { color: #c1cac4; line-height: 1.75; }
+      p { margin: 14px 0; }
+      strong { color: #e7eae8; font-weight: 600; }
+      ul { padding-left: 22px; }
+      li + li { margin-top: 10px; }
+      dl { margin: 0; }
+      .field { padding: 18px 0; border-top: 1px solid #242b27; }
+      dt { color: #e7eae8; overflow-wrap: anywhere; }
+      dd { margin: 7px 0 0; font-size: 15px; }
+      code { font-family: "SF Mono", Consolas, monospace; font-size: .85em; overflow-wrap: anywhere; }
+      footer { border-top: 1px solid #303733; color: #abb6ae; line-height: 1.7; }
+      @media (max-width: 760px) {
+        header, footer { padding: 24px; }
+        .layout { display: block; padding: 40px 24px 64px; }
+        nav { position: static; display: flex; flex-wrap: wrap; gap: 0 20px; margin-bottom: 36px; }
+        footer { flex-direction: column; gap: 8px; }
+        section { margin-top: 36px; }
+      }
+    </style>
+  </head>
+  <body>
+    <a class="skip" href="#content">Skip to content</a>
+    <header><a class="brand" href="/">SpaceVibe Deck</a><span class="label">Privacy notice / 01</span></header>
+    <div class="layout">
+      <nav aria-label="On this page">
+        <a href="#builds">01 / Your build</a><a href="#data">02 / The payload</a>
+        <a href="#delivery">03 / Delivery</a><a href="#retention">04 / Retention</a>
+        <a href="#infrastructure">05 / Infrastructure</a><a href="#contact">06 / Questions</a>
+      </nav>
+      <main id="content">
+        <div class="label">Usage analytics · Schema 1</div>
+        <h1>What Deck sends.</h1>
+        <p class="intro">Usage totals.<br />No code, paths or prompts.</p>
+        <p class="meta">Effective September 7, 2026 · <a href="/privacy/2026-09-07">Dated copy of this notice</a></p>
+        <p>Deck uses small usage snapshots to understand which agents and features people use and where to focus development. They describe participating install-days, not total installations, individual journeys or user retention.</p>
+        <section id="builds">
+          <h2>Which version are you running?</h2>
+          <p><strong>The upcoming Electron release sends usage analytics automatically and has no in-app opt-out.</strong> No account is required.</p>
+          <p>The public <strong>1.0.0 release and older Tauri builds do not send these analytics</strong>. Earlier development builds that show a “Share usage stats” setting follow that setting. This notice describes the analytics-enabled client and its receiving service; publishing it does not change an installed build.</p>
+        </section>
+        <section id="data">
+          <h2>The complete payload</h2>
+          <p>Each request contains only the following fields. The service rejects additional fields.</p>
+          <dl>
+            <div class="field"><dt>schemaVersion</dt><dd>The payload format version, currently 1.</dd></div>
+            <div class="field"><dt>dailyId · day</dt><dd>A random identifier generated for each local calendar day, plus that date. It lets repeated snapshots replace the same daily record. There is no permanent installation identifier in the payload.</dd></div>
+            <div class="field"><dt>version · platform · arch</dt><dd>The Deck version, macOS or Windows, and ARM64 or x64 architecture.</dd></div>
+            <div class="field"><dt>agents</dt><dd>Daily launch counts for Claude, Codex, OpenCode, Antigravity, Gemini and Cursor Agent. All custom agents share a single “custom” bucket; their names and commands are never sent.</dd></div>
+            <div class="field"><dt>surfaces</dt><dd>Daily open counts for the browser, Explorer and usage dashboard.</dd></div>
+            <div class="field"><dt>maxTabs · maxPanes</dt><dd>The highest number of simultaneous tabs and panes that day.</dd></div>
+            <div class="field"><dt>restoredSessions</dt><dd>Whether any session was restored that day, as a yes-or-no value.</dd></div>
+          </dl>
+          <p><strong>Never in this payload:</strong> code, prompts, replies, terminal output, file names or paths, repository or branch names, browser URLs, agent commands, account names, hostnames, locale, time zone, or individual action timestamps.</p>
+          <p>The receiving service adds a first-received timestamp solely to enforce retention. It does not read or store your IP address, user agent or location as analytics fields.</p>
+        </section>
+        <section id="delivery">
+          <h2>Small, cumulative snapshots</h2>
+          <p>The client sends a snapshot after startup, roughly every 15 minutes when counters change, a six-hour heartbeat, and a best-effort final snapshot when it quits. Later snapshots replace the same day's counters instead of adding them again.</p>
+          <p>Deck keeps up to seven daily buffers locally to retry failed delivery. The service accepts dates from the preceding 30 UTC calendar days through the following day, allowing for local time zones. Older snapshots are discarded rather than reintroduced after cleanup.</p>
+          <p>Requests travel over HTTPS to <code>api.deck.spacevibe.dev/v1/ping</code>. No public statistics or data export endpoint is provided. These unauthenticated counts are internal product feedback, not verified adoption figures.</p>
+        </section>
+        <section id="retention">
+          <h2>A short life for daily records</h2>
+          <p>Raw daily records are scheduled for deletion from the live database within <strong>35 days of first receipt</strong>. Cleanup starts at day 34 to leave room for the daily job; a failed job can delay deletion and requires operator attention.</p>
+          <p>Before deletion, the service retains coarse totals grouped by day, app version, platform and architecture. These totals contain no daily identifier and may be kept longer for internal analysis. Aggregation and deletion happen in one database transaction.</p>
+          <p>Cloudflare D1 also maintains recovery history through <a href="https://developers.cloudflare.com/d1/reference/time-travel/">Time Travel</a>. Depending on the account plan, deleted data can remain recoverable for up to 30 additional days (7 days on the free plan). This recovery history is separate from the live database retention schedule.</p>
+        </section>
+        <section id="infrastructure">
+          <h2>Where the request goes</h2>
+          <p>SpaceVibe operates the receiving service on Cloudflare Workers and D1. Worker request logging, invocation logging and tracing are disabled for this service.</p>
+          <p>Cloudflare necessarily handles network metadata, including IP addresses, while delivering and protecting requests. Disabling application logging does not remove that infrastructure processing. See <a href="https://www.cloudflare.com/privacypolicy/">Cloudflare's privacy policy</a> for its practices.</p>
+          <p>The website hosting this notice is served by Vercel and has its own network delivery processing. See <a href="https://vercel.com/legal/privacy-policy">Vercel's privacy policy</a>.</p>
+        </section>
+        <section id="contact">
+          <h2>Questions or corrections?</h2>
+          <p>Contact the maintainer through the <a href="https://github.com/mxrsv/spacevibe-deck/issues">SpaceVibe Deck issue tracker</a>. Please do not include private code, credentials or other sensitive information in a public issue.</p>
+          <p>Material changes will receive a new dated notice. This <a href="/privacy/2026-09-07">September 7, 2026 notice</a> will remain available.</p>
+        </section>
+      </main>
+    </div>
+    <footer><span>SpaceVibe Deck · Privacy</span><a href="/">Back to Deck ↗</a></footer>
+  </body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,20 @@
   "installCommand": "npm ci",
   "buildCommand": "vite build --config marketing/landing-prototype/vite.build.mjs",
   "outputDirectory": "marketing/landing-prototype/dist",
-  "rewrites": [{ "source": "/", "destination": "/landing-prototype/index.html" }],
+  "rewrites": [
+    {
+      "source": "/",
+      "destination": "/landing-prototype/index.html"
+    },
+    {
+      "source": "/privacy",
+      "destination": "/privacy/2026-09-07/index.html"
+    },
+    {
+      "source": "/privacy/2026-09-07",
+      "destination": "/privacy/2026-09-07/index.html"
+    }
+  ],
   "headers": [
     {
       "source": "/install.sh",
@@ -35,7 +48,12 @@
     },
     {
       "source": "/deck-tour(.*)",
-      "headers": [{ "key": "Cache-Control", "value": "public, max-age=86400" }]
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400"
+        }
+      ]
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,24 @@
   "rewrites": [{ "source": "/", "destination": "/landing-prototype/index.html" }],
   "headers": [
     {
+      "source": "/install.sh",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=300, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/install.ps1",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=300, must-revalidate"
+        }
+      ]
+    },
+    {
       "source": "/assets/(.*)",
       "headers": [
         {


### PR DESCRIPTION
## What

- **Quick-install landing** (commit 1): the hero renders platform → command → Copy via `install-command.js`, the build emits `install.sh` / `install.ps1` at the deployment root, and the Releases selector rejects prerelease installers for both platforms. Ten tracked files carried verbatim from the local `main` merge `8e4fcf4`, plus the six files that had never been committed anywhere (`install.sh`, `install.ps1`, `install-command.js`, `install-command.css`, and their two test files).
- **Privacy page** (commit 2): `marketing/public/privacy/2026-09-07/index.html` (byte-identical to the copy the DECK-1 session deployed by CLI on 2026-09-07), `!/marketing/public` in `.vercelignore`, and `/privacy` + `/privacy/2026-09-07` rewrites in `vercel.json`.
- **Windows hash fix** (commit 3): `install.ps1` computes the installer's SHA-512 through .NET instead of `Get-FileHash`; see the CI finding below.

## Why

`deck.spacevibe.dev` is deployed both by the Vercel git integration (`origin/main`) and by ad-hoc `vercel --prod` runs. The quick-install landing went live on 2026-08-26 by CLI from an uncommitted tree; every production deploy since 2026-09-05 (`3bf8c8e`, `fef9e03`, `7ae2938` by git, then the DECK-1 privacy deploy by CLI) rebuilt the landing without it, so `install.sh` / `install.ps1` have answered **404** while `README.md` and `docs/CONTEXT.md` still describe them as live. The DECK-1 privacy page had the mirror-image problem: uncommitted, so the next git deploy would have dropped `/privacy`. This PR puts both on `origin/main` so one source of truth survives the next deploy.

Pushing local `main` as-is was not an option: a build from the committed tree alone fails in `vite.build.mjs` with `Landing build: bootstrap endpoint "landing-prototype/install.sh" is missing.` (reproduced on a pristine worktree of local `main`).

## Evidence

- `vite build --config marketing/landing-prototype/vite.build.mjs`: built; `dist/install.sh`, `dist/install.ps1` and `dist/privacy/2026-09-07/index.html` emitted, endpoint SHA-256 equal to source.
- `vitest run marketing/landing-prototype/`: 9 files, **121 passed / 2 skipped** (the Windows-only mocked branches; the macOS branches ran on Apple Silicon).
- `prettier --check README.md vercel.json marketing/public/privacy/2026-09-07/index.html`: clean. `marketing/**` has no lint signal by configuration.
- Vercel preview for `f2bb702` built and deployed (`Build Completed in /vercel/output [22s]`); the new `vite.build.mjs` throws when either endpoint is missing, so a completed build implies both were emitted.
- CI on `0ece85d`: Linux `check` green; `windows-check` fails on the same five pre-existing files that fail on `main` (see below).
- Not run here: `npm test` / `npm run build` for the app locally (this PR touches no `src/` or `electron/` file); CI covers them.

## Windows CI finding (commit 3)

The first Windows run of the bootstrap suite (this test had only ever run on macOS) failed inside `install.ps1`: `The term 'Get-FileHash' is not recognized`. In Windows PowerShell 5.1 that cmdlet is a script function auto-loaded through `PSModulePath`; CI's `npm test` runs under pwsh, and a `powershell.exe` started from PowerShell 7 inherits pwsh's module path, where the lookup resolves to the Core edition of `Microsoft.PowerShell.Utility` and fails ([PowerShell/PowerShell#24630](https://github.com/PowerShell/PowerShell/discussions/24630); the same defect hit [openai/codex#27117](https://github.com/openai/codex/issues/27117)). The digest is now computed with `System.Security.Cryptography.SHA512`, which needs no module lookup and yields the same uppercase hex the comparison already expects. Second run: `install-bootstrap.test.js` **5 tests | 2 skipped, green on windows-latest**; `windows-check` still fails on `electron/fs/read`, `electron/pty/info`, `electron/pty/manager`, `electron/worktrees` and `scripts/verify-electron-monaco-smoke-package`, exactly the set that fails on `main`.

## Follow-ups (not in this PR)

- The DECK-1 worktree (`deck-1-privacy-production`) still holds its uncommitted copy of `vercel.json`, `.vercelignore` and `marketing/public/`; drop them there once this merges.
- Local `main` carries the same landing hunks inside `8e4fcf4` and the six install files as UNTRACKED copies; merging `origin/main` back needs those untracked copies removed first (git refuses to overwrite untracked files), and `install.ps1` there predates commit 3.
- `docs/CONTEXT.md` "Landing quick install is live — 2026-08-26" becomes true again after this deploys; the deploy-path trap itself is not yet written down in the living docs.

https://claude.ai/code/session_01S5PARPCFeLyYpikiT7wz5i
