### PR TITLE
feat(telemetry): make usage analytics mandatory, with no opt-out

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,18 +45,24 @@ superseded by `docs/internals/` wherever they disagree.
 - The Electron cutover is a **clean install** with no settings/workspace migration. The final
   Tauri release must explain the manual transition and old data location. “No Electron” must
   stop being a proof point at cutover; “no accounts” remains valid. **“No telemetry” is
-  retired, and analytics is ON by default (decided 2026-08-23, committed 2026-08-24 as
-  `cdc07a0`):** the 2026-08-22 opt-in model was built, never released, and reversed by
-  the owner the next day — no consent question is asked,
-  `declined` (the Settings → Privacy switch) is the only state never inferred away, an
-  unreadable state file still fails closed to off, and public copy says "on by default,
-  no code, paths or prompts" and never "anonymous". `USAGE_CONSENT_ASKED` in
-  [`usage-notice.ts`](src/telemetry/usage-notice.ts) `current` is the whole reversal
-  switch; the consent modal stays in the tree behind it. Rollout consequence: every
-  install of the next release POSTs, so the Worker and the privacy page are
+  retired, and analytics is MANDATORY — always on, with no opt-out (owner-decided
+  2026-09-06).** The 2026-08-22 opt-in model was built, never released, and reversed to
+  default-on on 2026-08-23 (`cdc07a0`); the switch that reversal kept has now gone too. No
+  consent question is asked, Settings → Privacy renders NO control, `parsePersisted` folds
+  even a `declined` written by an earlier build back to `enabled`, and `setEnabled(false)` is
+  refused in MAIN rather than merely unreachable from the UI — the renderer is not the trust
+  boundary. An unreadable state file still fails closed to off, and that is now the only
+  state in which a shipped build sends nothing. The disclosure stayed when the switch went:
+  Settings → Privacy still states exactly what is sent, and public copy says "always on,
+  no opt-out, no code, paths or prompts" and never "anonymous". Two constants in
+  [`usage-notice.ts`](src/telemetry/usage-notice.ts) `current` are the whole reversal —
+  `USAGE_CONSENT_ASKED` and `USAGE_ANALYTICS_MANDATORY`; the consent modal and the entire
+  opt-out machinery stay in the tree behind them, covered by tests that pass
+  `mandatory: false`. Rollout consequence, unchanged and now unavoidable: every install of
+  the next release POSTs and no user can stop it, so the Worker and the privacy page are
   prerequisites, not follow-ups. See the
   [usage analytics spec](docs/specs/2026-08-22-anonymous-usage-telemetry-design.md)
-  `decided` (amended 2026-08-24).
+  `decided` (amended 2026-08-24, superseded on consent by the 2026-09-06 decision).
 - Electron process classification must use the measured `ps` snapshot path, not
   `node-pty.process`; the latter returned version/executable strings instead of argv0.
 - **Pane detach Phase A exists on Tauri**, including IPC contract tests; remaining native
@@ -782,6 +788,23 @@ registry. Record a resolved fork in this queue with a one-line reason; move it t
 
 Open queue:
 
+- **Analytics became mandatory — the opt-out switch is gone (owner-decided 2026-09-06 in
+  conversation, after the legal and copy risks were stated).** A fork because it again
+  amends DL-29.9 and because it changes the app's outbound-data policy: there is now no
+  user-reachable way to stop a POST. `USAGE_ANALYTICS_MANDATORY` in
+  [`usage-notice.ts`](src/telemetry/usage-notice.ts) `current` is the switch;
+  `parsePersisted` folds `declined` into `enabled`, `setEnabled(false)` throws in main, and
+  `TelemetryDeps.mandatory` (defaulting to the constant) keeps BOTH policies testable, the
+  `shouldShowUsageNotice(enabled)` precedent. Settings → Privacy keeps its whole disclosure
+  and loses only the control — chosen over deleting the category (an app collecting with no
+  on-screen account of it) and over a disabled switch (a dead control reads worse than none).
+  Copy was corrected in the same change so nothing ships a false claim: README (both spots),
+  the landing's EN and VI proof points, the Settings copy, and the copy test that had pinned
+  "Turn it off here". **NOT resolved here:** the endpoint still does not resolve, so this
+  makes MXR-24 sharper rather than smaller — mandatory collection into a dead hostname is
+  still collection into a dead hostname, and the Worker, D1 and privacy page remain
+  prerequisites for the next release. The legal exposure (GDPR: no opt-out, no objection
+  path) was raised and accepted by the owner.
 - **Analytics consent reversed to default-on (decided 2026-08-23 in conversation
   after hearing the risks; committed 2026-08-24 as `cdc07a0`).** A fork because it amends DL-29.9 —
   the decision modal's rule now governs a surface that mounts nowhere
