### PR TITLE
feat: Thêm kéo thả, ghim và menu thao tác cho tab strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ startup on Windows.
 
 ### Highlights
 
+- **Arrange and pin tabs.** Drag terminal, file, browser and Agents tabs into
+  place; right-click to pin, unpin, close others or close tabs to the right.
+  Pinned tabs keep their icon and name and are skipped by bulk closes.
+  Preferences last for the current window session.
+  [Tab strip](src/ui/tab-strip.tsx) `current`.
+
 - ⚡ **Faster Windows terminal startup.** Deck no longer starts a PowerShell/WMI
   process census in front of a new shell, split or docked pane. Background
   inspection stays paused through shell startup and resumes on its normal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ the release PR, and frozen at the tag — never an auto-generated commit list.
 
 ## Unreleased
 
+- **Arrange and pin tabs.** Drag terminal, file, browser and Agents tabs into
+  place; right-click to pin, unpin, close others or close tabs to the right.
+  Pinned tabs keep their icon and name and are skipped by bulk closes.
+  Preferences last for the current window session.
+  [Tab strip](src/ui/tab-strip.tsx) `current`.
+
 - **Return to Agent Board.** When session restore is enabled, quitting while viewing Agent
   Board now brings the Board back on screen at the next launch. Switching away before quitting
   keeps only its `Agents` tab open ([Board restore](src/terminal/session-restore.ts) `current`).
@@ -17,12 +23,6 @@ This update makes starting new work more deliberate and improves terminal
 startup on Windows.
 
 ### Highlights
-
-- **Arrange and pin tabs.** Drag terminal, file, browser and Agents tabs into
-  place; right-click to pin, unpin, close others or close tabs to the right.
-  Pinned tabs keep their icon and name and are skipped by bulk closes.
-  Preferences last for the current window session.
-  [Tab strip](src/ui/tab-strip.tsx) `current`.
 
 - ⚡ **Faster Windows terminal startup.** Deck no longer starts a PowerShell/WMI
   process census in front of a new shell, split or docked pane. Background

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ beside terminals as tabs on the same stage. Cmd/Ctrl+click on a path from an age
 file and line in a configured editor
 ([PTY host](electron/pty/spawn.ts) `current`, [stage strip](src/ui/stage-surface-strip.ts) `current`).
 
+Drag tabs to rearrange them, or right-click for **Pin/Unpin**, **Close**,
+**Close Others** and **Close to the Right**. Pinned tabs stay first with their
+icon and name; bulk closes skip them. Order and pins last for the current
+window session; keyboard navigation follows the visible order
+([tab strip](src/ui/tab-strip.tsx) `current`, [strip order](src/lib/strip-order.ts) `current`).
+
 ### Sessions that come back
 
 Deck continuously journals open tabs and file surfaces, guards boot restoration against crash

--- a/docs/DESIGN-LANGUAGE.md
+++ b/docs/DESIGN-LANGUAGE.md
@@ -1301,9 +1301,9 @@ window's identity and its actions at the same time.
   consequence is deliberate and worth stating: the same chips exist in both
   layouts, so the navigation rail no longer lists documents at all. A rail row
   says which repository and worktree a session is in; the strip says what is
-  open. **Amended 2026-08-16:** the strip is ONE row of one chip shape, in the
-  order things were opened — see DL-18.10, which retired the segments this
-  rule and DL-18.8 used to name.
+  open. **Amended 2026-08-16:** the strip is ONE row of one chip shape.
+  Open order is the default; manual order and pinned groups follow DL-18.10
+  (DECK-45, 2026-09-09), which also retired the separate surface segments.
 - **DL-18.7** **The stage is the focal surface in every theme.** The terminal
   and document surface keep the active theme's `--bg`; the left navigation
   frame/rail and every docked side panel share the derived `--sidebar-bg`.
@@ -1418,18 +1418,25 @@ window's identity and its actions at the same time.
   uses
   ([`fileIcon`](../src/files/ui/file-icons.ts) `current`), which is where that
   vocabulary stopped being docked-panel-only; the browser keeps its globe.
-  **Order is when it was opened**, on one window-wide clock the three owners
-  share ([`open-sequence.ts`](../src/lib/open-sequence.ts) `current`,
-  [`mergeStripOrder`](../src/lib/strip-order.ts) `current`), so a document
-  opened before a terminal tab sits before it. The keyboard walks that same
-  merge — the point of the rule rather than a side effect: ⌘⇧[ / ⌘⇧], ⌘1–9 and
-  ⌘9 count CHIPS, so ⌘2 can land on a document. Approved by the owner on
-  2026-08-16, who chose the glyph-led chip and the interleaved order over
-  keeping documents in a segment of their own. Two things deliberately did NOT
-  change: a label is never coloured by git status (Deck's file model has no
-  git status to read), and sidebar mode still scopes the terminal chips to the
-  active repository (DL-18.6) — the merge orders whatever that scope leaves
-  visible.
+  **Default order is when it was opened**, on one window-wide clock
+  ([`open-sequence.ts`](../src/lib/open-sequence.ts)). **DECK-45, 2026-09-09:**
+  dragging changes the order within the pinned or ordinary group, with a neutral
+  insertion line and a label ghost. The strip scrolls horizontally when chips no
+  longer fit, including during an edge drag. Escape cancels the drag.
+  Pinned chips sit first, retain the same icon and name, and replace the close
+  button with a trailing pin glyph. A 6px additional gap separates the two groups.
+  Right-click or Shift+F10 opens the existing popover row treatment with
+  **Pin/Unpin**, **Close**, **Close Others**, **Close to the Right**. Disabled
+  actions remain visible; Escape/outside press dismiss, arrow keys move focus,
+  and dismissal returns focus to the chip. A normal active-chip click stays inert.
+  The menu is portalled out of the scroll clip and obscures the native browser
+  stage while open ([`TabStripMenu`](../src/ui/tab-strip-menu.tsx)).
+  Order and pins last for the current window session. The keyboard uses the same
+  visible merge ([`mergeStripOrder`](../src/lib/strip-order.ts)): ⌘⇧[ / ⌘⇧],
+  ⌘1–9 and ⌘9 count chips after reorder/pinning. Sidebar mode still scopes
+  terminal chips to the active repository. Bulk closes skip pinned and hidden
+  chips, preserve the existing Busy/dirty guards and never imply a workspace-wide
+  close ([`closeChips`](../src/ui/tab-strip-close.ts)).
   **Amended the same day, after the owner saw it rendered — a chip says WHAT
   is open and nothing else.** Three things came off it, in the order the owner
   asked:

--- a/docs/internals/terminal.md
+++ b/docs/internals/terminal.md
@@ -83,10 +83,21 @@ Ids are process-local integers from 1, never reused.
   waits for xterm's write drain so a transfer serializes after every byte landed. Paste is
   bracketed and `\n` becomes `\r`, the only route that lands a multi-line body in an agent
   TUI's composer as one block.
-- **Strip order** is one window-wide clock ([`open-sequence.ts`](../../src/lib/open-sequence.ts)):
-  terminal tabs, documents and the browser tab share it, keys are never reused, and
-  [`mergeStripOrder`](../../src/lib/strip-order.ts) is walked by both the keyboard
-  (`TabManager`) and the paint (`TabStrip`), so ⌘1–9 and tab cycling count chips.
+- **Strip order** starts with the window-wide clock
+  ([`open-sequence.ts`](../../src/lib/open-sequence.ts)).
+  [`stripPreferences` and `mergeStripOrder`](../../src/lib/strip-order.ts) apply a manual
+  order and pinned prefix without rewriting open keys or owner indexes. Preferences are
+  renderer-local: they survive workspace/layout switches, but are not journaled across
+  application restarts. The shell supplies `visibleTabIndexes` so keyboard digits/cycling
+  count the same repository-scoped chips as the strip.
+- **Strip close actions** ([`tab-strip-close.ts`](../../src/ui/tab-strip-close.ts)) capture
+  identities before awaiting guards. A single close uses App's existing workspace cleanup;
+  bulk closes target only visible, unpinned chips and deliberately omit that cleanup so it
+  cannot sweep pinned or hidden files. Files close sequentially through their dirty guard,
+  then terminals use one Busy confirmation; cancelling stops the remaining batch but does
+  not undo earlier confirmed file closes. Files retained in another workspace become
+  visible again when that workspace is reopened. Pinning a preview promotes it to a kept
+  file tab so another preview cannot replace it.
 - The closed-tab stack holds 10 snapshots in memory (`layout`, `cwds`, `name`, `dotColor`,
   `workspacePath`); ⌘⇧T reopens with fresh shells and does not re-run agents.
 

--- a/src/lib/strip-order.test.ts
+++ b/src/lib/strip-order.test.ts
@@ -49,6 +49,20 @@ describe("mergeStripOrder", () => {
     expect(mergeStripOrder([at(1)], [])).toEqual([{ kind: "tab", index: 0 }]);
     expect(mergeStripOrder([], [at(1)])).toEqual([{ kind: "surface", index: 0 }]);
   });
+
+  it("shares manual order and the pinned prefix across owner index spaces", () => {
+    expect(
+      mergeStripOrder([at(1), at(3)], [at(2), at(4)], {
+        order: [4, 3, 2, 1],
+        pinned: [2],
+      }),
+    ).toEqual([
+      { kind: "surface", index: 0 },
+      { kind: "surface", index: 1 },
+      { kind: "tab", index: 1 },
+      { kind: "tab", index: 0 },
+    ]);
+  });
 });
 
 describe("the open-order clock", () => {
@@ -59,5 +73,33 @@ describe("the open-order clock", () => {
     expect(keys).toEqual([1, 2, 3]);
     // Never `UNSEQUENCED`: a real chip must always outrank a fixture one.
     expect(keys.every((key) => key > UNSEQUENCED)).toBe(true);
+  });
+});
+
+describe("manual strip preferences", () => {
+  it("moves visible chips while preserving hidden positions and pin groups", async () => {
+    const { stripPreferences, moveStripTab, EMPTY_STRIP_PREFERENCES } =
+      await import("./strip-order");
+    stripPreferences.value = { order: [1, 2, 3, 4, 5], pinned: [1] };
+    moveStripTab(5, 3, [1, 3, 5], [1, 2, 3, 4, 5]);
+    expect(stripPreferences.value).toEqual({ order: [1, 2, 5, 4, 3], pinned: [1] });
+    moveStripTab(3, 1, [1, 5, 3], [1, 2, 3, 4, 5]);
+    expect(stripPreferences.value.order).toEqual([1, 2, 5, 4, 3]);
+    stripPreferences.value = EMPTY_STRIP_PREFERENCES;
+  });
+
+  it("unpin restores the manual slot and new chips append", async () => {
+    const { stripPreferences, setStripPinned, EMPTY_STRIP_PREFERENCES } =
+      await import("./strip-order");
+    stripPreferences.value = { order: [3, 1, 2], pinned: [] };
+    setStripPinned(2, true);
+    expect(
+      mergeStripOrder([at(1), at(2), at(3), at(4)], [], stripPreferences.value).map((s) => s.index),
+    ).toEqual([1, 2, 0, 3]);
+    setStripPinned(2, false);
+    expect(
+      mergeStripOrder([at(1), at(2), at(3), at(4)], [], stripPreferences.value).map((s) => s.index),
+    ).toEqual([2, 0, 1, 3]);
+    stripPreferences.value = EMPTY_STRIP_PREFERENCES;
   });
 });

