### PR TITLE
docs(deck): add contributing guide, PR template and documentation contract (MXR-35)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+<!--
+Read CONTRIBUTING.md first. One concern per pull request; small and focused is what gets
+reviewed. Anything in a fork-listed area of AGENTS.md needs an issue before code.
+-->
+
+## What changed
+
+<!-- The change, in a few sentences. Keep scope tight. -->
+
+## Why
+
+<!-- The problem this solves and why this approach. Link the issue. -->
+
+## Evidence
+
+<!-- Name the class of evidence: which suites and builds ran, whether the change was seen in
+     a running `electron:dev` on macOS, whether Windows hardware was involved. Green unit
+     tests are not native evidence; say what has NOT been run. -->
+
+## UI changes
+
+<!-- Before and after screenshots for any visible change; a short video for motion, timing
+     or interaction. Upload them here, do not commit them. Delete this section if none. -->
+
+## Documentation
+
+<!-- Does a page under docs/ now disagree with the code? Which one did you update, or why
+     none needs it? Internal pages hold decisions and constraints, not feature descriptions;
+     user guides change when how to use a feature changes. -->
+
+## Checklist
+
+- [ ] One concern, explained above
+- [ ] Evidence stated, including what has not been run
+- [ ] Before/after images (or a video) for any UI change
+- [ ] Docs checked against the change; drift rows updated if a claim changed
+- [ ] English only; conventional commit subject with a scope

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1297,6 +1297,31 @@ it runs on rather than implying both.
   off their rows with nothing to scroll them back. It is `overflow: clip` now — keep it that
   way, and treat "the top bar looks misaligned" as a scroll report, not a layout one.
 