@@ -1141,9 +1164,9 @@ _(Heading retained for the global living-doc convention.)_
 | A project cluster can be dragged into place                                    | `building` | unverified | Built 2026-08-22 from the [spec](docs/specs/2026-08-22-rail-workspace-reorder-design.md) `decided` (new DL-27.20): `RailStreamGroup.orderKey`, a pure `rail-order.ts`, a delegated pointer controller on the rail's list, and a `railOrder` settings field. Renderer-only, so it reaches BOTH hosts. Targeted suites green (147 assertions across `rail-order`, `rail-cluster-drag`, `settings-schema`, `agent-rail-model`, plus the two reorder cases in `agent-rail.test.tsx`), and `tsc --noEmit` / prettier / oxlint / the design-language gate clean against every file this touches — the four failures in those runs were read and attributed to concurrent sessions. **The full `npm test` (3776/0) and `npm run build` ran green on 2026-08-24 with the whole batch; still owed: a host pass and owner eye review — no cluster has ever actually been dragged.** A code review and a four-angle simplify ran over it: six correctness findings fixed (the worst deleted a cluster from the rail on a duplicated `orderKey`), two cleanups taken, and one declined — the controller reads the rail's DOM instead of taking injected geometry, so spec §8's "mirroring `new-pane-drag.ts`'s deps shape" is not yet true. Cross-window drag is phase 2 and unbuilt; there is no keyboard equivalent — [detail](docs/CONTEXT.md#a-project-cluster-goes-where-the-user-puts-it--2026-08-22) `current` |
 | The rail's close model is native-verified                                     | `building` | unverified | Built 2026-08-22 from the [spec](docs/specs/2026-08-22-rail-close-model-design.md) `decided` (new DL-27.21): every agent row carries its own ✕ closing that PANE, a live project header closes every tab of the repository under one busy dialog and then drops its history entries, and the leaf became a container plus hit layer. Renderer-only apart from one `disposeTab` branch, so it reaches BOTH hosts. `npx tsc --noEmit` is clean and the six affected suites are green (183 tests: close-coordinator, agent-rail, agent-rail-model, app, tab-lifecycle, rail-order) — the full `npm test` (3776/0), `npm run build` and the design-language gate ran green on 2026-08-24 with the whole batch, but there is **no `electron:dev` or `tauri dev` pass and no owner eye review**; no agent has been closed from a leaf and no project from a header in a running app — [detail](docs/CONTEXT.md#every-rail-row-closes-what-it-names--2026-08-22) `current` |
 | Closing the last tab closes the window                                        | `current`  | **false**  | True until 2026-08-22 and deliberately reversed (close model table row 3): `disposeTab`'s empty branch raises the Open board and leaves the window standing, so electron-migration spec §9.5's "the last SURFACE closes THIS window" no longer describes the tab path. `removeEmptyTab`'s pane-MOVED path still closes the window, and the `surfaces.total() > 0` branch still shows a document instead of the board. Pinned by `tab-manager.tab-lifecycle.test.ts` (the old assertion was inverted, not deleted); never seen in a running host — [detail](docs/CONTEXT.md#every-rail-row-closes-what-it-names--2026-08-22) `current` |
-| Deck sends usage analytics by default                                         | `building` | unverified | Built 2026-08-22 as the spec's opt-in client, then REVERSED to default-on by the owner (decided 2026-08-23, committed 2026-08-24 as `cdc07a0`): no consent question, `declined` is the only value never inferred away, unreadable still fails closed, and the consent modal survives behind `USAGE_CONSENT_ASKED=false`. Suite-verified — the telemetry suites' first execution was 62/62 (2026-08-23) and the full `npm test` is 3776/0 with both typechecks and `npm run build` green — but **no host pass and no owner eye review**, and the Worker, D1 and privacy page DO NOT EXIST, so every install of the next release would POST into a hostname that does not resolve today, and Settings links a page that 404s; rollout §12 steps 1-2 are prerequisites now — [plan](docs/plans/2026-08-22-anonymous-usage-telemetry.md) |
+| Deck sends usage analytics, always on, with no opt-out                        | `building` | unverified | Built 2026-08-22 as the spec's opt-in client, reversed to default-on on 2026-08-23 (`cdc07a0`), and made MANDATORY on 2026-09-06: Settings → Privacy renders no control, `parsePersisted` folds `declined` into `enabled`, and `setEnabled(false)` is refused in main. Suite-verified — `npm test` 3876 passed / 0 failed, both typechecks, `npm run build` and `npm run lint` green, with the telemetry suites at 59/59 including three new mandatory-policy cases and the opt-out machinery still covered under `mandatory: false` — but **no host pass and no owner eye review**: no running app has shown the switchless Privacy category. The backend is unchanged and is now the sharper problem, not the smaller one: the Worker, D1 and privacy page DO NOT EXIST, `api.deck.spacevibe.dev` does not resolve (measured 2026-09-06), so every install of the next release POSTs into nothing **and no user can stop it**, while Settings links a page that 404s. Rollout §12 steps 1-2 are hard prerequisites — [plan](docs/plans/2026-08-22-anonymous-usage-telemetry.md) |
 | Markdown opens rendered, and its policy holds                                  | `building` | unverified | Built 2026-08-23 from the [spec](docs/specs/2026-08-23-markdown-rendered-view-design.md) `decided` (new DL §31): `.md` opens rendered, ⌘⇧V flips it, Monaco colorizes the fences, mermaid loads only for a document that has one, and the §6 policy (escaped raw HTML, no `href` anywhere, dead `javascript:`/`data:`/out-of-root links, local-only images, no network fetch) is unit-asserted as pure functions. `npm test` 3755 passed / 8 failed with every failure reproduced as another session's uncommitted work and green on a pristine `HEAD` worktree; `src/files` 278/278; both typechecks, `npm run build` and `generate:menu:check` clean; `marked` and `mermaid` measured as their own lazy chunks. **Owed: a native `electron:dev` pass and the owner eye review** — nothing has been rendered in a running host, so no diagram has been drawn, no image read off disk, no link clicked and no colorized fence seen in either theme. Electron-only by inheritance (no Tauri file surface); Windows is Gate C — [detail](docs/CONTEXT.md#markdown-opens-rendered--2026-08-23) `current` |
-| “No telemetry” is public copy                                                 | `deprecated` | retired  | Retired 2026-08-22 with the opt-in client, re-worded with the default-on reversal (`cdc07a0`, 2026-08-24): README (both spots) and the landing proof point now say analytics is on by default with no code, paths or prompts and a Settings → Privacy switch; the tour's proof is `cat src/telemetry/payload.ts`, whose quoted lines state only what is absent. The 1.0.0 `CHANGELOG.md` entry keeps the old claim as a frozen release record on purpose — [spec §9](docs/specs/2026-08-22-anonymous-usage-telemetry-design.md) `decided` |
+| “No telemetry” is public copy                                                 | `deprecated` | retired  | Retired 2026-08-22 with the opt-in client, re-worded with the default-on reversal (`cdc07a0`, 2026-08-24): README (both spots) and the landing proof point now say analytics is on by default with no code, paths or prompts and a Settings → Privacy switch; **that wording is stale again as of 2026-09-06** — the switch is gone, and README (both spots) plus the landing's EN and VI proof points were rewritten to "always on, no opt-out". The tour's proof is `cat src/telemetry/payload.ts`, whose quoted lines state only what is absent. The 1.0.0 `CHANGELOG.md` entry keeps the old claim as a frozen release record on purpose — [spec §9](docs/specs/2026-08-22-anonymous-usage-telemetry-design.md) `decided` |
 | The rail says which agent holds the keyboard                                  | `building` | unverified | Built 2026-08-23 (new DL-27.22) after the owner reported a rail with no active item: a multi-agent tab renders headless, so DL-27.8's row wash had nowhere to land. `PaneView.focused` projects `activePaneId()`, `ManagerCallbacks.onActivePaneChange` is what tells the tab layer focus moved, and the model ANDs the two so at most one leaf in the rail is washed. `npx tsc --noEmit`, `npm run build`, prettier and the five affected suites are green (156 tests across `agent-rail`, `agent-rail-model`, `terminal-manager`, `tab-manager.tab-lifecycle` and `tabs-store`), plus a gallery pass on the REAL rail measuring exactly one washed row at `--tab-active-bg` with `aria-current="true"`. **Owed: a native `electron:dev` pass and the owner's eye review** — no pane has been focused in a running app; the gallery screenshot shows the wash inside DL-27.19's frame on `deck-dark` only, and no light theme was checked. Renderer-only apart from one callback, so it reaches BOTH hosts — [plan](docs/plans/2026-08-23-rail-focused-pane-marker.md) `building` |
 