--- a/src/lib/strip-order.ts
+++ b/src/lib/strip-order.ts
@@ -1,6 +1,6 @@
 /**
- * The strip's one ordering rule: a chip sits where it was opened, whatever
- * kind of chip it is (DL-18.6, 2026-08-16).
+ * The strip's shared order: pinned chips first, then manual placement,
+ * falling back to open order for new chips (DL-18.10, DECK-45).
  *
  * Until then the strip was two segments — every terminal tab, a hairline,
  * then every non-terminal surface — and that shape was baked into the
@@ -14,6 +14,60 @@
  * TabManager still learns nothing about files, only that a surface carries an
  * order key ([`SurfaceStrip.orderKey`](../terminal/tab-manager.ts)).
  */
+
+import { signal } from "@preact/signals";
+
+export interface StripPreferences {
+  readonly order: readonly number[];
+  readonly pinned: readonly number[];
+}
+
+export const EMPTY_STRIP_PREFERENCES: StripPreferences = { order: [], pinned: [] };
+
+/** Window-local presentation preferences, shared by the chips and keyboard.
+ * Open keys are identities: never rewrite them or reorder a PTY owner's array.
+ * Preferences survive layout/workspace switches, not an application restart. */
+export const stripPreferences = signal<StripPreferences>(EMPTY_STRIP_PREFERENCES);
+
+export function setStripPinned(key: number, pinned: boolean): void {
+  if (key <= 0) return;
+  const current = stripPreferences.value;
+  stripPreferences.value = {
+    ...current,
+    pinned: pinned
+      ? [...new Set([...current.pinned, key])]
+      : current.pinned.filter((item) => item !== key),
+  };
+}
+
+/** Move within one pin group, replacing only visible positions. Hidden
+ * workspaces keep their relative order. New chips append in open order. */
+export function moveStripTab(
+  source: number,
+  before: number | null,
+  visible: readonly number[],
+  all: readonly number[],
+): void {
+  const current = stripPreferences.value;
+  const pinned = new Set(current.pinned);
+  const group = visible.filter((key) => key > 0 && pinned.has(key) === pinned.has(source));
+  if (!group.includes(source) || source === before || (before !== null && !group.includes(before)))
+    return;
+  const rest = group.filter((key) => key !== source);
+  const at = before === null ? rest.length : rest.indexOf(before);
+  const moved = [...rest.slice(0, at), source, ...rest.slice(at)];
+  const keys = [...new Set(all.filter((key) => key > 0))];
+  const ordered = mergeStripOrder(
+    keys.map((openedAt) => ({ openedAt })),
+    [],
+    current,
+  ).map((slot) => keys[slot.index]!);
+  let index = 0;
+  stripPreferences.value = {
+    order: ordered.map((key) => (group.includes(key) ? moved[index++]! : key)),
+    pinned: current.pinned.filter((key) => keys.includes(key)),
+  };
+}
 
 /** Which owner a slot belongs to. */
 export type StripSlotKind = "tab" | "surface";