+## Documentation
+
+Most code changes need no documentation change; agents and maintainers can read the code.
+The index is [docs/README.md](docs/README.md) `current`.
+
+- `docs/internals/` holds architectural decisions and their reasons, constraints that span
+  modules, and traps that are hard to discover from the source. Before adding a paragraph,
+  ask what a maintainer would get wrong without it. If reading the relevant code answers the
+  question, leave it out. It is the one place in the repository that still takes new
+  documentation.
+- `docs/user/` helps users accomplish tasks, in the voice of the shipped product, with no
+  implementation detail and no contributor tooling. Update the feature's section when how to
+  use it changes; a UI tweak needs no entry and a new control needs no page.
+- `docs/operations/` is the maintainer runbook: setup, release, debugging. Every page under
+  `internals/` and `operations/` opens with the "For maintainers" callout.
+- Do not write file catalogs, field or method enumerations, control-flow narration, or
+  appended PR summaries. Types, tests and code already record the implementation. When a
+  documented decision changes, rewrite or remove the text; never append a second account of
+  the new behaviour. Keep a local explanation in a code comment; use an internal page only
+  when the reasoning crosses boundaries.
+- Plans, specs, research notes and review reports are not committed. A merged PR is the
+  implementation record, and active work lives in the issue that owns it.
+- `docs/DESIGN-LANGUAGE.md` stays at its path and keeps its numbering: a test reads it, and
+  code comments cite its rules. `CHANGELOG.md` is read by the release workflow.
+
 ## Chưa khớp thực tế
 
 _(Heading retained for the global living-doc convention.)_

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing
+
+## Where things are
+
+- Setup, commands, tests and what a green run proves:
+  [docs/operations/development.md](docs/operations/development.md).
+- How Deck is built: [docs/internals/](docs/internals/overview.md), starting with the
+  overview and the [glossary](docs/internals/glossary.md).
+- Repository rules for contributors and agents, including the
+  [documentation rules](AGENTS.md#documentation): [AGENTS.md](AGENTS.md).
+- Visual rules: [docs/DESIGN-LANGUAGE.md](docs/DESIGN-LANGUAGE.md). They are numbered,
+  cited from code comments, and parsed by a test.
+
+## Where the project is
+
+SpaceVibe Deck 1.0 shipped on 2026-08-20 for macOS on Apple Silicon (signed and notarized)
+and for Windows x64 (unsigned, and not yet verified on real Windows hardware). Since then
+the surfaces around the Agent Rail, session restore and the sidebar have been reshaped and
+are being finished for the next release. Most of that work has suite and build evidence but
+no pass in a running app yet. The Tauri host under `src-tauri/` is feature-frozen; new
+features land on Electron only.
+
+## What is most likely to be accepted
+
+- Small, focused bug fixes, with a test where the behaviour is testable.
+- Evidence from a running app on macOS or Windows for a surface that shipped with suite
+  evidence only, and fixes for what that evidence finds.
+- Documentation corrections where a page disagrees with the code.
+
+## What needs an issue first
+
+- Anything in a fork-listed area of [AGENTS.md](AGENTS.md#forks): PTY ownership, process
+  classification, the window coordinator, tab materialization, layout, close and quit,
+  release, updater, signing or dependency configuration, or a design-language rule.
+- New product surfaces or product scope. Describe the problem before the solution.
+
+## Pull requests
+
+- One concern per pull request. If the description says "also", split it.
+- Say what changed and why, and name the class of evidence: suite and build, an
+  `electron:dev` run on macOS, or Windows hardware. Green unit tests are not native
+  evidence.
+- A UI change needs before and after screenshots; motion or timing needs a short video.
+  Upload them to the pull request; never commit them.
+- Follow the documentation rules: internal pages hold decisions and hard-to-discover
+  constraints, user guides change when how to use a feature changes, and a cosmetic change
+  needs no documentation entry. Plans and research notes are not committed.
+- Commit subjects are conventional commits with a scope, for example `fix(rail): …` or
+  `docs(deck): …`.
+- Everything in the repository is English: strings, comments, docs and commit messages.
+- CI runs the menu check, lint, the test suite, both builds and the Rust checks on every
+  pull request. Run the smallest local proof for your change before opening it.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ release runbooks under [docs/operations/](docs/operations/development.md) `curre
 Focused issues and pull requests are welcome. Please open an
 [issue](https://github.com/mxrsv/spacevibe-deck/issues) before starting a substantial product
 or architecture change, and keep each pull request to one concern.
+[CONTRIBUTING.md](CONTRIBUTING.md) `current` says what is likely to be accepted, what needs
+an issue first, and what a pull request must carry.
 
 ## License
 

--- a/docs/internals/agent-rail.md
+++ b/docs/internals/agent-rail.md
@@ -1,5 +1,7 @@
 # Agent Rail
 
+> For maintainers. Using Deck? See [docs/user/](../user/).
+
 The rail is the left column: one cluster per project, one row per agent pane, each row
 saying what its agent last said and in what state. This page states the invariants of the
 model, the state derivation, the pairing that reads a sentence off the agent's own session

--- a/docs/internals/file-surface.md
+++ b/docs/internals/file-surface.md
@@ -1,5 +1,7 @@
 # File surface, browser tab and path opening
 
+> For maintainers. Using Deck? See [docs/user/](../user/).
+
 Three things share the stage with the terminal grid: documents opened from the file
 explorer, the browser tab, and the routing that turns a path an agent printed into one of
 those. All of it is Electron only: the file channels, the `WebContentsView` and the external

--- a/docs/internals/glossary.md
+++ b/docs/internals/glossary.md
@@ -1,5 +1,7 @@
 # Glossary
 
+> For maintainers. Using Deck? See [docs/user/](../user/).
+
 The words Deck's code, tests and documents use, each with the terms to avoid. The UI
 hierarchy is Window → Tab → Pane; documents and the browser are surfaces beside tabs.
 

--- a/docs/internals/overview.md
+++ b/docs/internals/overview.md
@@ -1,5 +1,7 @@
 # Architecture overview
 
+> For maintainers. Using Deck? See [docs/user/](../user/).
+
 SpaceVibe Deck is an Electron desktop terminal for running several AI agent CLIs side by
 side. The main process (`electron/`) owns everything the renderer cannot: PTYs, the process
 table, windows, persistent stores, the native menu, the updater, usage analytics, git

--- a/docs/internals/session-restore.md
+++ b/docs/internals/session-restore.md
@@ -1,5 +1,7 @@
 # Session restore
 
+> For maintainers. Using Deck? See [docs/user/](../user/).
+
 On launch Deck reopens the tabs that were open at quit and resumes each built-in agent's
 conversation. Electron only: the lookup channel has no Tauri counterpart.
 `Settings.restoreSessions` (default on) is the kill switch.

--- a/docs/internals/telemetry.md
+++ b/docs/internals/telemetry.md
@@ -1,5 +1,7 @@
 # Usage analytics
 
+> For maintainers. Using Deck? See [docs/user/](../user/).
+
 Deck sends one small usage snapshot per day, on by default, and the only state it never
 infers away is an explicit "off". This page is the contract: what leaves the machine, who
 owns the state, and when a POST fires. Electron only: the Tauri host sends nothing.

--- a/docs/internals/terminal.md
+++ b/docs/internals/terminal.md
@@ -1,5 +1,7 @@
 # Terminal, panes and tabs
 
+> For maintainers. Using Deck? See [docs/user/](../user/).
+
 The stage is a set of tabs, each a split tree of panes, each pane one xterm.js instance bound
 to one PTY that the main process owns. This page covers the PTY manager and its ownership
 model, the tab and layout layer in the renderer, how a tab is materialized and an agent

--- a/docs/internals/traps.md
+++ b/docs/internals/traps.md
@@ -1,5 +1,7 @@
 # Known traps and live switches
 
+> For maintainers. Using Deck? See [docs/user/](../user/).
+
 Things that have bitten this codebase and are not obvious from reading one file, plus the
 constants that currently switch behaviour off and are meant to be flipped back.
 

--- a/docs/operations/development.md
+++ b/docs/operations/development.md
@@ -1,5 +1,7 @@
 # Development
 
+> For maintainers. Using Deck? See [docs/user/](../user/).
+
 How to build, run, test and check the repository. Architecture is in
 [`../internals/`](../internals/overview.md); cutting a release is in [release.md](release.md).
 

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -1,5 +1,7 @@
 # Cutting a release
 
+> For maintainers. Using Deck? See [docs/user/](../user/).
+
 One pushed tag ships SpaceVibe Deck for macOS and Windows, both self-updating, through
 [`electron-release.yml`](../../.github/workflows/electron-release.yml). Nothing ships the
 Tauri host automatically any more; [`release.yml`](../../.github/workflows/release.yml) is a


### PR DESCRIPTION
## What changed

- `AGENTS.md` gains a `## Documentation` section: what `docs/internals/`, `docs/user/` and `docs/operations/` each hold, the test to apply before adding a paragraph ("what would a maintainer get wrong without it?"), and what is never written — file catalogs, field enumerations, control-flow narration, appended PR summaries. It also records that plans, specs, research notes and review reports are not committed; a merged PR is the implementation record.
- `CONTRIBUTING.md` (new): where setup, internals and visual rules live, the project's actual stage, what is most likely to be accepted, what needs an issue first (the fork list), and what a pull request must carry.
- `.github/pull_request_template.md` (new): what/why, evidence — including what has **not** been run — UI before/after, docs drift, and a checklist.
- `README.md` gains one line pointing at `CONTRIBUTING.md`.
- Every page under `docs/internals/` and `docs/operations/` opens with `> For maintainers. Using Deck? See docs/user/.`

## Why

The docs tiers were rebuilt on 2026-09-05, but the rules governing them lived only in the maintainer's private global config — invisible to anyone cloning this public repo. This declares them in the repository. Closes MXR-35.

`.github/SECURITY.md` was in the issue's scope and is **deliberately not included**: GitHub's private vulnerability reporting is `enabled: false` for this repository, so the drafted file routed reporters to `/security/advisories/new`, which rejects them. The file also does not affect the community-profile checklist (no `security` key in `community/profile`). Recorded on MXR-35; reopen if private reporting is ever enabled.

## Evidence

Documentation-only — no source file changed, so no suite, typecheck or build applies.

- `docs-compliance.sh`: one `❌` at `README.md:168`, verified pre-existing at `origin/main:166` (the drift table's `[hero]` / `[social preview]` links); shifted two lines by this change, not caused by it.
- `docs-anchors.sh`: 13 findings, all in `docs/ARCHITECTURE.md` and `docs/CONTEXT.md` — files this PR does not touch, all pre-existing on `origin/main`.
- Branched from `origin/main` in a clean worktree rather than committed from the shared checkout, which carries several other sessions' uncommitted work in `AGENTS.md`, `README.md` and `docs/`. The diff is 136 insertions and zero deletions.

## UI changes

None.

## Documentation

This PR is the documentation change. `docs/ARCHITECTURE.md` and `docs/CONTEXT.md` still contradict the new `## Documentation` section by existing at all — that deletion is MXR-36, blocked on MXR-38.

https://claude.ai/code/session_013mEAsjBAjrKEv1dzTtmGdc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a contributor guide covering accepted changes, pull request requirements, evidence, documentation, and validation expectations.
  - Added a pull request template to standardize change descriptions, rationale, evidence, UI impact, and checklist completion.
  - Updated project guidance and the README to improve navigation between contributor, user, maintainer, and operational documentation.
  - Clarified which documentation is intended for maintainers versus end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->