-Updated 2026-09-04.
+Updated 2026-09-06.

--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ edits are not restored.
 The usage dashboard reads supported agents' existing local session logs and groups token use
 and known model costs by agent and day
 ([usage aggregation](src/lib/usage-aggregate.ts) `current`). It needs no Deck account. Deck
-sends first-party usage analytics — on by default, with no code, file paths or prompts,
-and switched off in Settings → Privacy ([what Deck sends](src/telemetry/payload.ts) `current`).
+sends first-party usage analytics — always on, with no code, file paths or prompts, and no way
+to switch them off; Settings → Privacy states exactly what is sent
+([what Deck sends](src/telemetry/payload.ts) `current`).
 
 ### Workflow-neutral agents
 
@@ -88,8 +89,8 @@ Deck checks for updates and tells you when one is ready; you choose when to down
 and relaunch. Both platforms use the moving
 [latest release](https://github.com/mxrsv/spacevibe-deck/releases/latest), never a pinned asset.
 
-**Trust:** MIT licensed · no Deck account · first-party usage analytics on by default, with
-no code, paths or prompts, and a Settings → Privacy switch that turns them off
+**Trust:** MIT licensed · no Deck account · first-party usage analytics always on, with no code,
+paths or prompts, and no opt-out; Settings → Privacy states what is sent
 ([what Deck sends](src/telemetry/payload.ts) `current`) · session and usage data read from
 local agent storage.
 

--- a/docs/internals/telemetry.md
+++ b/docs/internals/telemetry.md
@@ -1,8 +1,10 @@
 # Usage analytics
 
-Deck sends one small usage snapshot per day, on by default, and the only state it never
-infers away is an explicit "off". This page is the contract: what leaves the machine, who
-owns the state, and when a POST fires. Electron only: the Tauri host sends nothing.
+Deck sends one small usage snapshot per day. Since 2026-09-06 it is MANDATORY: there is no
+switch, no consent question, and an "off" recorded by an earlier build is overridden rather
+than honoured. The one state that still stops a send is a `telemetry.json` Deck cannot read.
+This page is the contract: what leaves the machine, who owns the state, and when a POST
+fires. Electron only: the Tauri host sends nothing.
 
 ## The payload
 
@@ -43,21 +45,34 @@ out.
   per-day maximum.
 - Three flat channels: `telemetry_count` (fire and forget), `telemetry_state` (also the
   "a window is ready" signal) and `telemetry_set_enabled`; one broadcast event,
-  `telemetry:state-changed`, so every window's Privacy switch moves together.
+  `telemetry:state-changed`. The event outlived the switch it synchronized: nothing in
+  Settings moves on it now, and it is kept because it is what a restored switch would need.
 
 ## State
 
-- `EMPTY_STATE` is `enabled`. `parsePersisted` folds every stored spelling except
-  `declined` into `enabled`: a missing field, garbage, or an opt-in-era `unanswered` all
-  read as on. `USAGE_CONSENT_ASKED` in
-  [`usage-notice.ts`](../../src/telemetry/usage-notice.ts) is `false`, so the consent modal
-  mounts nowhere; it stays in the tree behind that constant.
-- **Unreadable fails closed.** When `telemetry.json` exists but cannot be read, consent reports
-  `unreadable`, nothing counts, nothing sends, `setEnabled` throws, and Deck neither guesses
-  nor overwrites the file. Settings → Privacy says so and tells the user to repair the file
-  and restart, because it is read once at launch.
-- **Off means off.** `setEnabled(false)` stops the timer, replaces the state with
-  `declined` and an empty day map (every unsent buffer and daily id deleted), then flushes.
+- `EMPTY_STATE` is `enabled`, and `parsePersisted` folds EVERY stored spelling into
+  `enabled` while `USAGE_ANALYTICS_MANDATORY` holds — `declined` included. That last fold is
+  the sharpest edge of the mandatory policy, so it is stated rather than implied: a recorded
+  refusal is overridden. It reaches almost nobody in practice, because analytics has never
+  shipped in a release (`cdc07a0` postdates 1.0.0), so a `declined` file exists only on
+  machines that ran a development build.
+- **Two constants, both in [`usage-notice.ts`](../../src/telemetry/usage-notice.ts), and both
+  the whole reversal.** `USAGE_CONSENT_ASKED` is `false`, so the consent modal mounts nowhere;
+  `USAGE_ANALYTICS_MANDATORY` is `true`, so there is nothing to answer. Neither surface was
+  deleted — the modal stays in the tree, and the opt-out machinery below stays in
+  `service.ts`, covered by tests that pass `mandatory: false`. `TelemetryDeps.mandatory`
+  defaults to the constant and exists so both policies stay testable.
+- **Unreadable fails closed, under either policy.** When `telemetry.json` exists but cannot be
+  read, consent reports `unreadable`, nothing counts, nothing sends, `setEnabled` throws, and
+  Deck neither guesses nor overwrites the file. A disk Deck cannot read is not a disk it may
+  assume anything from. Settings → Privacy says so and tells the user to repair the file and
+  restart, because it is read once at launch.
+- **`setEnabled(false)` is refused in main**, not merely unreachable from the UI. Settings
+  renders no switch, but `telemetry_set_enabled` is still a registered channel and the
+  renderer is not the trust boundary — the refusal is what makes "cannot be turned off" a
+  property of the app rather than of the current UI. With the constant flipped back, the
+  original behaviour returns: stop the timer, replace the state with `declined` and an empty
+  day map (every unsent buffer and daily id deleted), then flush.
 - Counters cap at 1,000,000 so a runaway loop cannot push the body past the server's 4 KB
   limit. Days are keyed by the local calendar day, and at most 7 pending days are kept.
 
@@ -82,7 +97,14 @@ status keeps it under the seven-day cap.
 ## Privacy surface
 
 Settings → Privacy ([`privacy-section.tsx`](../../src/ui/settings/sections/privacy-section.tsx))
-is a view over `telemetry.json` reached through `telemetry_state`: one switch, "Share usage
-stats", disabled while loading, unavailable or unreadable, plus the disclosure in plain words
-and a link to `USAGE_PRIVACY_URL`. A failed write surfaces through the persist-error bar; the
-UI never claims a change main did not keep.
+is a view over `telemetry.json` reached through `telemetry_state`. It carries NO control: the
+disclosure in plain words, the `unreadable` alert, and a link to `USAGE_PRIVACY_URL`. A switch
+would be a lie in either position — working, it would contradict main's refusal; disabled, it
+would be a dead thing to keep pressing.
+
+The disclosure did not go with the switch, and that is the shape of the whole decision: taking
+the choice away is not a licence to stop saying what is taken. The copy states that analytics
+is always on and cannot be turned off, lists what is sent and what never is, and — pinned by
+the copy test — never calls the payload "anonymous" and never implies the collection is
+optional. The category therefore has text to read and nothing to set, which is why the
+settings-screen row inventory counts 18 rows rather than 19.

--- a/electron/telemetry/service.test.ts
+++ b/electron/telemetry/service.test.ts
@@ -39,7 +39,19 @@ interface Harness {
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-function harness(initial?: unknown, options?: { unreadable?: boolean }): Harness {
+/**
+ * `mandatory` defaults to FALSE here, not to the shipped constant.
+ *
+ * The opt-out machinery is unreachable in shipped builds but is deliberately
+ * kept (see `USAGE_ANALYTICS_MANDATORY`), so its tests have to keep running:
+ * a default of `true` would silently turn every one of them into an assertion
+ * about the refusal instead. The mandatory policy gets its own describe block,
+ * which passes `mandatory: true` explicitly.
+ */
+function harness(
+  initial?: unknown,
+  options?: { unreadable?: boolean; mandatory?: boolean },
+): Harness {
   let nowMs = Date.UTC(2026, 7, 22, 12, 0, 0);
   let uuidCounter = 0;
   let status: number | Error = 204;
@@ -51,6 +63,7 @@ function harness(initial?: unknown, options?: { unreadable?: boolean }): Harness
   const flushes: PersistedTelemetry[] = [];
   let persisted: unknown = initial;
   const deps: TelemetryDeps = {
+    mandatory: options?.mandatory ?? false,
     now: () => nowMs,
     localDay: (ms) => new Date(ms).toISOString().slice(0, 10),
     randomUUID: () => `uuid-${(uuidCounter += 1)}`,
@@ -233,6 +246,46 @@ describe("telemetry lifecycle", () => {
     h.service.noteWindowReady();
     expect(h.posts.length).toBeGreaterThan(0);
     expect(h.timerRunning()).toBe(true);
+  });
+});
+
+describe("mandatory analytics", () => {
+  it("refuses to turn off, and says so rather than failing quietly", async () => {
+    // Settings renders no switch, but `telemetry_set_enabled` is still a
+    // registered channel and the renderer is not the trust boundary. The
+    // refusal has to live here for "cannot be turned off" to be a property of
+    // the app rather than of the current UI.
+    const h = harness(ENABLED_STATE, { mandatory: true });
+    h.service.count("agent", "claude", 1);
+    await expect(h.service.setEnabled(false)).rejects.toThrow(/mandatory/);
+    // The refusal changes nothing: consent stands, the timer stands, and the
+    // day's buffer is NOT deleted the way a real decline would delete it.
+    expect(h.service.state().consent).toBe("enabled");
+    expect(h.timerRunning()).toBe(true);
+    expect(h.flushes).toEqual([]);
+  });
+
+  it("counts and sends for a user who had turned analytics off", () => {
+    // The sharpest edge of the decision, pinned: a `declined` file written by
+    // an earlier build is overridden, not honoured.
+    const h = harness({ consent: "declined", consentVersion: 1, days: {} }, { mandatory: true });
+    h.service.count("agent", "claude", 1);
+    h.service.noteWindowReady();
+    expect(h.service.state().consent).toBe("enabled");
+    expect(h.posts.length).toBeGreaterThan(0);
+    expect(h.timerRunning()).toBe(true);
+  });
+
+  it("still fails closed on an unreadable state file", () => {
+    // Mandatory does not mean "send regardless". A disk Deck cannot read is
+    // not a disk it may assume anything from, and this is the one state in
+    // which a shipped build sends nothing.
+    const h = harness(undefined, { unreadable: true, mandatory: true });
+    h.service.count("agent", "claude", 1);
+    h.service.noteWindowReady();
+    expect(h.service.state().consent).toBe("unreadable");
+    expect(h.posts).toEqual([]);
+    expect(h.writes).toEqual([]);
   });
 });
 
@@ -441,17 +494,28 @@ describe("shouldSend cadence", () => {
 
 describe("persisted-state parsing", () => {
   it("degrades malformed input to the default, but never away from `declined`", () => {
-    expect(parsePersisted(null)).toEqual(EMPTY_STATE);
-    expect(parsePersisted([])).toEqual(EMPTY_STATE);
+    expect(parsePersisted(null, false)).toEqual(EMPTY_STATE);
+    expect(parsePersisted([], false)).toEqual(EMPTY_STATE);
     // A garbage string is a file Deck cannot read a preference out of, so it
     // takes the default…
-    expect(parsePersisted({ consent: "yes" }).consent).toBe("enabled");
-    expect(parsePersisted({}).consent).toBe("enabled");
+    expect(parsePersisted({ consent: "yes" }, false).consent).toBe("enabled");
+    expect(parsePersisted({}, false).consent).toBe("enabled");
     // …and `declined` is the one value that is never inferred away, because it
     // is the only one a user can only have put there on purpose.
-    expect(parsePersisted({ consent: "declined" }).consent).toBe("declined");
+    expect(parsePersisted({ consent: "declined" }, false).consent).toBe("declined");
     // The spelling an opt-in build left behind folds into the default.
-    expect(parsePersisted({ consent: "unanswered" }).consent).toBe("enabled");
+    expect(parsePersisted({ consent: "unanswered" }, false).consent).toBe("enabled");
+  });
+
+  it("folds even `declined` into enabled once analytics is mandatory", () => {
+    // The one value the opt-out policy protected is the one the mandatory
+    // policy overrides, so it is pinned rather than left implied: a recorded
+    // refusal does not survive this build.
+    expect(parsePersisted({ consent: "declined" }, true).consent).toBe("enabled");
+    expect(parsePersisted({ consent: "unanswered" }, true).consent).toBe("enabled");
+    expect(parsePersisted({ consent: "yes" }, true).consent).toBe("enabled");
+    // An unreadable FILE is still a different answer — that path never reaches
+    // `parsePersisted` at all, and `consentNow` reports `unreadable`.
   });
 
   it("drops malformed days and unknown counter keys", () => {

--- a/electron/telemetry/service.ts
+++ b/electron/telemetry/service.ts
@@ -26,6 +26,11 @@ import {
   type TelemetryStateReply,
   type UsagePayloadLike,
 } from "./model";
+// The policy constant is stated once, renderer-side, and imported here the way
+// `electron/fs/write.ts` imports `applyEol` — one spelling of the rule for both
+// processes, so main and Settings can never disagree about whether the switch
+// exists.
+import { USAGE_ANALYTICS_MANDATORY } from "../../src/telemetry/usage-notice";
 
 export interface TelemetryStoreAccess {
   /** True when `telemetry.json` exists but could not be read — fail closed. */
@@ -54,6 +59,13 @@ export interface TelemetryDeps {
   onStateChanged?(state: TelemetryStateReply): void;
   /** Injectable interval for tests; returns the stopper. */
   startTimer?(handler: () => void, intervalMs: number): () => void;
+  /**
+   * Whether analytics is mandatory. Defaults to the constant; a parameter so
+   * the tests can drive BOTH policies — the `shouldShowUsageNotice(enabled)`
+   * precedent. The opt-out machinery below is kept rather than deleted, and
+   * this is what keeps it covered while it is unreachable in shipped builds.
+   */
+  mandatory?: boolean;
 }
 
 export interface TelemetryService {
@@ -110,22 +122,32 @@ function parseBuffer(raw: unknown): DayBuffer | null {
 /**
  * Validate persisted state from disk.
  *
- * `declined` is the only value that survives a round trip unchanged, and that
- * asymmetry is the whole rule since analytics went on by default (2026-08-23):
- * OFF is a state only the user can put the app in, so it is never inferred
- * away. Everything else — a missing field, a garbage string, or the
- * `unanswered` an opt-in build left behind — reads as the new default.
+ * Every value reads as `enabled` while `USAGE_ANALYTICS_MANDATORY` holds
+ * (2026-09-06): a missing field, a garbage string, the `unanswered` an opt-in
+ * build left behind, and — the one that actually changed — a `declined` an
+ * earlier build wrote. That last fold is deliberate and is the sharpest edge
+ * of this decision, so it is stated rather than buried: a recorded refusal is
+ * overridden, not honoured. It reaches almost nobody in practice, because
+ * analytics has never shipped in a release (`cdc07a0` postdates 1.0.0), so a
+ * `declined` file exists only on machines that ran a development build.
  *
- * A file that cannot be READ at all is a different answer: `consentNow` reports
- * `unreadable` and nothing is sent, because a disk Deck cannot read is not a
- * disk it may assume a preference from.
+ * With the constant flipped back, `declined` again survives a round trip
+ * unchanged — OFF becomes a state only the user can put the app in, and one
+ * that is never inferred away.
+ *
+ * A file that cannot be READ at all is a different answer under either policy:
+ * `consentNow` reports `unreadable` and nothing is sent, because a disk Deck
+ * cannot read is not a disk it may assume a preference from.
  */
-export function parsePersisted(raw: unknown): PersistedTelemetry {
+export function parsePersisted(
+  raw: unknown,
+  mandatory: boolean = USAGE_ANALYTICS_MANDATORY,
+): PersistedTelemetry {
   if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
     return EMPTY_STATE;
   }
   const source = raw as Record<string, unknown>;
-  const consent = source.consent === "declined" ? "declined" : "enabled";
+  const consent = !mandatory && source.consent === "declined" ? "declined" : "enabled";
   const consentVersion = isCount(source.consentVersion) ? source.consentVersion : 0;
   const days: Record<string, DayBuffer> = {};
   const rawDays = source.days;
@@ -159,9 +181,10 @@ export function shouldSend(buffer: DayBuffer, nowMs: number, consent: ConsentSta
 }
 
 export function createTelemetryService(deps: TelemetryDeps): TelemetryService {
+  const mandatory = deps.mandatory ?? USAGE_ANALYTICS_MANDATORY;
   let state: PersistedTelemetry = deps.store.unreadable()
     ? EMPTY_STATE
-    : parsePersisted(deps.store.read());
+    : parsePersisted(deps.store.read(), mandatory);
   let stopTimer: (() => void) | null = null;
   let sending = false;
   let initialSnapshotDone = false;
@@ -426,6 +449,14 @@ export function createTelemetryService(deps: TelemetryDeps): TelemetryService {
     state: replyState,
 
     async setEnabled(next: boolean): Promise<void> {
+      if (!next && mandatory) {
+        // Settings no longer renders a switch, but `telemetry_set_enabled` is
+        // still a registered channel and the renderer is not the trust
+        // boundary. Refusing here rather than relying on an absent control is
+        // what makes "cannot be turned off" a property of the app instead of a
+        // property of the current UI.
+        throw new Error("usage analytics is mandatory in this build");
+      }
       if (deps.store.unreadable()) {
         // Fail closed: no consent is inferred and nothing is reset here.
         // Recovering requires the user to repair or remove the file.

--- a/marketing/landing-prototype/src/copy.js
+++ b/marketing/landing-prototype/src/copy.js
@@ -60,7 +60,7 @@ export const messages = {
     proofOpenBody: "The whole app is on GitHub — read it, build it, fork it, ship a patch.",
     proofLocalTitle: "Your work stays on your machine",
     proofLocalBody:
-      "Your code, terminals and agent sessions stay local. Deck sends first-party usage analytics — on by default, never code, file paths or prompts — and Settings → Privacy turns them off.",
+      "Your code, terminals and agent sessions stay local. Deck sends first-party usage analytics — always on, with no opt-out, never code, file paths or prompts — and Settings → Privacy states exactly what is sent.",
     scSplit: "split",
     scSplitH: "split down",
     scTab: "new tab",
@@ -141,7 +141,7 @@ export const messages = {
     proofOpenBody: "Toàn bộ app nằm trên GitHub — đọc, tự build, fork hay gửi patch đều được.",
     proofLocalTitle: "Công việc của bạn ở lại trên máy bạn",
     proofLocalBody:
-      "Code, terminal và phiên agent đều nằm local. Deck gửi usage analytics first-party — bật mặc định, không bao giờ kèm code, đường dẫn file hay prompt — tắt được trong Settings → Privacy.",
+      "Code, terminal và phiên agent đều nằm local. Deck gửi usage analytics first-party — luôn bật, không tắt được, và không bao giờ kèm code, đường dẫn file hay prompt — Settings → Privacy ghi rõ những gì được gửi.",
     scSplit: "chia dọc",
     scSplitH: "chia ngang",
     scTab: "tab mới",

--- a/src/telemetry/usage-notice.ts
+++ b/src/telemetry/usage-notice.ts
@@ -6,9 +6,12 @@
  * a notice row, and it could only ever render while consent is unanswered on
  * a host that can do analytics at all — the Electron host — so on Tauri and
  * in the browser preview nothing ever shows. But no consent question is asked
- * any more: analytics is ON by default, `USAGE_CONSENT_ASKED` below is false,
- * `declined` (the Settings → Privacy switch) is the only state never inferred
- * away, and an unreadable `telemetry.json` fails closed to off. See
+ * any more, and since 2026-09-06 there is no answer to give: analytics is
+ * MANDATORY, `USAGE_CONSENT_ASKED` below is false and
+ * `USAGE_ANALYTICS_MANDATORY` is true, so `declined` is unreachable and an
+ * existing one folds back to `enabled`. An unreadable `telemetry.json` still
+ * fails closed to off — that is a disk Deck cannot read, not a preference, and
+ * guessing past it would mean writing over state of unknown shape. See
  * docs/internals/telemetry.md.
  */
 
@@ -43,6 +46,32 @@ export const USAGE_PRIVACY_URL = "https://deck.spacevibe.dev/privacy";
  * constant exists to keep.
  */
 export const USAGE_CONSENT_ASKED: boolean = false;
+
+/**
+ * Whether analytics is MANDATORY — on for every install, with no way to turn
+ * it off (owner-decided 2026-09-06).
+ *
+ * This is a step beyond the 2026-08-23 default-on reversal, which kept the
+ * Settings → Privacy switch as the one way out. There is no way out now:
+ * `declined` stops being a state the user can reach, `parsePersisted` folds an
+ * existing one back to `enabled`, and `setEnabled(false)` is refused by main
+ * rather than merely unreachable from the UI — the renderer is not the trust
+ * boundary, so a channel that still exists must not honour a request the
+ * product no longer offers.
+ *
+ * The disclosure did NOT go with the switch: Settings → Privacy still states
+ * exactly what is sent and what is not, and still links the privacy notice.
+ * Taking the control away while keeping the account of what is taken is the
+ * whole shape of this decision — a surface that collects silently would be
+ * worse on every axis that matters.
+ *
+ * Typed `boolean` rather than left as the literal, the `USAGE_CONSENT_ASKED`
+ * and `GRAB_PASTE_DISABLED` shape: neither branch becomes statically
+ * unreachable, so a dead-code pass cannot delete the half that makes this
+ * reversible. Flipping this one constant back, re-mounting `ToggleRow` in
+ * `privacy-section.tsx` and restoring the copy is the whole reversal.
+ */
+export const USAGE_ANALYTICS_MANDATORY: boolean = true;
 
 export interface UsageNoticeConditions {
   /** True only where the telemetry host answers — the Electron host. */

--- a/src/ui/settings/sections/privacy-section.test.tsx
+++ b/src/ui/settings/sections/privacy-section.test.tsx
@@ -37,51 +37,43 @@ describe("PrivacySection", () => {
     mount.remove();
   });
 
-  it("pins the privacy copy: on by default, the way off, retention, processor — never anonymous", () => {
-    // The privacy-copy contract (spec §11), rewritten 2026-08-23 when
-    // analytics went on by default: this row is now the ONLY place in the app
-    // that says Deck collects anything, so it has to say both halves — that it
-    // is on, and where it goes off.
+  it("pins the privacy copy: always on, no opt-out, retention, processor — never anonymous", () => {
+    // The privacy-copy contract (spec §11), rewritten 2026-09-06 when the
+    // switch went: this is the ONLY place in the app that says Deck collects
+    // anything, and it is now the only place that says the collection cannot
+    // be refused. Taking the control away is not a licence to soften either
+    // half, so both are pinned — including the word "anonymous" staying out.
     act(() => render(<PrivacySection />, mount));
     const text = mount.textContent ?? "";
-    expect(text).toContain("On by default");
-    expect(text).toContain("Turn it off here");
+    expect(text).toContain("always on");
+    expect(text).toContain("cannot be turned off");
     expect(text).toContain("35 days");
     expect(text).toContain("Cloudflare");
     expect(text).toContain("random id for that day");
     expect(text.toLowerCase()).not.toContain("anonymous");
   });
 
-  it("disables the switch while loading or unreadable, enables it on an answer", () => {
-    telemetryConsent.value = "loading";
-    act(() => render(<PrivacySection />, mount));
-    const toggle = (): HTMLButtonElement | null =>
-      mount.querySelector<HTMLButtonElement>("button[role='switch']");
-    expect(toggle()?.disabled).toBe(true);
-    act(() => {
-      telemetryConsent.value = "unreadable";
-    });
-    expect(toggle()?.disabled).toBe(true);
-    act(() => {
-      telemetryConsent.value = "declined";
-    });
-    expect(toggle()?.disabled).toBe(false);
+  it("offers no control at all, in every consent phase", () => {
+    // A switch here would be a lie in both positions: working, it would
+    // contradict main, which refuses `setEnabled(false)`; disabled, it would
+    // be a dead thing to keep pressing. The phases are walked because the old
+    // section rendered the control in all of them.
+    for (const phase of ["loading", "unreadable", "declined", "enabled"] as const) {
+      act(() => {
+        telemetryConsent.value = phase;
+      });
+      act(() => render(<PrivacySection />, mount));
+      expect(mount.querySelector("button[role='switch']")).toBeNull();
+    }
+    expect(host.telemetrySetEnabled).not.toHaveBeenCalled();
   });
 
   it("says why an unreadable state file keeps sharing off", () => {
+    // Fail-closed survives the mandatory policy, and a page that says "always
+    // on" owes the reader the one case where it is in fact off.
     telemetryConsent.value = "unreadable";
     act(() => render(<PrivacySection />, mount));
     expect(mount.textContent).toContain("could not be read");
     expect(mount.textContent).toContain("telemetry.json");
-  });
-
-  it("writes the flipped consent through to the host", async () => {
-    telemetryConsent.value = "declined";
-    act(() => render(<PrivacySection />, mount));
-    const toggle = mount.querySelector<HTMLButtonElement>("button[role='switch']");
-    await act(async () => {
-      toggle?.click();
-    });
-    expect(host.telemetrySetEnabled).toHaveBeenCalledWith(true);
   });
 });

--- a/src/ui/settings/sections/privacy-section.tsx
+++ b/src/ui/settings/sections/privacy-section.tsx
@@ -1,67 +1,46 @@
 import { ArrowSquareOut } from "@phosphor-icons/react";
 import { useEffect } from "preact/hooks";
-import { useSignal } from "@preact/signals";
 import { openUrl } from "../../../host/shell-host";
 import { reportPersistError } from "../../../chrome/events";
-import { ToggleRow } from "../../controls/config-row";
 import { CHROME_ICON, DeckIcon } from "../../controls/deck-icon";
-import {
-  ensureTelemetryStateLoaded,
-  setTelemetryEnabled,
-  telemetryConsent,
-} from "../../../telemetry/consent-store";
+import { ensureTelemetryStateLoaded, telemetryConsent } from "../../../telemetry/consent-store";
 import { USAGE_PRIVACY_URL } from "../../../telemetry/usage-notice";
 
 /**
- * The Privacy category (spec §7): one switch over MAIN-owned consent state,
- * then the whole disclosure in plain words. This is a VIEW over
- * `telemetry.json` reached through `telemetry_state` — deliberately not a
+ * The Privacy category (spec §7): the whole disclosure in plain words, over
+ * MAIN-owned state read through `telemetry_state` — deliberately not a
  * settings-schema pair, because settings get copied to other machines and
  * pasted into issues, and consent must never travel with them.
  *
- * Four states: loading and unreadable disable the switch; enabled and
- * declined/off are the two the user can move between. A failed write stays
- * visible through the persist-error bar — the UI never claims a change main
- * did not keep. No identifier is displayed because no daily id ever crosses
- * into the renderer.
+ * The switch is GONE (2026-09-06, `USAGE_ANALYTICS_MANDATORY`): usage stats
+ * are on for every install with no way to turn them off, so a control here
+ * would be a lie either way — working, it would contradict main, which refuses
+ * `setEnabled(false)`; disabled, it would be a dead thing to keep pressing.
+ * The account of what is sent stays, and is the reason this category still
+ * exists at all: taking the choice away is not a licence to stop saying what
+ * is taken. No identifier is displayed because no daily id ever crosses into
+ * the renderer.
+ *
+ * `unreadable` is still reported, because it still means nothing is being sent
+ * — fail-closed survives the mandatory policy, and a user reading a page that
+ * says "always on" deserves to know when it is in fact off.
  *
  * The copy never calls the payload "anonymous" (spec §11) — the copy test
- * pins that word out.
+ * pins that word out — and it must never claim the collection is optional.
  */
 export function PrivacySection() {
-  const busy = useSignal(false);
-
   useEffect(() => {
     void ensureTelemetryStateLoaded();
   }, []);
 
   const consent = telemetryConsent.value;
-  const enabled = consent === "enabled";
-  const locked = consent === "loading" || consent === "unavailable" || consent === "unreadable";
-
-  const toggle = async (): Promise<void> => {
-    if (busy.value || locked) {
-      return;
-    }
-    busy.value = true;
-    try {
-      await setTelemetryEnabled(!enabled);
-    } catch {
-      reportPersistError("Could not save your usage-stats choice.");
-    } finally {
-      busy.value = false;
-    }
-  };
 
   return (
     <>
-      <ToggleRow
-        label="Share usage stats"
-        desc="On by default. Turn it off here and Deck stops counting. No code, paths or prompts."
-        checked={enabled}
-        disabled={busy.value || locked}
-        onToggle={() => void toggle()}
-      />
+      <p class="settings-screen__note">
+        Deck sends first-party usage stats. They are always on and cannot be turned off in this
+        build. No code, file paths or prompts are ever included.
+      </p>
       {consent === "unreadable" ? (
         // Fail-closed (spec §5): the state file exists but could not be read,
         // so analytics stays off and Deck refuses to guess or overwrite it.
@@ -73,19 +52,17 @@ export function PrivacySection() {
         </p>
       ) : null}
       <p class="settings-screen__note">
-        When sharing is on, Deck sends one small daily snapshot: a fresh random id for that day, the
-        date, Deck's version, platform and architecture, launch counts per built-in agent (custom
-        agents count as one bucket), how often the browser, explorer and usage surfaces were opened,
-        the day's highest tab and pane counts, and whether sessions were restored at launch. The
-        daily id is random every day and is never derived from your machine, so days cannot be
-        linked.
+        Deck sends one small daily snapshot: a fresh random id for that day, the date, Deck's
+        version, platform and architecture, launch counts per built-in agent (custom agents count as
+        one bucket), how often the browser, explorer and usage surfaces were opened, the day's
+        highest tab and pane counts, and whether sessions were restored at launch. The daily id is
+        random every day and is never derived from your machine, so days cannot be linked.
       </p>
       <p class="settings-screen__note">
         Deck never sends code, file paths, repository or branch names, prompts, terminal output,
         hostname, username, locale or timezone. Raw records expire after 35 days. The data is stored
         on Deck's own Cloudflare Worker; Cloudflare processes ordinary connection metadata at its
-        edge as the infrastructure provider. Turning sharing off deletes unsent data immediately;
-        already-accepted records remain until their 35-day deadline.
+        edge as the infrastructure provider.
       </p>
       <button
         type="button"

--- a/src/ui/settings/settings-screen.test.tsx
+++ b/src/ui/settings/settings-screen.test.tsx
@@ -374,11 +374,12 @@ const EXPECTED_ROWS = [
   // about
   "Check for updates",
   "Release notes",
-  // privacy — one switch over MAIN-owned consent state (usage-analytics spec
-  // §7), added 2026-08-22. The disclosure paragraphs under it are
-  // `.settings-screen__note`, not `.cfg-row__label`, so the walk sees the
-  // switch alone.
-  "Share usage stats",
+  // privacy — NO row. The category is still in the rail and still carries the
+  // whole disclosure, but its one switch went when analytics became mandatory
+  // (2026-09-06, `USAGE_ANALYTICS_MANDATORY`). Its paragraphs are
+  // `.settings-screen__note`, not `.cfg-row__label`, so the walk sees nothing
+  // there — which is the point: the category has text to read and nothing to
+  // set. Restoring the switch restores a row here.
   // reset — its own rail category since 2026-08-19, a pinned foot before that
   // (so this row used to be reachable from every category, and is now reached
   // by selecting one).
@@ -414,7 +415,7 @@ describe("SettingsScreen — every setting survived the move", () => {
     });
   });
 
-  it("reaches all 19 rows by walking the rail", () => {
+  it("reaches all 18 rows by walking the rail", () => {
     act(() => {
       render(<SettingsScreen open onClose={vi.fn()} />, host);
     });


### PR DESCRIPTION
Lands the owner's 2026-09-06 decision: usage analytics is on for every install and cannot be refused. Cherry-pick of `d1531cb` onto `origin/main`.

Linear: [DECK-38](https://linear.app/mxrsv/issue/DECK-38/djua-client-always-on-d1531cb-vao-main-go-cong-tac-tat-analytics), a sub-issue of [DECK-1](https://linear.app/mxrsv/issue/DECK-1/backend-analytics-chua-ton-tai-nhung-client-dja-bat-mac-djinh).

## What changes

`USAGE_ANALYTICS_MANDATORY` in `src/telemetry/usage-notice.ts` is the whole switch, following the `USAGE_CONSENT_ASKED` and `GRAB_PASTE_DISABLED` shape — nothing is deleted, so flipping the constant back restores the opt-out. Behind it:

- `parsePersisted` folds every stored spelling into `enabled`, `declined` included. Overriding a recorded refusal is the sharpest edge here and is pinned by its own test.
- `setEnabled(false)` is **refused in main**, not merely unreachable from the UI. `telemetry_set_enabled` is still a registered IPC channel and the renderer is not a trust boundary.
- `TelemetryDeps.mandatory` defaults to the constant, so both policies stay tested; the opt-out suites keep running under `mandatory: false`.
- An unreadable `telemetry.json` still fails closed, and is now the only state in which a shipped build sends nothing.

Settings → Privacy keeps its entire disclosure and loses only the control. A switch there would be a lie in both positions: on, it would contradict main; greyed, it would be a dead control. Copy is corrected everywhere it claimed an opt-out — README both spots, the landing's EN and VI proof points, the Settings copy, and the test that pinned "Turn it off here".

## Conflict resolved

One, in `AGENTS.md`, and only its trailing line: `Updated 2026-09-04.` on this base against `Updated 2026-09-06.` on the branch. Took the later date. Everything else in `AGENTS.md` merged cleanly, including the drift row that already reads "always on, with no opt-out". No code file conflicted.

## Verification

```
npx tsc --noEmit                   exit 0
npx tsc -p tsconfig.electron.json  exit 0
npm run generate:menu:check        clean
npx prettier --check .             clean
npm test                           3893 passed / 0 failed / 3 skipped (303 files)
npm run build                      built in 12.89s
```

## Not verified

No `electron:dev` host pass and no owner eye review — no running app has shown the switchless Privacy category. Windows is Gate C.

## Note on the base

This is cut from `origin/main` (`f4fec4a`). The local `main` on the author's machine carries further unpushed work; that divergence is tracked separately and is deliberately not part of this PR.

https://claude.ai/code/session_01Bn6yqd6TMzv7YxKap7XExg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Usage analytics are now always on and cannot be disabled.
  * Existing declined settings are treated as enabled, while unreadable local state still prevents sending.
  * Settings → Privacy now explains what is collected without displaying an analytics toggle.
* **Documentation**
  * Updated the README, telemetry documentation, and marketing copy to describe the mandatory analytics policy and privacy disclosure.
* **Tests**
  * Added coverage for mandatory analytics behavior, persisted consent handling, and the updated Privacy settings experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->