@@ -46,7 +100,10 @@ export interface StripOrderKey {
 export function mergeStripOrder(
   tabs: readonly StripOrderKey[],
   surfaces: readonly StripOrderKey[],
+  preferences: StripPreferences = EMPTY_STRIP_PREFERENCES,
 ): readonly StripSlot[] {
+  const ranks = new Map(preferences.order.map((key, index) => [key, index]));
+  const pinned = new Set(preferences.pinned);
   const entries = [
     ...tabs.map((tab, index) => ({
       slot: { kind: "tab" as const, index },
@@ -59,6 +116,13 @@ export function mergeStripOrder(
   ];
   return entries
     .map((entry, position) => ({ ...entry, position }))
-    .sort((a, b) => a.openedAt - b.openedAt || a.position - b.position)
+    .sort(
+      (a, b) =>
+        Number(pinned.has(b.openedAt)) - Number(pinned.has(a.openedAt)) ||
+        (ranks.get(a.openedAt) ?? preferences.order.length) -
+          (ranks.get(b.openedAt) ?? preferences.order.length) ||
+        a.openedAt - b.openedAt ||
+        a.position - b.position,
+    )
     .map((entry) => entry.slot);
 }

--- a/src/styles/05-tab-bar-toolbar.css
+++ b/src/styles/05-tab-bar-toolbar.css
@@ -635,3 +635,71 @@
     transition: none;
   }
 }
+
+/* DECK-45: the shared strip's pinned group, pointer drag and context menu. */
+.tabbar__tabs {
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+  -webkit-app-region: no-drag;
+}
+.tabbar__tabs::-webkit-scrollbar {
+  display: none;
+}
+.tabbar__tabs > .tab {
+  flex-shrink: 0;
+  touch-action: none;
+}
+.tab__pin {
+  display: flex;
+  color: var(--text-faint);
+  margin-left: 2px;
+}
+.tab.is-pinned {
+  padding-right: 6px;
+}
+.tab.is-pinned + .tab:not(.is-pinned) {
+  margin-left: 6px;
+}
+.tab:focus-visible {
+  outline: 1px solid var(--hair-strong);
+  outline-offset: -1px;
+}
+.tab:focus-within .tab__close {
+  opacity: 1;
+}
+.tabbar__tabs.is-tab-dragging,
+.tabbar__tabs.is-tab-dragging .tab {
+  cursor: grabbing;
+}
+.tab-strip-ghost {
+  max-width: 210px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tab-strip-drop-line {
+  position: fixed;
+  width: 2px;
+  background: var(--text-primary);
+  z-index: 101;
+  pointer-events: none;
+}
+.tab-strip-menu {
+  max-width: calc(100vw - 16px);
+  max-height: calc(100vh - 16px);
+  overflow-y: auto;
+  -webkit-app-region: no-drag;
+}
+.tab-strip-menu .toolbar-menu__sep {
+  display: block;
+}
+.tab-strip-menu .toolbar-menu__row:disabled {
+  color: var(--text-faint);
+  cursor: default;
+  background: transparent;
+}
+.tab-strip-error {
+  color: var(--text-primary);
+  font-size: var(--type-meta);
+}

--- a/src/terminal/tab-manager-types.ts
+++ b/src/terminal/tab-manager-types.ts
@@ -65,6 +65,9 @@ export interface TabManagerDeps extends TerminalManagerDeps {
    * below is unchanged.
    */
   surfaces?: SurfaceStrip;
+  /** The shell's current terminal projection, in owner index space. Missing
+   * means all tabs. Digits and cycling must count the same visible chips. */
+  visibleTabIndexes?: () => readonly number[];
   /**
    * Cmd+Shift+A routes here instead of calling `focusNextAttention`
    * directly, so the app can run the same overlay preflight as a status-dot

--- a/src/terminal/tab-manager.file-surfaces.test.ts
+++ b/src/terminal/tab-manager.file-surfaces.test.ts
@@ -19,6 +19,7 @@ import type { BrowserClient } from "../browser/browser-client";
 import { composeSurfaceStrip } from "../ui/stage-surface-strip";
 import { activeTabIndex, tabViews, statusInfo } from "./tabs-store";
 import { settings } from "../settings/settings-store";
+import { stripPreferences, EMPTY_STRIP_PREFERENCES } from "../lib/strip-order";
 import { DEFAULT_SETTINGS } from "../settings/settings-schema";
 import { sendAgentNotification } from "../lib/native-notification";
 import { initializeDesktopEnvironment, resetDesktopEnvironmentForTests } from "../lib/platform";
@@ -93,6 +94,7 @@ beforeEach(() => {
   // Task 23: reset the live setting the production-default notifier reads,
   // and clear the mocked native adapter so per-test call counts start fresh.
   settings.value = DEFAULT_SETTINGS;
+  stripPreferences.value = EMPTY_STRIP_PREFERENCES;
   vi.mocked(sendAgentNotification).mockClear();
 });
 
@@ -829,6 +831,30 @@ describe("file surfaces in the tab strip — the real FileSurfaceController (Tas
     expect(activeTabIndex.value).toBe(0);
 
     tm.dispose();
+  });
+
+  it("digits and cycling use manual order with pinned surfaces and hidden terminals", async () => {
+    const { tm } = setup({
+      deps: { surfaces, visibleTabIndexes: () => [0, 2] },
+      infos: IDLE_SHELLS,
+    });
+    await tm.materialize({ layout: null, cwds: ["/a"] });
+    await surfaces.openFile("/a", "/a/one.ts", true);
+    await tm.materialize({ layout: null, cwds: ["/a"] });
+    await tm.materialize({ layout: null, cwds: ["/a"] });
+    const [first, hidden, last] = tabViews.value.map((tab) => tab.openedAt!);
+    const file = surfaces.orderKey!(0);
+    stripPreferences.value = { order: [last!, hidden!, first!, file], pinned: [file] };
+    tm.runAction("select-tab-1");
+    expect(surfaces.activeIndex()).toBe(0);
+    tm.cycleTab(1);
+    expect(activeTabIndex.value).toBe(2);
+    tm.runAction("select-tab-3");
+    expect(activeTabIndex.value).toBe(0);
+    tm.runAction("select-last-tab");
+    expect(activeTabIndex.value).toBe(0);
+    tm.dispose();
+    stripPreferences.value = EMPTY_STRIP_PREFERENCES;
   });
 
   it("a file opened BEFORE a terminal tab takes the earlier digit", async () => {

--- a/src/terminal/tab-manager.ts
+++ b/src/terminal/tab-manager.ts
@@ -14,7 +14,7 @@ import type { DetachTarget } from "./pane-detach";
 import { defaultTransferClient } from "./transfer-client";
 import { normalizeWorkspacePath, workspaceLabel } from "../lib/workspace-label";
 import { nextOpenSequence, UNSEQUENCED } from "../lib/open-sequence";
-import { mergeStripOrder, type StripSlot } from "../lib/strip-order";
+import { mergeStripOrder, stripPreferences, type StripSlot } from "../lib/strip-order";
 import { lastRows, stripAnsiSequences } from "../lib/strip-ansi-sequences";
 import { sendAgentNotification } from "../lib/native-notification";
 import { getDesktopEnvironment } from "../lib/platform";
@@ -2137,11 +2137,15 @@ export function createTabManager(
    * few dozen entries.
    */
   function stripSlots(): readonly StripSlot[] {
+    const visible = deps.visibleTabIndexes?.();
     return mergeStripOrder(
       tabs.map((tab) => ({ openedAt: tab.openedAt })),
       Array.from({ length: surfaces.count() }, (_, index) => ({
         openedAt: surfaces.orderKey?.(index) ?? UNSEQUENCED,
       })),
+      stripPreferences.value,
+    ).filter(
+      (slot) => slot.kind === "surface" || visible === undefined || visible.includes(slot.index),
     );
   }
 

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -205,7 +205,7 @@ import {
   suspendSessionJournal,
 } from "../terminal/session-journal";
 import { restoreSession, resumeWorkspace } from "../terminal/session-restore";
-import { worktreeForPath } from "../repositories/repository-model";
+import { activeRepositoryTabIndexes, worktreeForPath } from "../repositories/repository-model";
 import { DesktopChrome } from "./desktop-chrome";
 import {
   archivedWorkspaceResumeAvailable,
@@ -554,6 +554,10 @@ export function App({ boot = { kind: "normal" } }: { boot?: BootMode } = {}) {
       return;
     }
     const manager = createTabManager(host, undefined, {
+      visibleTabIndexes: () =>
+        settings.value.tabBarPosition === "left"
+          ? activeRepositoryTabIndexes(tabViews.value, activeTabIndex.value, repositoryScans.value)
+          : tabViews.value.map((_, index) => index),
       onOpenTaskLauncher: openTaskLauncher,
       onRequestAttentionFocus: (tabIndex) => requestAttentionFocus(tabIndex),
       onToggleSettings: () => toggleSettings(),
@@ -2085,7 +2089,8 @@ export function App({ boot = { kind: "normal" } }: { boot?: BootMode } = {}) {
       topTabs={
         <TabBar
           onSelectTab={selectTab}
-          onCloseTab={(index) => void closeTab(index)}
+          onCloseTab={closeTab}
+          onCloseTabs={async (indexes) => (await tabsRef.current?.closeTabs(indexes)) ?? false}
           toolbar={chromeActions}
           fileController={fileController}
           onSelectBrowser={selectBrowserTab}
@@ -2159,7 +2164,10 @@ export function App({ boot = { kind: "normal" } }: { boot?: BootMode } = {}) {
               }) ? (
                 <TabStrip
                   onSelectTab={selectTab}
-                  onCloseTab={(index) => void closeTab(index)}
+                  onCloseTab={closeTab}
+                  onCloseTabs={async (indexes) =>
+                    (await tabsRef.current?.closeTabs(indexes)) ?? false
+                  }
                   fileController={fileController}
                   onSelectBrowser={selectBrowserTab}
                   onCloseBrowser={closeBrowserTab}

--- a/src/ui/tab-bar.tsx
+++ b/src/ui/tab-bar.tsx
@@ -4,7 +4,8 @@ import { TabStrip } from "./tab-strip";
 
 interface TabBarProps {
   onSelectTab(index: number): void;
-  onCloseTab(index: number): void;
+  onCloseTab(index: number): void | Promise<void>;
+  onCloseTabs?(indexes: readonly number[]): Promise<boolean>;
   /**
    * The feature toolbar, built once by `App` so this mount and the sidebar
    * frame's mount can never drift apart (one element, both layouts). TabBar
@@ -48,6 +49,7 @@ export function TabBar(props: TabBarProps) {
       <TabStrip
         onSelectTab={props.onSelectTab}
         onCloseTab={props.onCloseTab}
+        onCloseTabs={props.onCloseTabs}
         fileController={props.fileController}
         onSelectBrowser={props.onSelectBrowser}
         onCloseBrowser={props.onCloseBrowser}

--- a/src/ui/tab-strip-close.ts
+++ b/src/ui/tab-strip-close.ts
@@ -1,0 +1,71 @@
+import { stripPreferences } from "../lib/strip-order";
+import { tabViews } from "../terminal/tabs-store";
+import { fileTabsFor } from "../files/file-surface-store";
+import { stageSurfaceDescriptors } from "./stage-surface-strip";
+import type { TabStripProps } from "./tab-strip";
+import type { StripMenuAction } from "./tab-strip-menu";
+
+export interface TabCloseTarget {
+  readonly key: string;
+  readonly openedAt: number;
+  readonly kind: "terminal" | "file" | "browser" | "agent-board";
+  readonly terminalKey?: number;
+  readonly workspace?: string;
+  readonly path?: string;
+  readonly close: () => void | Promise<void>;
+}
+
+// Guards intentionally run sequentially: cancellation stops later closes.
+/* oxlint-disable no-await-in-loop */
+export function closeTargets(
+  chips: readonly TabCloseTarget[],
+  key: string,
+  action: StripMenuAction,
+): readonly TabCloseTarget[] {
+  const index = chips.findIndex((chip) => chip.key === key);
+  if (index < 0) return [];
+  if (action === "close") return [chips[index]!];
+  return chips.filter(
+    (chip, position) =>
+      chip.key !== key &&
+      !stripPreferences.value.pinned.includes(chip.openedAt) &&
+      (action !== "right" || position > index),
+  );
+}
+
+/** A cancelled file guard stops the remaining batch. Terminal targets use
+ * the existing single Busy prompt. Earlier confirmed file closes stay closed. */
+export async function closeChips(
+  targets: readonly TabCloseTarget[],
+  props: Pick<TabStripProps, "onCloseTabs" | "fileController">,
+  bulk: boolean,
+): Promise<void> {
+  for (const chip of targets.filter((item) => item.kind === "file")) {
+    if (!fileTabsFor(chip.workspace ?? null).some((item) => item.openedAt === chip.openedAt))
+      continue;
+    await chip.close();
+    if (fileTabsFor(chip.workspace ?? null).some((item) => item.openedAt === chip.openedAt)) return;
+  }
+  const terminals = targets.filter((chip) => chip.kind === "terminal");
+  if (bulk && props.onCloseTabs) {
+    const indexes = terminals
+      .map((chip) => tabViews.value.findIndex((tab) => tab.key === chip.terminalKey))
+      .filter((index) => index >= 0);
+    if (indexes.length > 0 && !(await props.onCloseTabs(indexes))) return;
+  } else {
+    for (const chip of terminals) {
+      await chip.close();
+      if (tabViews.value.some((tab) => tab.key === chip.terminalKey)) return;
+    }
+  }
+  for (const chip of targets.filter(
+    (item) => item.kind === "browser" || item.kind === "agent-board",
+  )) {
+    if (
+      stageSurfaceDescriptors(props.fileController).some(
+        (item) => item.kind === chip.kind && item.openedAt === chip.openedAt,
+      )
+    )
+      await chip.close();
+  }
+}

--- a/src/ui/tab-strip-drag.test.ts
+++ b/src/ui/tab-strip-drag.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTabStripDrag } from "./tab-strip-drag";
+
+const box = (left: number, width: number): DOMRect => ({
+  left,
+  right: left + width,
+  top: 0,
+  bottom: 30,
+  width,
+  height: 30,
+  x: left,
+  y: 0,
+  toJSON: () => ({}),
+});
+function pointer(target: EventTarget, type: string, x: number, y = 10): void {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: x,
+    clientY: y,
+    button: 0,
+  });
+  Object.defineProperty(event, "pointerId", { value: 1 });
+  target.dispatchEvent(event);
+}
+
+describe("tab strip pointer reorder", () => {
+  let list: HTMLDivElement;
+  let dispose: () => void;
+  let drop: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn(() => 1),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    list = document.createElement("div");
+    list.innerHTML = [1, 2, 3]
+      .map(
+        (key) =>
+          `<div data-strip-key="${key}" data-pinned="false"><span class="tab__label">${key}</span><button>Close</button></div>`,
+      )
+      .join("");
+    document.body.append(list);
+    list.getBoundingClientRect = () => box(0, 300);
+    [...list.children].forEach((el, index) => {
+      el.getBoundingClientRect = () => box(index * 100, 100);
+    });
+    drop = vi.fn();
+    dispose = createTabStripDrag(list, { onStart: vi.fn(), onDrop: drop });
+  });
+  afterEach(() => {
+    dispose();
+    document.body.innerHTML = "";
+    vi.unstubAllGlobals();
+  });
+
+  it("remeasures the release position even before the animation frame fires", () => {
+    pointer(list.children[0]!, "pointerdown", 10);
+    pointer(window, "pointermove", 130);
+    pointer(window, "pointerup", 290);
+    expect(drop).toHaveBeenCalledExactlyOnceWith(1, null);
+    expect(document.querySelector(".tab-strip-ghost")).toBeNull();
+  });
+  it("leaves normal clicks and close buttons alone", () => {
+    pointer(list.children[0]!, "pointerdown", 10);
+    pointer(window, "pointerup", 12);
+    pointer(list.querySelector("button")!, "pointerdown", 10);
+    pointer(window, "pointermove", 250);
+    pointer(window, "pointerup", 250);
+    expect(drop).not.toHaveBeenCalled();
+  });
+  it("Escape cancels the drop and suppresses the following selection click", () => {
+    const click = vi.fn();
+    list.addEventListener("click", click);
+    pointer(list.children[0]!, "pointerdown", 10);
+    pointer(window, "pointermove", 150);
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    pointer(window, "pointerup", 200);
+    list.children[0]!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(drop).not.toHaveBeenCalled();
+    expect(click).not.toHaveBeenCalled();
+  });
+  it("abandons a removed source and drops outside the strip", () => {
+    pointer(list.children[0]!, "pointerdown", 10);
+    pointer(window, "pointermove", 150);
+    list.children[0]!.remove();
+    pointer(window, "pointerup", 200);
+    expect(drop).not.toHaveBeenCalled();
+    pointer(list.children[0]!, "pointerdown", 110);
+    pointer(window, "pointermove", 150, 100);
+    pointer(window, "pointerup", 200, 100);
+    expect(drop).not.toHaveBeenCalled();
+  });
+  it("restricts a pinned source to the pinned group", () => {
+    (list.children[0] as HTMLElement).dataset.pinned = "true";
+    (list.children[1] as HTMLElement).dataset.pinned = "true";
+    pointer(list.children[0]!, "pointerdown", 10);
+    pointer(window, "pointermove", 290);
+    pointer(window, "pointerup", 290);
+    expect(drop).toHaveBeenCalledExactlyOnceWith(1, null);
+  });
+});

--- a/src/ui/tab-strip-drag.ts
+++ b/src/ui/tab-strip-drag.ts
@@ -1,0 +1,191 @@
+/** Horizontal pointer drag, measured once per frame. Identity is read again
+ * at release so a closing tab or changing workspace cannot redirect a drop. */
+const CHIP = "[data-strip-key]";
+const THRESHOLD = 5;
+const EDGE = 28;
+const SPEED = 12;
+const GHOST_OFFSET = 12;
+
+interface Deps {
+  onStart(): void;
+  onDrop(source: number, before: number | null): void;
+}
+
+export function createTabStripDrag(list: HTMLElement, deps: Deps): () => void {
+  let press: { id: number; key: number; x: number; y: number; pinned: string } | null = null;
+  let point = { x: 0, y: 0 };
+  let dragging = false;
+  let cancelled = false;
+  let frame: number | null = null;
+  let ghost: HTMLElement | null = null;
+  let line: HTMLElement | null = null;
+
+  function chips(): HTMLElement[] {
+    return [...list.querySelectorAll<HTMLElement>(CHIP)].filter(
+      (el) => el.dataset.pinned === press?.pinned,
+    );
+  }
+
+  function measure(): { before: number | null; x: number; inside: boolean; velocity: number } {
+    const rect = list.getBoundingClientRect();
+    const entries = chips().filter((el) => Number(el.dataset.stripKey) !== press?.key);
+    const next = entries.find((el) => {
+      const box = el.getBoundingClientRect();
+      return point.x < box.left + box.width / 2;
+    });
+    const last = entries[entries.length - 1]?.getBoundingClientRect();
+    const x = next?.getBoundingClientRect().left ?? last?.right ?? rect.left;
+    const velocity = point.x < rect.left + EDGE ? -SPEED : point.x > rect.right - EDGE ? SPEED : 0;
+    return {
+      before: next ? Number(next.dataset.stripKey) : null,
+      x: Math.max(rect.left, Math.min(rect.right, x)),
+      inside:
+        point.x >= rect.left &&
+        point.x <= rect.right &&
+        point.y >= rect.top &&
+        point.y <= rect.bottom,
+      velocity,
+    };
+  }
+
+  function paint(): void {
+    frame = null;
+    if (!dragging || cancelled) return;
+    const target = measure();
+    const rect = list.getBoundingClientRect();
+    if (ghost) {
+      ghost.style.left = `${point.x + GHOST_OFFSET}px`;
+      ghost.style.top = `${point.y + GHOST_OFFSET}px`;
+    }
+    if (line) {
+      line.style.display = target.inside ? "block" : "none";
+      line.style.left = `${target.x}px`;
+      line.style.top = `${rect.top}px`;
+      line.style.height = `${rect.height}px`;
+    }
+    if (target.inside && target.velocity !== 0) {
+      const previous = list.scrollLeft;
+      list.scrollLeft += target.velocity;
+      if (previous !== list.scrollLeft) frame = requestAnimationFrame(paint);
+    }
+  }
+
+  function clearVisuals(): void {
+    if (frame !== null) cancelAnimationFrame(frame);
+    frame = null;
+    ghost?.remove();
+    line?.remove();
+    ghost = null;
+    line = null;
+    list.classList.remove("is-tab-dragging");
+  }
+
+  function cleanup(): void {
+    const id = press?.id;
+    press = null;
+    if (id !== undefined && list.hasPointerCapture?.(id)) list.releasePointerCapture(id);
+    window.removeEventListener("pointermove", move);
+    window.removeEventListener("pointerup", up);
+    window.removeEventListener("pointercancel", cancel);
+    window.removeEventListener("keydown", keydown, true);
+    window.removeEventListener("blur", cancel);
+    clearVisuals();
+    dragging = false;
+    cancelled = false;
+  }
+
+  function swallowClick(): void {
+    const swallow = (event: Event): void => {
+      event.preventDefault();
+      event.stopPropagation();
+    };
+    window.addEventListener("click", swallow, { capture: true, once: true });
+    setTimeout(() => window.removeEventListener("click", swallow, true), 0);
+  }
+
+  function cancel(): void {
+    if (dragging) swallowClick();
+    cleanup();
+  }
+
+  function keydown(event: KeyboardEvent): void {
+    if (event.key !== "Escape" || !press) return;
+    event.preventDefault();
+    event.stopPropagation();
+    cancelled = true;
+    clearVisuals();
+  }
+
+  function move(event: PointerEvent): void {
+    if (!press || event.pointerId !== press.id || cancelled) return;
+    point = { x: event.clientX, y: event.clientY };
+    if (!dragging) {
+      if (Math.hypot(point.x - press.x, point.y - press.y) < THRESHOLD) return;
+      const source = chips().find((el) => Number(el.dataset.stripKey) === press?.key);
+      if (!source) {
+        cleanup();
+        return;
+      }
+      dragging = true;
+      deps.onStart();
+      list.classList.add("is-tab-dragging");
+      list.setPointerCapture?.(press.id);
+      ghost = document.createElement("div");
+      ghost.className = "pane-drag-ghost tab-strip-ghost";
+      ghost.textContent = source.querySelector(".tab__label")?.textContent ?? "Tab";
+      line = document.createElement("div");
+      line.className = "tab-strip-drop-line";
+      document.body.append(ghost, line);
+    }
+    event.preventDefault();
+    if (frame === null) frame = requestAnimationFrame(paint);
+  }
+
+  function up(event: PointerEvent): void {
+    if (!press || event.pointerId !== press.id) return;
+    point = { x: event.clientX, y: event.clientY };
+    const source = press.key;
+    const target = measure();
+    const commit =
+      dragging &&
+      !cancelled &&
+      target.inside &&
+      chips().some((el) => Number(el.dataset.stripKey) === source);
+    if (dragging) swallowClick();
+    cleanup();
+    if (commit) deps.onDrop(source, target.before);
+  }
+
+  function down(event: PointerEvent): void {
+    if (
+      event.button !== 0 ||
+      press ||
+      event.ctrlKey ||
+      !(event.target instanceof Element) ||
+      event.target.closest("button")
+    )
+      return;
+    const chip = event.target.closest<HTMLElement>(CHIP);
+    const key = Number(chip?.dataset.stripKey);
+    if (!chip || !Number.isSafeInteger(key) || key <= 0) return;
+    press = {
+      id: event.pointerId,
+      key,
+      x: event.clientX,
+      y: event.clientY,
+      pinned: chip.dataset.pinned ?? "false",
+    };
+    point = { x: event.clientX, y: event.clientY };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+    window.addEventListener("pointercancel", cancel);
+    window.addEventListener("keydown", keydown, true);
+    window.addEventListener("blur", cancel);
+  }
+
+  list.addEventListener("pointerdown", down);
+  return () => {
+    list.removeEventListener("pointerdown", down);
+    cleanup();
+  };
+}

--- a/src/ui/tab-strip-menu.tsx
+++ b/src/ui/tab-strip-menu.tsx
@@ -1,0 +1,117 @@
+import { createPortal } from "preact/compat";
+import { useEffect, useLayoutEffect, useRef } from "preact/hooks";
+import { PushPin, PushPinSlash, X } from "@phosphor-icons/react";
+import { DeckIcon, CHROME_ICON } from "./controls/deck-icon";
+import {
+  useDismiss,
+  useStageOverlayFlag,
+  useSurfacePlacement,
+  type AnchorRect,
+} from "./worktree-card-menus";
+
+export type StripMenuAction = "pin" | "close" | "others" | "right";
+
+export interface StripMenuAnchor {
+  readonly key: string;
+  readonly rect: AnchorRect;
+  readonly trigger: HTMLElement;
+}
+
+interface Props {
+  readonly anchor: StripMenuAnchor;
+  readonly label: string;
+  readonly pinned: boolean;
+  readonly canPin: boolean;
+  readonly canCloseOthers: boolean;
+  readonly canCloseRight: boolean;
+  readonly onAction: (action: StripMenuAction) => void;
+  readonly onClose: () => void;
+}
+
+/** A portalled menu clears the strip's scroll clip and the browser's native
+ * stage layer. Reuse Deck's placement, dismissal and row treatment. */
+export function TabStripMenu(props: Props) {
+  const { ref, style, placed } = useSurfacePlacement(props.anchor.rect, "below");
+  useDismiss(props.onClose, ref, null);
+  useStageOverlayFlag();
+  const rows = [
+    {
+      id: "pin",
+      label: props.pinned ? "Unpin" : "Pin",
+      icon: props.pinned ? PushPinSlash : PushPin,
+      disabled: !props.canPin,
+    },
+    { id: "close", label: "Close", icon: X, disabled: false },
+    { id: "others", label: "Close Others", icon: X, disabled: !props.canCloseOthers },
+    { id: "right", label: "Close to the Right", icon: X, disabled: !props.canCloseRight },
+  ] as const;
+
+  const closeRef = useRef(props.onClose);
+  closeRef.current = props.onClose;
+  const menuElement = ref.current;
+  useLayoutEffect(() => {
+    if (placed) menuElement?.querySelector<HTMLButtonElement>("button:not(:disabled)")?.focus();
+  }, [placed, menuElement, props.anchor]);
+
+  useEffect(() => {
+    const trigger = props.anchor.trigger;
+    const resize = (): void => closeRef.current();
+    window.addEventListener("resize", resize);
+    return () => {
+      window.removeEventListener("resize", resize);
+      if (
+        trigger.isConnected &&
+        (document.activeElement === document.body || menuElement?.contains(document.activeElement))
+      ) {
+        trigger.focus();
+      }
+    };
+  }, [props.anchor, menuElement]);
+
+  return createPortal(
+    <div
+      ref={ref}
+      class="toolbar-menu tab-strip-menu"
+      role="menu"
+      aria-label={`Actions for ${props.label}`}
+      style={style}
+      onKeyDown={(event) => {
+        event.stopPropagation();
+        if (event.key === "Tab") {
+          props.onClose();
+          return;
+        }
+        if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
+        event.preventDefault();
+        const buttons = [
+          ...(ref.current?.querySelectorAll<HTMLButtonElement>("button:not(:disabled)") ?? []),
+        ];
+        const current = buttons.indexOf(document.activeElement as HTMLButtonElement);
+        const next =
+          event.key === "Home"
+            ? 0
+            : event.key === "End"
+              ? buttons.length - 1
+              : (current + (event.key === "ArrowDown" ? 1 : -1) + buttons.length) % buttons.length;
+        buttons[next]?.focus();
+      }}
+    >
+      {rows.map((row, index) => (
+        <div key={row.id} role="none">
+          {index === 1 && <span class="toolbar-menu__sep" role="separator" />}
+          <button
+            type="button"
+            role="menuitem"
+            class="toolbar-menu__row"
+            disabled={row.disabled}
+            onClick={() => props.onAction(row.id)}
+          >
+            <DeckIcon icon={row.icon} size={CHROME_ICON} />
+            <span class="toolbar-menu__label">{row.label}</span>
+          </button>
+        </div>
+      ))}
+    </div>,
+    document.body,
+  );
+}

--- a/src/ui/tab-strip.test.tsx
+++ b/src/ui/tab-strip.test.tsx
@@ -15,18 +15,20 @@ import { act } from "preact/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { activeTabIndex, tabViews, type TabView, type PaneView } from "../terminal/tabs-store";
 import { TabStrip } from "./tab-strip";
+import { stripPreferences, EMPTY_STRIP_PREFERENCES, setStripPinned } from "../lib/strip-order";
 import { initializeDesktopEnvironment, resetDesktopEnvironmentForTests } from "../lib/platform";
 import {
   createFileSurfaceController,
   type FileSurfaceController,
 } from "../files/file-surface-controller";
-import { openFileTab, resetFileSurfaces } from "../files/file-surface-store";
+import { openFileTab, closeFileSurface, resetFileSurfaces } from "../files/file-surface-store";
 import { nextOpenSequence, resetOpenSequence } from "../lib/open-sequence";
 import type { FileClient } from "../files/file-client";
 import { repositoryScans } from "../repositories/repositories-store";
 import type { RepositoryScan } from "../repositories/repository-client";
 import {
   browserOpen,
+  browserOpenedAt,
   browserState,
   browserSurfaceActive,
   EMPTY_STATE,
@@ -93,6 +95,7 @@ describe("TabStrip mounted outside the tab bar (sidebar layout)", () => {
     resetBrowserStore();
     resetAgentBoardStore();
     resetOpenSequence();
+    stripPreferences.value = EMPTY_STRIP_PREFERENCES;
     paneTails.value = new Map();
     fileController = createFileSurfaceController({ client: fileClient });
   });
@@ -130,6 +133,275 @@ describe("TabStrip mounted outside the tab bar (sidebar layout)", () => {
       );
     });
   };
+
+  const chipNamed = (name: string): HTMLElement =>
+    [...host.querySelectorAll<HTMLElement>(".tab")].find(
+      (el) => el.querySelector(".tab__label")?.textContent === name,
+    )!;
+  it("reorders mounted terminal chips from mouse pointer events", () => {
+    tabViews.value = [
+      tab({ key: 1, openedAt: 1, name: "First" }),
+      tab({ key: 2, openedAt: 2, name: "Second" }),
+    ];
+    const select = vi.fn();
+    mount({ onSelectTab: select });
+    const list = host.querySelector<HTMLElement>('[role="tablist"]')!;
+    const box = (left: number, width: number) =>
+      ({ left, right: left + width, top: 0, bottom: 30, width, height: 30 }) as DOMRect;
+    list.getBoundingClientRect = () => box(0, 200);
+    chipNamed("First").getBoundingClientRect = () => box(0, 100);
+    chipNamed("Second").getBoundingClientRect = () => box(100, 100);
+    const pointer = (target: EventTarget, type: string, x: number) => {
+      const event = new MouseEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        clientX: x,
+        clientY: 15,
+        button: 0,
+      });
+      Object.defineProperty(event, "pointerId", { value: 1 });
+      target.dispatchEvent(event);
+    };
+    act(() => {
+      pointer(chipNamed("Second").querySelector(".tab__label")!, "pointerdown", 150);
+      pointer(window, "pointermove", 10);
+      pointer(window, "pointerup", 10);
+      list.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect([...list.querySelectorAll(".tab__label")].map((el) => el.textContent)).toEqual([
+      "Second",
+      "First",
+    ]);
+    expect(select).not.toHaveBeenCalled();
+  });
+  const context = (name: string): void => {
+    act(() => {
+      chipNamed(name).dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          cancelable: true,
+          clientX: 50,
+          clientY: 25,
+        }),
+      );
+    });
+  };
+  const menuAction = async (label: string): Promise<void> => {
+    await act(async () => {
+      [...document.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')]
+        .find((el) => el.textContent === label)!
+        .click();
+    });
+  };
+
+  it("pins a tab without selecting it, retains its name and removes its close button", async () => {
+    tabViews.value = [
+      tab({ key: 1, name: "Alpha", openedAt: nextOpenSequence() }),
+      tab({ key: 2, name: "Beta", openedAt: nextOpenSequence() }),
+    ];
+    const select = vi.fn();
+    mount({ onSelectTab: select });
+    context("Beta");
+    expect(document.querySelector('[role="menu"]')).not.toBeNull();
+    await menuAction("Pin");
+    expect(host.querySelector(".tab__label")?.textContent).toBe("Beta");
+    expect(chipNamed("Beta").querySelector(".tab__close")).toBeNull();
+    expect(chipNamed("Beta").querySelector(".tab__pin")).not.toBeNull();
+    expect(select).not.toHaveBeenCalled();
+    context("Beta");
+    await menuAction("Unpin");
+    expect(host.querySelector(".tab__label")?.textContent).toBe("Alpha");
+    expect(chipNamed("Beta").querySelector(".tab__close")).not.toBeNull();
+  });
+
+  it("Close Others targets only visible unpinned terminals in one guarded batch", async () => {
+    const keys = [nextOpenSequence(), nextOpenSequence(), nextOpenSequence(), nextOpenSequence()];
+    tabViews.value = [
+      tab({ key: 1, name: "Alpha", openedAt: keys[0] }),
+      tab({ key: 2, name: "Pinned", openedAt: keys[1] }),
+      tab({ key: 3, name: "Close me", openedAt: keys[2] }),
+      tab({ key: 4, name: "Hidden", workspacePath: "/elsewhere", openedAt: keys[3] }),
+    ];
+    setStripPinned(keys[1]!, true);
+    const closeTabs = vi.fn(async () => true);
+    mount({ onCloseTabs: closeTabs });
+    context("Alpha");
+    await menuAction("Close Others");
+    expect(closeTabs).toHaveBeenCalledExactlyOnceWith([2]);
+  });
+
+  it("Close to the Right follows the displayed manual order", async () => {
+    tabViews.value = [
+      tab({ key: 1, name: "Alpha", openedAt: 1 }),
+      tab({ key: 2, name: "Beta", openedAt: 2 }),
+      tab({ key: 3, name: "Gamma", openedAt: 3 }),
+    ];
+    stripPreferences.value = { order: [3, 1, 2], pinned: [] };
+    const closeTabs = vi.fn(async () => true);
+    mount({ onCloseTabs: closeTabs });
+    context("Alpha");
+    await menuAction("Close to the Right");
+    expect(closeTabs).toHaveBeenCalledExactlyOnceWith([1]);
+  });
+
+  it("keeps a pinned preview file when another preview opens", async () => {
+    tabViews.value = [tab({ openedAt: nextOpenSequence() })];
+    openFileTab("/repo", "/repo/a.ts", { keep: false });
+    mount();
+    context("a.ts");
+    await menuAction("Pin");
+    act(() => {
+      openFileTab("/repo", "/repo/b.ts", { keep: false });
+    });
+    expect(chipNamed("a.ts").querySelector(".tab__label--preview")).toBeNull();
+    expect(chipNamed("a.ts").dataset.pinned).toBe("true");
+  });
+
+  it("Escape closes the menu and a disappearing owner cannot redirect an action", async () => {
+    tabViews.value = [
+      tab({ key: 1, name: "Alpha", openedAt: 1 }),
+      tab({ key: 2, name: "Beta", openedAt: 2 }),
+    ];
+    mount();
+    context("Beta");
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(document.querySelector('[role="menu"]')).toBeNull();
+    context("Beta");
+    act(() => {
+      tabViews.value = [tab({ key: 1, name: "Alpha", openedAt: 1 })];
+    });
+    expect(document.querySelector('[role="menu"]')).toBeNull();
+  });
+
+  it("a cancelled file close stops the batch before touching any terminals", async () => {
+    tabViews.value = [
+      tab({ key: 1, name: "Alpha", openedAt: nextOpenSequence() }),
+      tab({ key: 2, name: "Beta", openedAt: nextOpenSequence() }),
+    ];
+    openFileTab("/repo", "/repo/a.ts", { keep: true });
+    const closeTabs = vi.fn(async () => true);
+    const closePath = vi.fn(async () => {});
+    mount({ onCloseTabs: closeTabs, fileController: { ...fileController, closePath } });
+    context("Alpha");
+    await menuAction("Close Others");
+    expect(closePath).toHaveBeenCalledExactlyOnceWith("/repo", "/repo/a.ts");
+    expect(closeTabs).not.toHaveBeenCalled();
+    expect(chipNamed("Beta")).toBeDefined();
+  });
+
+  it("Close explicitly targets a pinned tab, but bulk actions are unavailable beside only pinned tabs", async () => {
+    tabViews.value = [
+      tab({ key: 1, name: "Alpha", openedAt: 1 }),
+      tab({ key: 2, name: "Beta", openedAt: 2 }),
+    ];
+    setStripPinned(1, true);
+    setStripPinned(2, true);
+    const closeTabs = vi.fn(async () => true);
+    const closeTab = vi.fn();
+    mount({ onCloseTabs: closeTabs, onCloseTab: closeTab });
+    context("Alpha");
+    expect(
+      [...document.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')].find(
+        (el) => el.textContent === "Close Others",
+      )?.disabled,
+    ).toBe(true);
+    await menuAction("Close");
+    expect(closeTab).toHaveBeenCalledExactlyOnceWith(0);
+    expect(closeTabs).not.toHaveBeenCalled();
+  });
+
+  it("resolves terminal identities again after waiting for a file guard", async () => {
+    tabViews.value = [
+      tab({ key: 1, name: "Alpha", openedAt: nextOpenSequence() }),
+      tab({ key: 2, name: "Gone", openedAt: nextOpenSequence() }),
+      tab({ key: 3, name: "Target", openedAt: nextOpenSequence() }),
+    ];
+    openFileTab("/repo", "/repo/a.ts", { keep: true });
+    let release = (): void => {};
+    const guard = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const closePath = vi.fn(async (workspace: string, path: string) => {
+      await guard;
+      closeFileSurface(workspace, path);
+    });
+    const closeTabs = vi.fn(async () => true);
+    mount({ onCloseTabs: closeTabs, fileController: { ...fileController, closePath } });
+    context("Alpha");
+    await menuAction("Close Others");
+    expect(closeTabs).not.toHaveBeenCalled();
+    await act(async () => {
+      tabViews.value = [
+        tab({ key: 3, name: "Target", openedAt: 3 }),
+        tab({ key: 4, name: "New", openedAt: nextOpenSequence() }),
+      ];
+      release();
+    });
+    await vi.waitFor(() => expect(closeTabs).toHaveBeenCalledExactlyOnceWith([0]));
+  });
+
+  it.each([false, true])(
+    "continues to browser and Agents only when the Busy guard accepts: %s",
+    async (accepted) => {
+      tabViews.value = [
+        tab({ key: 1, name: "Alpha", openedAt: nextOpenSequence() }),
+        tab({ key: 2, name: "Beta", openedAt: nextOpenSequence() }),
+      ];
+      browserOpen.value = true;
+      browserOpenedAt.value = nextOpenSequence();
+      openAgentBoard();
+      const closeTabs = vi.fn(async () => accepted);
+      const closeBrowser = vi.fn();
+      const closeBoard = vi.fn();
+      mount({
+        onCloseTabs: closeTabs,
+        onCloseBrowser: closeBrowser,
+        onCloseAgentBoard: closeBoard,
+      });
+      context("Alpha");
+      await menuAction("Close Others");
+      expect(closeTabs).toHaveBeenCalledExactlyOnceWith([1]);
+      expect(closeBrowser).toHaveBeenCalledTimes(accepted ? 1 : 0);
+      expect(closeBoard).toHaveBeenCalledTimes(accepted ? 1 : 0);
+      if (!accepted) {
+        expect(chipNamed("Browser")).toBeDefined();
+        expect(chipNamed("Agents")).toBeDefined();
+      }
+    },
+  );
+
+  it("keeps a single close locked until its callback settles", async () => {
+    tabViews.value = [tab({ key: 1, name: "Alpha", openedAt: 1 })];
+    let release = (): void => {};
+    const closeTab = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        }),
+    );
+    mount({ onCloseTab: closeTab });
+    act(() => {
+      chipNamed("Alpha").querySelector<HTMLButtonElement>(".tab__close")!.click();
+    });
+    act(() => {
+      chipNamed("Alpha").querySelector<HTMLButtonElement>(".tab__close")!.click();
+    });
+    expect(closeTab).toHaveBeenCalledExactlyOnceWith(0);
+    await act(async () => {
+      release();
+    });
+    await vi.waitFor(() => {
+      act(() => {
+        chipNamed("Alpha").querySelector<HTMLButtonElement>(".tab__close")!.click();
+      });
+      expect(closeTab).toHaveBeenCalledTimes(2);
+    });
+    await act(async () => {
+      release();
+    });
+  });
 
   it("renders every chip, and no add button, with no .tabbar in the tree", () => {
     tabViews.value = [tab({ key: 1, name: "Alpha" })];

--- a/src/ui/tab-strip.tsx
+++ b/src/ui/tab-strip.tsx
@@ -1,44 +1,21 @@
-/**
- * The tab chips themselves: every open thing in ONE row, in the order it was
- * opened — terminal tabs, the active workspace's file tabs and the browser
- * chip interleaved (DL-18.6, 2026-08-16) — plus the new-tab button. Top-tab
- * mode shows the global terminal set; sidebar mode scopes it to the active
- * tab's repository, the unit `AgentRail` is built around.
- *
- * A chip says WHAT is open and nothing else (DL-18.10). It carried an agent
- * attention mark and opened a rename/colour popover until 2026-08-16, when the
- * owner removed both: agent state is the rail's job, and a chip that also
- * reported it made the strip a second status surface. `TabPopover` itself was
- * deleted later the same day, with the rename and workspace-logo features it
- * carried and the ⌘⇧R chord that raised it.
- *
- * Until 2026-08-16 this was two segments split by a hairline: every terminal
- * tab, `.tabbar__sep`, then every surface. One chip shape and one order
- * replaced both, so nothing about a chip says what KIND of thing it opened
- * except its glyph — an agent's brand mark, a file's type icon, the browser's
- * globe. The order itself is not computed here: `mergeStripOrder` is shared
- * with `TabManager`, which walks the same row for ⌘⇧[/], ⌘1–9 and ⌘9.
- *
- * Extracted from `TabBar` on 2026-08-14 because the strip now has TWO mounts,
- * not one: `TabBar` in top-tab mode, where the strip IS the window frame, and
- * `.stage__strip` in sidebar mode, where it is the frame row's column-2
- * occupant (DL-18.3, DL-18.6). One component so the two can never drift into
- * two different answers about what a chip does.
- *
- * Selection and close still leave through global tab indexes, so `TabManager`
- * keeps ownership. Only the sidebar projection is scoped; file chips continue
- * through `FileSurfaceController` exactly as before.
- */
-import { Globe, SquaresFour, TerminalWindow, X } from "@phosphor-icons/react";
-import { activeTabIndex, tabViews, type TabView } from "../terminal/tabs-store";
-import type { PaneAgent } from "../lib/process-info";
+/** One strip for every surface. Async actions resolve targets by identity;
+ * display positions never replace the indexes owned by TabManager/files. */
+import type { ComponentChildren } from "preact";
+import { useEffect, useLayoutEffect, useRef, useState } from "preact/hooks";
+import { Globe, PushPin, SquaresFour, TerminalWindow, X } from "@phosphor-icons/react";
+import { activeTabIndex, tabViews } from "../terminal/tabs-store";
 import { UNSEQUENCED } from "../lib/open-sequence";
-import { mergeStripOrder } from "../lib/strip-order";
+import {
+  mergeStripOrder,
+  moveStripTab,
+  setStripPinned,
+  stripPreferences,
+} from "../lib/strip-order";
 import { AgentGlyph } from "./controls/agent-glyph";
 import { fileIcon } from "../files/ui/file-icons";
 import { CHROME_ICON, DeckIcon } from "./controls/deck-icon";
 import type { FileSurfaceController } from "../files/file-surface-controller";
-import { activeWorkspace } from "../files/file-surface-store";
+import { activeWorkspace, fileSurfaces, promoteFileTab } from "../files/file-surface-store";
 import { fileTabViews } from "../files/file-tab-views";
 import { browserState, browserSurfaceActive } from "../browser/browser-store";
 import { agentBoardSurfaceActive } from "./agent-board-store";
@@ -47,310 +24,280 @@ import { repositoryScans } from "../repositories/repositories-store";
 import { activeRepositoryTabIndexes } from "../repositories/repository-model";
 import { paneTails } from "../terminal/session-tail-store";
 import { tabTail } from "./agent-rail-model";
+import { TabStripMenu, type StripMenuAction, type StripMenuAnchor } from "./tab-strip-menu";
+import { createTabStripDrag } from "./tab-strip-drag";
+import { closeChips, closeTargets, type TabCloseTarget } from "./tab-strip-close";
 
 export interface TabStripProps {
   onSelectTab(index: number): void;
-  onCloseTab(index: number): void;
-  /**
-   * The same `SurfaceStrip` wired into `TabManager` (Task 5) — read here
-   * only for `fileTabViews`'s projection and the `activate`/`closePath`
-   * calls its own chips need. The strip never learns what a file IS, only
-   * what this projects (spec §2.3's seam, extended to the renderer).
-   */
+  onCloseTab(index: number): void | Promise<void>;
+  /** One existing Busy guard over the union of the targeted terminal panes. */
+  onCloseTabs?(indexes: readonly number[]): Promise<boolean>;
   fileController: FileSurfaceController;
-  /**
-   * The browser chip's two actions, owned by `App` like every other chip
-   * callback: `App` is the one module that sees both the file store and the
-   * browser store, so the mutual-exclusion rule ("exactly one surface owns
-   * the stage") lives there, never in this presentation layer.
-   */
   onSelectBrowser(): void;
-  onCloseBrowser(): void;
-  /**
-   * The Agent Board chip's two actions, owned by `App` for the browser's
-   * reason: taking the stage means stepping BOTH other surfaces off it, and
-   * `App` is the only module that sees all three stores.
-   */
+  onCloseBrowser(): void | Promise<void>;
   onSelectAgentBoard(): void;
-  onCloseAgentBoard(): void;
-  /**
-   * Sidebar mode follows the active tab's REPOSITORY. Top-tab mode has no rail
-   * to switch that scope, so it deliberately keeps the global strip.
-   *
-   * The unit was the worktree until 2026-08-16, when the rail stopped being
-   * shaped like the repository layout: its rows are tabs in a project, so a
-   * strip scoped tighter than the rail would hide a sibling tab the rail is
-   * still listing (agent-status-rail spec §4.1). For the 46 of 51 repositories
-   * with a single working directory the two answers are identical.
-   */
+  onCloseAgentBoard(): void | Promise<void>;
   scopeToActiveRepository: boolean;
 }
 
-/**
- * The agent whose brand mark leads a terminal chip.
- *
- * Prefers the agent the LABEL already names — the chip reads as one thing,
- * and a tab running `claude` beside `gemini` must not show gemini's mark over
- * the word "claude". Falls back to whichever agent the tab runs first, and to
- * null for a plain shell, which wears the terminal glyph instead.
- */
-function chipAgent(tab: TabView): PaneAgent | null {
-  return tab.agents.find((agent) => agent === tab.process) ?? tab.agents[0] ?? null;
+interface Chip {
+  readonly key: string;
+  readonly openedAt: number;
+  readonly label: string;
+  readonly closeLabel: string;
+  readonly kind: "terminal" | "file" | "browser" | "agent-board";
+  readonly active: boolean;
+  readonly glyph: ComponentChildren;
+  readonly dirty?: boolean;
+  readonly preview?: boolean;
+  readonly terminalKey?: number;
+  readonly workspace?: string;
+  readonly path?: string;
+  readonly select: () => void;
+  readonly close: () => void | Promise<void>;
+}
+
+function terminalChips(props: TabStripProps, surfaceActive: boolean): readonly Chip[] {
+  const tabs = tabViews.value;
+  const active = activeTabIndex.value;
+  const indexes = props.scopeToActiveRepository
+    ? activeRepositoryTabIndexes(tabs, active, repositoryScans.value)
+    : tabs.map((_, index) => index);
+  return indexes.flatMap((index) => {
+    const tab = tabs[index];
+    if (!tab) return [];
+    const tail = tabTail(tab, paneTails.value);
+    const agent = tab.agents.find((item) => item === tab.process) ?? tab.agents[0];
+    return [
+      {
+        key: `tab-${tab.key}`,
+        openedAt: tab.openedAt ?? UNSEQUENCED,
+        label: tab.name ?? (tail || tab.process || "shell"),
+        closeLabel: "Close tab",
+        kind: "terminal" as const,
+        terminalKey: tab.key,
+        active: index === active && !surfaceActive,
+        glyph: agent ? (
+          <AgentGlyph agent={agent} className="tab__logo" />
+        ) : (
+          <DeckIcon icon={TerminalWindow} size={CHROME_ICON} />
+        ),
+        select: () => {
+          if (index !== active || surfaceActive) props.onSelectTab(index);
+        },
+        close: () => {
+          const current = tabViews.value.findIndex((item) => item.key === tab.key);
+          if (current >= 0) return props.onCloseTab(current);
+        },
+      },
+    ];
+  });
+}
+
+function surfaceChips(props: TabStripProps): readonly Chip[] {
+  const files = fileTabViews(props.fileController);
+  const workspace = activeWorkspace.value;
+  return stageSurfaceDescriptors(props.fileController).flatMap((surface): Chip[] => {
+    if (surface.kind === "file") {
+      const tab = files[surface.index];
+      if (!tab || !workspace) return [];
+      return [
+        {
+          key: `file-${workspace}-${tab.path}-${surface.openedAt}`,
+          openedAt: surface.openedAt,
+          label: tab.name,
+          closeLabel: `Close ${tab.name}`,
+          kind: "file",
+          workspace,
+          path: tab.path,
+          active: tab.active,
+          dirty: tab.dirty,
+          preview: tab.preview,
+          glyph: <DeckIcon icon={fileIcon(tab.name)} size={CHROME_ICON} />,
+          select: () => props.fileController.activate(surface.index),
+          close: () => props.fileController.closePath(workspace, tab.path),
+        },
+      ];
+    }
+    const browser = surface.kind === "browser";
+    return [
+      {
+        key: `${surface.kind}-${surface.openedAt}`,
+        openedAt: surface.openedAt,
+        label: browser ? browserState.value.title || browserState.value.url || "Browser" : "Agents",
+        closeLabel: browser ? "Close the browser tab" : "Close the agent board tab",
+        kind: surface.kind,
+        active: browser ? browserSurfaceActive.value : agentBoardSurfaceActive.value,
+        glyph: <DeckIcon icon={browser ? Globe : SquaresFour} size={CHROME_ICON} />,
+        select: () => {
+          if (browser ? !browserSurfaceActive.value : !agentBoardSurfaceActive.value) {
+            (browser ? props.onSelectBrowser : props.onSelectAgentBoard)();
+          }
+        },
+        close: browser ? props.onCloseBrowser : props.onCloseAgentBoard,
+      },
+    ];
+  });
 }
 
 export function TabStrip(props: TabStripProps) {
-  const tabs = tabViews.value;
-  const active = activeTabIndex.value;
-  const visibleIndexes = props.scopeToActiveRepository
-    ? activeRepositoryTabIndexes(tabs, active, repositoryScans.value)
-    : tabs.map((_, index) => index);
-  const visibleTabs = visibleIndexes.flatMap((index) => {
-    const tab = tabs[index];
-    return tab === undefined ? [] : [{ index, tab }];
-  });
-  // A file, browser or Agent Board surface can hold the stage while `active`
-  // still names whichever terminal tab it sits on top of (selecting a surface
-  // never touches `TabManager`'s own `active` index) — so a terminal chip is
-  // only the VISIBLE active tab when none of the three is true.
-  const fileTabs = fileTabViews(props.fileController);
   const surfaceActive =
     props.fileController.activeIndex() >= 0 ||
     browserSurfaceActive.value ||
     agentBoardSurfaceActive.value;
-  // The row, in open order. The surface list is built in the SurfaceStrip
-  // index space on purpose — files, then the browser's slot, then the Board's
-  // — because that is the space `fileController.activate(index)` and the
-  // keyboard both speak. Where a chip PAINTS is this merge's answer; what it
-  // addresses is still its owner's own index.
-  //
-  // `stageSurfaceDescriptors` is the same reading `composeSurfaceStrip`
-  // publishes, so the two can never disagree about which slot is which — the
-  // inference this used to make ("no file tab at this index ⇒ the browser")
-  // was true at two surface kinds and silently wrong at three.
-  const surfaceSlots = stageSurfaceDescriptors(props.fileController);
-  const slots = mergeStripOrder(
-    visibleTabs.map(({ tab }) => ({ openedAt: tab.openedAt ?? UNSEQUENCED })),
-    // `openedAt` is never undefined here — the descriptor fills a missing key
-    // with `UNSEQUENCED` itself, which matters because the comparator is
-    // arithmetic: ONE undefined key would produce NaN and scramble the whole
-    // row rather than misplace one chip.
-    surfaceSlots.map((slot) => ({ openedAt: slot.openedAt })),
+  const terminals = terminalChips(props, surfaceActive);
+  const surfaces = surfaceChips(props);
+  const preferences = stripPreferences.value;
+  const chips = mergeStripOrder(terminals, surfaces, preferences).map(
+    (slot) => (slot.kind === "tab" ? terminals : surfaces)[slot.index]!,
   );
-  /**
-   * One terminal chip. The glyph slot holds the agent's brand mark, or a
-   * terminal glyph when no agent is recognised — one picture per chip and
-   * nothing beside it.
-   *
-   * It carried the tab's colour dot as a corner badge for one day. The owner
-   * removed both the dot and the picker behind it on 2026-08-16 (DL-18.10
-   * amended): the chips are glyph-led, and a second mark on the same 15px box
-   * was noise rather than identity. `TabView.dotColor` still exists and is
-   * still carried across a window transfer, but nothing can set it since
-   * `TabPopover` was deleted later that day.
-   */
-  function terminalChip(tab: TabView, index: number) {
-    // The chip says what this tab's agent just said (DL-18.10, amended
-    // 2026-08-17, owner) — the same sentence the rail row shows, through the
-    // same precedence. A name the user typed still wins, exactly as it does
-    // there, and a tab whose agent has said nothing keeps its process name.
-    const tail = tabTail(tab, paneTails.value);
-    const label = tab.name ?? (tail !== "" ? tail : (tab.process ?? "shell"));
-    const agent = chipAgent(tab);
-    return (
-      <div
-        key={`tab-${tab.key}`}
-        role="tab"
-        aria-selected={index === active && !surfaceActive}
-        tabIndex={0}
-        class={`tab ${index === active && !surfaceActive ? "is-active" : ""}`}
-        // The chip is narrow by design, so the sentence it carries is trimmed
-        // by the layout and kept whole here (DL-27.4's contract, which the
-        // strip inherits along with the sentence).
-        title={label}
-        // A file surface sitting on top of THIS same index still needs the
-        // click to take the stage back (spec §7, "selecting a terminal tab
-        // takes the stage back"); clicking the chip that already holds it is
-        // a no-op, since 2026-08-16 removed the popover it used to open.
-        onClick={() => {
-          if (index !== active || surfaceActive) {
-            props.onSelectTab(index);
-          }
-        }}
-      >
-        <span class="tab__glyph">
-          {agent === null ? (
-            <DeckIcon icon={TerminalWindow} size={CHROME_ICON} />
-          ) : (
-            <AgentGlyph agent={agent} className="tab__logo" />
-          )}
-        </span>
-        <span class="tab__label">{label}</span>
-        <button
-          type="button"
-          class="tab__close"
-          aria-label="Close tab"
-          onClick={(event) => {
-            event.stopPropagation();
-            props.onCloseTab(index);
-          }}
-        >
-          <DeckIcon icon={X} size={CHROME_ICON} />
-        </button>
-      </div>
-    );
-  }
+  const [menu, setMenu] = useState<StripMenuAnchor | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const list = useRef<HTMLDivElement>(null);
+  const closing = useRef(false);
+  const latest = useRef(chips);
+  latest.current = chips;
+  const owner = chips.find((chip) => chip.key === menu?.key);
+  const scope = props.scopeToActiveRepository ? activeWorkspace.value : null;
 
-  /**
-   * One file chip. Same shell as a terminal chip, with the tree's file-type
-   * glyph in the slot the agent mark occupies there (DL §8's icon rule, which
-   * stopped being docked-panel-only when the strip became one row).
-   */
-  function fileChip(tab: (typeof fileTabs)[number], index: number) {
-    return (
-      <div
-        key={`file-${tab.path}`}
-        role="tab"
-        aria-selected={tab.active}
-        tabIndex={0}
-        class={`tab tab--file ${tab.active ? "is-active" : ""}`}
-        onClick={() => props.fileController.activate(index)}
-      >
-        <span class="tab__glyph">
-          <DeckIcon icon={fileIcon(tab.name)} size={CHROME_ICON} />
-        </span>
-        <span class={`tab__label ${tab.preview ? "tab__label--preview" : ""}`}>{tab.name}</span>
-        {tab.dirty && <span class="tab__dot tab__dot--dirty" aria-hidden="true" />}
-        <button
-          type="button"
-          class="tab__close"
-          aria-label={`Close ${tab.name}`}
-          onClick={(event) => {
-            event.stopPropagation();
-            const workspacePath = activeWorkspace.value;
-            if (workspacePath !== null) {
-              void props.fileController.closePath(workspacePath, tab.path);
-            }
-          }}
-        >
-          <DeckIcon icon={X} size={CHROME_ICON} />
-        </button>
-      </div>
-    );
-  }
+  useLayoutEffect(() => {
+    setMenu(null);
+  }, [scope]);
+  useLayoutEffect(() => {
+    if (menu && !owner) setMenu(null);
+  }, [menu, owner]);
+  useEffect(() => {
+    if (!list.current) return;
+    return createTabStripDrag(list.current, {
+      onStart: () => setMenu(null),
+      onDrop: (source, before) => {
+        const all = [
+          ...tabViews.value.map((tab) => tab.openedAt ?? UNSEQUENCED),
+          ...[...fileSurfaces.value.values()].flatMap((surface) =>
+            surface.tabs.map((tab) => tab.openedAt),
+          ),
+          ...latest.current.map((chip) => chip.openedAt),
+        ];
+        moveStripTab(
+          source,
+          before,
+          latest.current.map((chip) => chip.openedAt),
+          all,
+        );
+      },
+    });
+  }, []);
 
-  /**
-   * The browser chip — one chip, present while the browser is open anywhere
-   * (its page survives losing the stage). Identified by the page title so the
-   * chip reads like the page, not like chrome.
-   */
-  function browserChip() {
-    return (
-      <div
-        key="browser"
-        role="tab"
-        aria-selected={browserSurfaceActive.value}
-        tabIndex={0}
-        class={`tab tab--browser ${browserSurfaceActive.value ? "is-active" : ""}`}
-        onClick={() => {
-          if (!browserSurfaceActive.value) {
-            props.onSelectBrowser();
-          }
-        }}
-      >
-        <span class="tab__glyph" aria-hidden="true">
-          <DeckIcon icon={Globe} size={CHROME_ICON} />
-        </span>
-        <span class="tab__label">
-          {browserState.value.title || browserState.value.url || "Browser"}
-        </span>
-        <button
-          type="button"
-          class="tab__close"
-          aria-label="Close the browser tab"
-          onClick={(event) => {
-            event.stopPropagation();
-            props.onCloseBrowser();
-          }}
-        >
-          <DeckIcon icon={X} size={CHROME_ICON} />
-        </button>
-      </div>
-    );
-  }
-
-  /**
-   * The Agent Board chip (spec §4.1). Its glyph is `SquaresFour` — the grid
-   * the surface itself draws — and its label is the word `Agents`, fixed: a
-   * chip says what is open and nothing else (DL-18.10), so it reports neither
-   * how many agents the Board lists nor what any of them is doing.
-   */
-  function agentBoardChip() {
-    return (
-      <div
-        key="agent-board"
-        role="tab"
-        aria-selected={agentBoardSurfaceActive.value}
-        tabIndex={0}
-        class={`tab tab--agent-board ${agentBoardSurfaceActive.value ? "is-active" : ""}`}
-        onClick={() => {
-          if (!agentBoardSurfaceActive.value) {
-            props.onSelectAgentBoard();
-          }
-        }}
-      >
-        <span class="tab__glyph" aria-hidden="true">
-          <DeckIcon icon={SquaresFour} size={CHROME_ICON} />
-        </span>
-        <span class="tab__label">Agents</span>
-        <button
-          type="button"
-          class="tab__close"
-          aria-label="Close the agent board tab"
-          onClick={(event) => {
-            event.stopPropagation();
-            props.onCloseAgentBoard();
-          }}
-        >
-          <DeckIcon icon={X} size={CHROME_ICON} />
-        </button>
-      </div>
-    );
-  }
+  const close = (targets: readonly TabCloseTarget[], bulk = false): void => {
+    if (closing.current) return;
+    closing.current = true;
+    setError(null);
+    void closeChips(targets, props, bulk)
+      .catch((cause: unknown) => {
+        console.error("[tab-strip] Close failed", cause);
+        setError("Could not close the selected tabs. Please try again.");
+      })
+      .finally(() => {
+        closing.current = false;
+      });
+  };
+  const openMenu = (chip: Chip, trigger: HTMLElement, x: number, y: number): void => {
+    setMenu({ key: chip.key, trigger, rect: { left: x, right: x, top: y, bottom: y } });
+  };
+  const actOnMenu = (action: StripMenuAction): void => {
+    if (!owner) return;
+    setMenu(null);
+    if (action !== "pin") {
+      close(closeTargets(chips, owner.key, action), action !== "close");
+      return;
+    }
+    const pinned = preferences.pinned.includes(owner.openedAt);
+    if (!pinned && owner.workspace && owner.path) promoteFileTab(owner.workspace, owner.path);
+    setStripPinned(owner.openedAt, !pinned);
+  };
 
   return (
     <>
-      <div class="tabbar__tabs" role="tablist" aria-label="Open tabs">
-        {/* One row, one order (DL-18.6). `slots` speaks two index spaces:
-            a `"tab"` index addresses `visibleTabs`, a `"surface"` index
-            addresses the SurfaceStrip space `composeSurfaceStrip` publishes —
-            every file tab, then the browser slot, then the Agent Board's — so
-            the chip a keyboard command activates and the chip painted here
-            are the same one. Which KIND that slot is comes from the
-            descriptor, never from what is missing at its index. */}
-        {slots.map((slot) => {
-          if (slot.kind === "tab") {
-            const entry = visibleTabs[slot.index];
-            return entry === undefined ? null : terminalChip(entry.tab, entry.index);
-          }
-          const surface = surfaceSlots[slot.index];
-          if (surface === undefined) {
-            return null;
-          }
-          if (surface.kind === "agent-board") {
-            return agentBoardChip();
-          }
-          if (surface.kind === "browser") {
-            return browserChip();
-          }
-          const fileTab = fileTabs[surface.index];
-          return fileTab === undefined ? null : fileChip(fileTab, surface.index);
+      <div ref={list} class="tabbar__tabs" role="tablist" aria-label="Open tabs">
+        {chips.map((chip) => {
+          const pinned = preferences.pinned.includes(chip.openedAt);
+          return (
+            <div
+              key={chip.key}
+              role="tab"
+              aria-selected={chip.active}
+              tabIndex={0}
+              aria-label={pinned ? `${chip.label}, pinned` : chip.label}
+              aria-haspopup="menu"
+              aria-expanded={menu?.key === chip.key}
+              data-strip-key={chip.openedAt}
+              data-pinned={String(pinned)}
+              class={`tab ${chip.kind === "terminal" ? "" : `tab--${chip.kind}`} ${chip.active ? "is-active" : ""} ${pinned ? "is-pinned" : ""}`}
+              title={chip.label}
+              onClick={chip.select}
+              onContextMenu={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                openMenu(chip, event.currentTarget, event.clientX, event.clientY);
+              }}
+              onKeyDown={(event) => {
+                if (event.target !== event.currentTarget) return;
+                if (event.key === "ContextMenu" || (event.shiftKey && event.key === "F10")) {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  const rect = event.currentTarget.getBoundingClientRect();
+                  openMenu(chip, event.currentTarget, rect.left, rect.bottom);
+                } else if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  chip.select();
+                }
+              }}
+            >
+              <span class="tab__glyph">{chip.glyph}</span>
+              <span class={`tab__label ${chip.preview ? "tab__label--preview" : ""}`}>
+                {chip.label}
+              </span>
+              {chip.dirty && <span class="tab__dot tab__dot--dirty" aria-hidden="true" />}
+              {pinned ? (
+                <span class="tab__pin" aria-hidden="true">
+                  <DeckIcon icon={PushPin} size={CHROME_ICON} />
+                </span>
+              ) : (
+                <button
+                  type="button"
+                  class="tab__close"
+                  aria-label={chip.closeLabel}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    close([chip]);
+                  }}
+                >
+                  <DeckIcon icon={X} size={CHROME_ICON} />
+                </button>
+              )}
+            </div>
+          );
         })}
       </div>
-      {/* No `+` after the chips since `openspec/changes/rail-create-consolidation`
-          (2026-09-02, owner): it was the one create control whose destination
-          was implicit — "the ACTIVE tab's workspace", said nowhere — and the
-          rail's cards each carry their own. `⌘T` (`new-tab`) keeps the
-          keyboard route and states its destination in the menu it raises. */}
+      {menu && owner && (
+        <TabStripMenu
+          key={menu.key}
+          anchor={menu}
+          label={owner.label}
+          pinned={preferences.pinned.includes(owner.openedAt)}
+          canPin={owner.openedAt > UNSEQUENCED}
+          canCloseOthers={closeTargets(chips, owner.key, "others").length > 0}
+          canCloseRight={closeTargets(chips, owner.key, "right").length > 0}
+          onAction={actOnMenu}
+          onClose={() => setMenu(null)}
+        />
+      )}
+      {error && (
+        <span role="alert" class="tab-strip-error">
+          {error}
+        </span>
+      )}
     </>
   );
 }

--- a/src/ui/worktree-card-menus.tsx
+++ b/src/ui/worktree-card-menus.tsx
@@ -68,7 +68,7 @@ type PlacementSide = "right" | "below";
  * and a bottom clamp needs its height — neither is known before it mounts, and
  * both change with the row set (the Tauri menu is ~70px shorter, spec §10).
  */
-function useSurfacePlacement(
+export function useSurfacePlacement(
   rect: AnchorRect | null,
   side: PlacementSide = "right",
 ): {
@@ -160,7 +160,7 @@ function useSurfacePlacement(
  * than re-invented, including the trigger exemption — the trigger's own click
  * toggles, so it must not close through this path too.
  */
-function useDismiss(
+export function useDismiss(
   onClose: () => void,
   surface: { readonly current: HTMLElement | null },
   trigger: HTMLElement | null,
@@ -241,7 +241,7 @@ const OVERLAY_RELEASE_MS = 260;
 let openCardMenus = 0;
 let releaseTimer: ReturnType<typeof setTimeout> | null = null;
 
-function useStageOverlayFlag(): void {
+export function useStageOverlayFlag(): void {
   useEffect(() => {
     openCardMenus += 1;
     if (releaseTimer !== null) {


### PR DESCRIPTION
## Tóm tắt

- Cho phép kéo thả terminal, file, browser và Agents trên tab strip; phím tắt đi theo thứ tự đang hiển thị.
- Thêm ghim tab và menu Pin/Unpin, Close, Close Others, Close to the Right. Đóng hàng loạt bỏ qua tab ghim/tab ẩn và giữ cảnh báo tác vụ đang chạy, file chưa lưu.

## Lý do

[DECK-45](https://linear.app/mxrsv/issue/DECK-45). Khi mở nhiều loại tab, người dùng cần tự sắp xếp và giữ các tab quan trọng ở đầu strip.

Thứ tự và ghim chỉ giữ trong phiên renderer hiện tại, chưa lưu qua lần khởi động lại. Kéo thả hoạt động trong cùng nhóm ghim hoặc nhóm thường. Ghim file preview chuyển file sang tab được giữ lại.

## Cách test

- [x] Chạy 7 suite liên quan: strip, drag, order, tab-bar, TabManager file surfaces, App và close coordinator — **173 tests passed**.
- [x] `npm run build` — exit 0, `✓ built in 30.01s`; TypeScript đạt.
- [x] Oxlint trên các file code thay đổi — exit 0; còn warnings. Prettier trên các file thay đổi và `git diff --check` đạt.
- [x] Trên Gallery: ghim một tab, kéo tab khác qua file tab, mở menu, dùng End và Escape; đã kiểm tra thứ tự và focus.
- [x] Người dùng xác nhận đã kéo bằng chuột được trên cửa sổ đang dùng ngày 2026-09-09; môi trường cửa sổ đó chưa được xác định.
- [ ] Trên Electron, mở terminal/file/browser/Agents, kéo trong từng nhóm rồi thử ⌘1–9 và ⌘⇧[/] ở cả hai kiểu bố cục.
- [ ] Với file chưa lưu và agent đang chạy, thử Close Others/Close to the Right rồi hủy cảnh báo; kiểm tra các tab ghim và tab thuộc workspace ẩn vẫn còn.
- [ ] Chưa kiểm chứng trên Windows thật.

**Lỗi có sẵn trên base:** suite design-language đạt 19/20; test dẫn chiếu mã quy tắc thiếu DL-19.9, DL-13.7, DL-13.8 và DL-27.25 (23 chỗ dẫn chiếu). Đã chạy lại trên checkout sạch của `origin/main` tại `49b1480` và nhận đúng cùng danh sách lỗi. PR này không sửa các quy tắc ngoài phạm vi.

## Screenshots

Trước — ảnh người dùng cung cấp:

![Tab strip trước thay đổi](https://uploads.linear.app/f4f6463b-a910-47c6-a5c1-2313ce114860/2f116e47-dba1-445b-abec-cb7bbacb1461/329c6e64-b111-4867-b9bc-9ecd8895a152)

Sau — component thật trên Gallery, tab architecture review ghim ở đầu; test sweep đã được kéo trước README:

![Tab strip sau thay đổi](https://uploads.linear.app/f4f6463b-a910-47c6-a5c1-2313ce114860/ba299619-a17f-484b-87a0-4b65d6d60d39/9a18f98e-4b17-429b-b917-8e86e6520877)

## Tài liệu và review

README/CHANGELOG mô tả thao tác và giới hạn lưu trạng thái; DESIGN-LANGUAGE và tài liệu terminal cập nhật thứ tự, phạm vi đóng, cảnh báo và danh tính tab qua thao tác bất đồng bộ.

Review correctness/React, tests/TypeScript và security đã kiểm tra lại trên worktree PR độc lập, không còn finding. Một Semgrep taint-rule timeout ở TabManager trong lượt review trước giới hạn coverage của rule đó.

Checkout chính giữ nguyên; PR chỉ chứa thay đổi DECK-45.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reorder terminal and surface tabs with drag-and-drop.
  - Pin tabs to keep them grouped at the beginning of the tab strip.
  - Use context-menu actions to pin, unpin, close, close other tabs, or close tabs to the right.
  - Tab order and pinned status persist during the current window session.
  - Keyboard navigation follows the visible tab order.
  - Bulk-close actions automatically preserve pinned tabs.

- **Documentation**
  - Updated user and design documentation with the new tab-management behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->